### PR TITLE
Ignore dumb meta-versions in Packagist

### DIFF
--- a/lib/repositories/packagist.rb
+++ b/lib/repositories/packagist.rb
@@ -35,11 +35,17 @@ class Repositories
     end
 
     def self.versions(project)
-      project['versions'].map do |k, v|
+      acceptable_versions(project).map do |k, v|
         {
           :number => k,
           :published_at => v['time']
         }
+      end
+    end
+
+    def self.acceptable_versions(project)
+      project['versions'].select do |k, v|
+        (k =~ /^dev-.*/i).nil? && (k =~ /^~.*/i).nil?
       end
     end
 

--- a/lib/tasks/one_off.rake
+++ b/lib/tasks/one_off.rake
@@ -1,0 +1,12 @@
+namespace :one_off do
+  task clean_packagist_versions: :environment do
+    Project.platform('packagist').find_each do |project|
+      redundant_versions = project.versions.where("number LIKE 'dev-%' OR number LIKE '~%'")
+      redundant_versions.destroy_all
+
+      project.set_latest_release_published_at
+      project.set_latest_release_number
+      project.save!
+    end
+  end
+end


### PR DESCRIPTION
I've run the one_off task locally against a download of around 100 packages, and it cleaned them up and reset the 'latest versions' as expected.  /cc @andrew 
