### PR TITLE
Add dotenv as a dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,10 @@ group :development do
   gem 'thin'
 end
 
+group :development, :test do
+  gem 'dotenv-rails'
+end
+
 group :production do
   gem 'puma'
   gem 'bugsnag'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,9 @@ GEM
       after_commit_action (~> 1.0.0)
     daemons (1.2.2)
     dalli (2.7.4)
+    dotenv (2.0.1)
+    dotenv-rails (2.0.1)
+      dotenv (= 2.0.1)
     elasticsearch (1.0.12)
       elasticsearch-api (= 1.0.12)
       elasticsearch-transport (= 1.0.12)
@@ -456,6 +459,7 @@ DEPENDENCIES
   coffee-rails
   counter_culture
   dalli
+  dotenv-rails
   elasticsearch-model
   elasticsearch-rails
   faraday-http-cache


### PR DESCRIPTION
I'd like to add `dotenv` as a dependency so I can easily specify a new `ELASTICSEARCH_URL` (since GitHub has my box setup all specifically like). :grinning:

The `.env` file was already ignored.
