### PR TITLE
Fix spelling error of Rubygems

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Lure rails into slurping down some data
  rails c
  irb> AuthToken.new(token: "<ure github token here>").save
  irb> Repositories::NPM.update "pictogram"
- irb> Repositories::Rubgems.update "split"
+ irb> Repositories::Rubygems.update "split"
  irb> Repositories::Bower.update "sbteclipse"
 ```
 


### PR DESCRIPTION
While I was following along with the setup instructions, this was the only one that didn't quite work as expected. :grinning:
