### PR TITLE
New dependency endpoints for github and releases

### DIFF
--- a/app/controllers/api/github_repositories_controller.rb
+++ b/app/controllers/api/github_repositories_controller.rb
@@ -3,15 +3,35 @@ class Api::GithubRepositoriesController < Api::ApplicationController
 
   def show
     render json: @github_repository.as_json({
-      except: [:id, :github_organisation_id, :owner_id],
-      include: {
-        repository_dependencies: {only: [:platform, :project_name, :requirements]}
-      }
+      except: [:id, :github_organisation_id, :owner_id]
     })
   end
 
   def projects
     render json: @github_repository.projects.paginate(page: params[:page]).as_json(only: [:name, :platform, :description, :language, :homepage, :repository_url,  :normalized_licenses], include: {versions: {only: [:number, :published_at]} })
+  end
+
+  def dependencies
+    dependencies = @github_repository.repository_dependencies || []
+
+    deps = dependencies.map do |dependency|
+      {
+        project_name: dependency.project_name,
+        platform: dependency.platform,
+        requirements: dependency.requirements,
+        latest_stable: dependency.try(:project).try(:latest_stable_release_number),
+        latest: dependency.try(:project).try(:latest_release_number),
+        deprecated: dependency.try(:project).try(:is_deprecated?),
+        outdated: dependency.outdated?
+      }
+    end
+
+    repo_json = @github_repository.as_json({
+      except: [:id, :github_organisation_id, :owner_id]
+    })
+    repo_json[:dependencies] = deps
+
+    render json: repo_json
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,12 +10,14 @@ Rails.application.routes.draw do
     get '/search', to: 'search#index'
     get '/searchcode', to: 'projects#searchcode'
 
-    get '/github/:owner/:name/projects', to: 'github_repositories#projects', constraints: { :name => /.*/ }
-    get '/github/:owner/:name', to: 'github_repositories#show', constraints: { :name => /.*/ }
+    get '/github/:owner/:name/dependencies', to: 'github_repositories#dependencies'
+    get '/github/:owner/:name/projects', to: 'github_repositories#projects'
+    get '/github/:owner/:name', to: 'github_repositories#show'
 
-    get '/:platform/:name/dependent_repositories', to: 'projects#dependent_repositories', constraints: { :name => /.*/ }
-    get '/:platform/:name/dependents', to: 'projects#dependents', constraints: { :name => /.*/ }
-    get '/:platform/:name', to: 'projects#show', constraints: { :name => /.*/ }
+    get '/:platform/:name/:version/dependencies', to: 'projects#dependencies', constraints: { :platform => /[\w\-\_]+/, :name => /[\w\-\_]+/, :version => /[\w\-\_\.]+/ }
+    get '/:platform/:name/dependent_repositories', to: 'projects#dependent_repositories'
+    get '/:platform/:name/dependents', to: 'projects#dependents'
+    get '/:platform/:name', to: 'projects#show'
   end
 
   namespace :admin do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -76,7 +76,6 @@ ActiveRecord::Schema.define(version: 20151117130742) do
 
   add_index "github_organisations", ["created_at"], name: "index_github_organisations_on_created_at", using: :btree
   add_index "github_organisations", ["github_id"], name: "index_github_organisations_on_github_id", unique: true, using: :btree
-  add_index "github_organisations", ["login"], name: "index_github_organisations_on_login", using: :btree
 
   create_table "github_repositories", force: :cascade do |t|
     t.string   "full_name"
@@ -171,10 +170,10 @@ ActiveRecord::Schema.define(version: 20151117130742) do
   end
 
   create_table "payola_sales", force: :cascade do |t|
-    t.string   "email"
-    t.string   "guid"
+    t.string   "email",                limit: 191
+    t.string   "guid",                 limit: 191
     t.integer  "product_id"
-    t.string   "product_type"
+    t.string   "product_type",         limit: 100
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "state"
@@ -192,11 +191,11 @@ ActiveRecord::Schema.define(version: 20151117130742) do
     t.integer  "affiliate_id"
     t.text     "customer_address"
     t.text     "business_address"
-    t.string   "stripe_customer_id"
+    t.string   "stripe_customer_id",   limit: 191
     t.string   "currency"
     t.text     "signed_custom_fields"
     t.integer  "owner_id"
-    t.string   "owner_type"
+    t.string   "owner_type",           limit: 100
   end
 
   add_index "payola_sales", ["coupon_id"], name: "index_payola_sales_on_coupon_id", using: :btree
@@ -240,7 +239,7 @@ ActiveRecord::Schema.define(version: 20151117130742) do
     t.datetime "updated_at"
     t.string   "currency"
     t.integer  "amount"
-    t.string   "guid"
+    t.string   "guid",                 limit: 191
     t.string   "stripe_status"
     t.integer  "affiliate_id"
     t.string   "coupon"
@@ -384,8 +383,8 @@ ActiveRecord::Schema.define(version: 20151117130742) do
     t.datetime "updated_at"
     t.string   "public_repo_token"
     t.string   "private_repo_token"
-    t.boolean  "token_upgrade",      default: false
-    t.boolean  "currently_syncing",  default: false
+    t.boolean  "token_upgrade"
+    t.boolean  "currently_syncing",  default: false, null: false
     t.datetime "last_synced_at"
   end
 


### PR DESCRIPTION
Bruuuh, take a look at this.

Removed `repository_dependencies` from the github endpoint and moved it to a nested `/dependencies` that shows the same detail we have in the HTML views (outdated/deprecated)

Removed some constraints that were too vague and added a tighter one for versions.

Those two endpoints allow us to fetch dependency status through the API and do this in shields.io:

![screen shot 2015-11-19 at 17 17 25](https://cloud.githubusercontent.com/assets/14751/11278225/e187317c-8ee1-11e5-8c56-f329b9d209b8.png)

So people can have a badge based on their github repo master or an specific release version.

PS. Do you like the badge urls?

:rocket:
