### PR TITLE
Configurable timeout and a lower default

### DIFF
--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,2 +1,2 @@
-Rack::Timeout.timeout = 25  # seconds
+Rack::Timeout.timeout = ENV.fetch("TIMEOUT", 10)  # seconds
 Rack::Timeout::Logger.disable


### PR DESCRIPTION
25s is way too long for page timeouts, so best drop that to 10.  Also make it changeable via Config.

This is bad:

![screenshot 2016-03-14 18 09 57](https://cloud.githubusercontent.com/assets/60786/13754724/fbda6dd0-ea0f-11e5-8edf-1c1cd7abdd1b.png)

Ultimately, it looks like you need two performance-M's, but we need to sort out cost first.
