### PR TITLE
Fixed payola initializer for migrations.

### DIFF
--- a/config/initializers/payola.rb
+++ b/config/initializers/payola.rb
@@ -1,4 +1,7 @@
-SubscriptionPlan.first if Rails.env.development? # have to force load the SubscriptionPlan class for development
+# have to force load the SubscriptionPlan class for development
+if Rails.env.development? && defined? SubscriptionPlan
+  SubscriptionPlan.first
+end
 
 Payola.background_worker = :sidekiq
 Payola.default_currency = 'gbp'


### PR DESCRIPTION
When running rake db:migrate command, initializers are loaded before migrations executed. So payola
initializer can not find 'SubscriptionPlan' model and it breaks migrations. With this change we control
'SubscriptionPlan' is defined before.

Without this change, contribution to this project will be painful.