### PR TITLE
issue 755 add links to package manager promos

### DIFF
--- a/app/views/dashboard/_monitoring_promo.html.erb
+++ b/app/views/dashboard/_monitoring_promo.html.erb
@@ -10,7 +10,7 @@
 <p><strong>Supported Package Managers:</strong></p>
 <div class="">
   <% Download.platforms.select{|p| p::LIBRARIAN_SUPPORT }.sort_by{|p| p.formatted_name.downcase }.each do |platform| %>
-    <div class="pictogram tip pictogram-<%= platform.formatted_name.downcase %>" title='<%= platform.formatted_name %>'></div>
+    <a class="pictogram tip pictogram-<%= platform.formatted_name.downcase %>" href="/<%= platform.formatted_name %>" title='<%= platform.formatted_name %>'></a>
   <% end %>
 </div>
 <br>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -112,9 +112,10 @@
         as soon as you push to GitHub.
       </p>
       <p><strong>Supported Package Managers:</strong></p>
-      <div class="">
+      <div>
         <% Download.platforms.select{|p| p::LIBRARIAN_SUPPORT }.sort_by{|p| p.formatted_name.downcase }.each do |platform| %>
-          <div class="pictogram tip pictogram-<%= platform.formatted_name.downcase %>" title='<%= platform.formatted_name %>'></div>
+        test
+          <a class="pictogram tip pictogram-<%= platform.formatted_name.downcase %>" title='<%= platform.formatted_name %>'></a>
         <% end %>
       </div>
       <br>


### PR DESCRIPTION
Added links to the promo icons

See screenshots
<img width="703" alt="screen shot 2016-08-03 at 20 49 41" src="https://cloud.githubusercontent.com/assets/1868592/17379982/acbf654e-59bc-11e6-81bb-1ac8e1523ab7.png">
<img width="583" alt="screen shot 2016-08-03 at 20 49 58" src="https://cloud.githubusercontent.com/assets/1868592/17379983/acc419c2-59bc-11e6-95d3-5de2513dae9b.png">

