### PR TITLE
Misc style amends to repo readme and tree view

### DIFF
--- a/app/assets/stylesheets/_readme.scss
+++ b/app/assets/stylesheets/_readme.scss
@@ -1,0 +1,66 @@
+// Styling the readme markup
+
+#readme {
+  .markdown-body {
+    word-break: break-word;
+
+    // Show the title anchors on hover
+
+    h1, h2, h3, h4, h5, h6 {
+      position: relative;
+
+      .anchor {
+        display: none;
+        height: 100%;
+        align-items: center;
+        position: absolute;
+        right: 100%;
+        padding-right: 10px;
+        svg {
+          height: 100%;
+        }
+      }
+
+      @media (min-width: 768px) {
+        &:hover .anchor {
+          display: block;
+        }
+      }
+
+    }
+
+    h1, h2 {
+      padding-bottom: 0.25em;
+      border-bottom: 1px solid #eee;
+      margin-top: 1em;
+      margin-bottom: 0.5em;
+    }
+
+    h3, h4 {
+      color: #555;
+      font-weight: normal;
+      line-height: 1.1;
+      margin-top: 1em;
+      margin-bottom: 0.5em;
+    }
+
+    h3 {
+      font-size: 21px;
+    }
+
+    h4 {
+      font-size: 18px;
+    }
+
+    p {
+      margin-bottom: 1.25em;
+    }
+
+    pre {
+      border: none;
+      padding: 15px;
+      margin: 0 0 1.5em 0;
+    }
+
+  }
+}

--- a/app/assets/stylesheets/_tree.scss
+++ b/app/assets/stylesheets/_tree.scss
@@ -1,43 +1,47 @@
-.tree ul {
-  &.top-level {
-    margin: 0;
-    & > li:before {
-      display: none;
-    }
-  }
+.tree {
+  margin-bottom: 20px;
 
-  padding: 0;
-  margin: 0px 0px 0px 20px;
-  list-style: none;
-  line-height: 1.8em;
-
-  li {
-    position: relative;
-
-    &:before {
-      position: absolute;
-      left: -15px;
-      top: 0px;
-      content: '';
-      display: block;
-      border-left: 1px solid #ddd;
-      height: .9em;
-      border-bottom: 1px solid #ddd;
-      width: 10px;
+  ul {
+    &.top-level {
+      margin: 0;
+      & > li:before {
+        display: none;
+      }
     }
 
-    &:after {
-      position: absolute;
-      left: -15px;
-      bottom: -7px;
-      content: '';
-      display: block;
-      border-left: 1px solid #ddd;
-      height: 100%;
-    }
+    padding: 0;
+    margin: 0px 0px 0px 20px;
+    list-style: none;
+    line-height: 1.8em;
 
-    &:last-child {
-      &:after { display: none }
+    li {
+      position: relative;
+
+      &:before {
+        position: absolute;
+        left: -15px;
+        top: 0px;
+        content: '';
+        display: block;
+        border-left: 1px solid #ddd;
+        height: .9em;
+        border-bottom: 1px solid #ddd;
+        width: 10px;
+      }
+
+      &:after {
+        position: absolute;
+        left: -15px;
+        bottom: -7px;
+        content: '';
+        display: block;
+        border-left: 1px solid #ddd;
+        height: 100%;
+      }
+
+      &:last-child {
+        &:after { display: none }
+      }
     }
   }
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,6 +5,7 @@
 @import "pictogram";
 @import "highlight";
 @import "tree";
+@import "readme";
 
 body {
   background-color: #fff;
@@ -174,13 +175,6 @@ h3,h4{
   small{
     color: #999;
     margin-left: 5px;
-  }
-}
-
-#readme{
-  overflow: hidden;
-  .markdown-body {
-    word-break: break-word;
   }
 }
 
@@ -372,4 +366,9 @@ tr.top td{
 
 .tip {
   cursor: default;
+}
+
+.adsbygoogle {
+  display: block;
+  margin: 10px 0 20px;
 }


### PR DESCRIPTION
Some minor style amends, if you'd like 😁 

- margin above and below ads
- horizontal lines after `h1` and `h2`
- only show title anchor link icon on hover (as per bootstrap, github)
- more vertical spacing
- removed border from code blocks to be more like github (and added a bit more padding)
- bit of margin underneath tree view

I put all the new styles relating to readmes in a new stylesheet `_readme.scss`.

I reviewed it on a few readmes but I haven't got many on my localhost, so please do have a look before you merge :)