### PR TITLE
Show dependent repo/project counts prompinently on respective pages

### DIFF
--- a/app/views/projects/dependent_repos.html.erb
+++ b/app/views/projects/dependent_repos.html.erb
@@ -6,7 +6,7 @@
 </h1>
 <hr>
 <% if @dependent_repos.any? %>
-  <p class="lead"><strong><%= @project.dependent_repositories.open_source.length %></strong> repositories depend on <%= link_to @project, project_path(@project.to_param) %>:</p>
+  <p class="lead"><strong><%= @dependent_repos.total_entries %></strong> <%= 'repository'.pluralize(@dependent_repos.total_entries) %> depend on <%= link_to @project, project_path(@project.to_param) %>:</p>
 <% end %>
 
 <div class="row">

--- a/app/views/projects/dependent_repos.html.erb
+++ b/app/views/projects/dependent_repos.html.erb
@@ -1,7 +1,14 @@
 <% title "Repositories that depend on #{@project}  on #{@project.platform_name} - Libraries" %>
 
-<h1>Repositories that depend on <%= link_to @project, project_path(@project.to_param) %></h1>
+<h1>
+  <div class="pictogram pictogram-<%= @project.platform.downcase %>"></div>
+  <%= link_to @project, project_path(@project.to_param) %>
+</h1>
 <hr>
+<% if @dependent_repos.any? %>
+  <p class="lead"><strong><%= @project.dependent_repositories.open_source.length %></strong> repositories depend on <%= link_to @project, project_path(@project.to_param) %>:</p>
+<% end %>
+
 <div class="row">
   <div class="col-sm-8">
     <% if @dependent_repos.any? %>

--- a/app/views/projects/dependents.html.erb
+++ b/app/views/projects/dependents.html.erb
@@ -1,7 +1,13 @@
 <% title "Projects that depend on #{@project} on #{@project.platform_name} - Libraries" %>
 
-<h1>Projects that depend on <%= link_to @project, project_path(@project.to_param) %></h1>
+<h1>
+  <div class="pictogram pictogram-<%= @project.platform.downcase %>"></div>
+  <%= link_to @project, project_path(@project.to_param) %>
+</h1>
 <hr>
+<% if @dependents.any? %>
+  <p class="lead"><strong><%= @project.dependents.length %></strong> projects depend on <%= link_to @project, project_path(@project.to_param) %>:</p>
+<% end %>
 
 <div class="row">
   <div class="col-sm-8">

--- a/app/views/projects/dependents.html.erb
+++ b/app/views/projects/dependents.html.erb
@@ -6,7 +6,7 @@
 </h1>
 <hr>
 <% if @dependents.any? %>
-  <p class="lead"><strong><%= @project.dependents.length %></strong> projects depend on <%= link_to @project, project_path(@project.to_param) %>:</p>
+  <p class="lead"><strong><%= @dependents.total_entries %></strong> <%= 'projects'.pluralize(@dependents.total_entries) %> depend on <%= link_to @project, project_path(@project.to_param) %>:</p>
 <% end %>
 
 <div class="row">


### PR DESCRIPTION
Show the counts prominently on the `/<platform>/<project>/dependents` and `/<platform>/<project>/dependent-repositories` pages.

Please check I've not incurred any huuuuuge queries. Pretty sure I'm just using cached counts though 🙊 

Looks like this:

![screen shot 2016-10-13 at 21 48 29](https://cloud.githubusercontent.com/assets/609579/19366376/da5b9d1a-918e-11e6-822e-2024e094067d.png)
![screen shot 2016-10-13 at 21 48 42](https://cloud.githubusercontent.com/assets/609579/19366377/da5f87f4-918e-11e6-9316-f7a18f3221ed.png)
