### PR TITLE
Dependency Tree API endpoint

### DIFF
--- a/app/controllers/api/tree_controller.rb
+++ b/app/controllers/api/tree_controller.rb
@@ -1,0 +1,14 @@
+class Api::TreeController < Api::ApplicationController
+  before_action :require_api_key
+  before_action :find_project
+
+  def show
+    find_version
+    if @version.nil?
+      @version = @project.latest_stable_version
+      raise ActiveRecord::RecordNotFound if @version.nil?
+    end
+    @kind = params[:kind] || 'normal'
+    render json: TreeResolver.new(@version, @kind).tree
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,9 +36,11 @@ Rails.application.routes.draw do
 
     get '/github/:login', to: 'github_users#show'
 
+    get '/:platform/:name/:version/tree', to: 'tree#show', constraints: { :platform => /[\w\-]+/, :name => /[\w\-\%]+/, :version => /[\w\.\-]+/ }
     get '/:platform/:name/:version/dependencies', to: 'projects#dependencies', constraints: { :platform => /[\w\-]+/, :name => /[\w\-\%]+/, :version => /[\w\.\-]+/ }
     get '/:platform/:name/dependent_repositories', to: 'projects#dependent_repositories', constraints: { :platform => /[\w\-]+/, :name => /[\w\.\-\%]+/ }
     get '/:platform/:name/dependents', to: 'projects#dependents', constraints: { :platform => /[\w\-]+/, :name => /[\w\.\-\%]+/ }
+    get '/:platform/:name/tree', to: 'tree#show', constraints: { :platform => /[\w\-]+/, :name => /[\w\.\-\%]+/ }
     get '/:platform/:name', to: 'projects#show', constraints: { :platform => /[\w\-]+/, :name => /[\w\.\-\%]+/ }
   end
 


### PR DESCRIPTION
Fixes #839

Urls like: 
```ruby
'https://libraries.io/api/npm/express/tree?api_key=XXX' # latest version
'https://libraries.io/api/npm/express/4.14.0/tree?api_key=XXX' #specific version
```

Requires an API key, so no anonymous access as it's quite intensive if not cached.

Some big trees may time out if they've not loaded within 60 seconds, need to come up with some way to say "check back in a minute" once #864 is complete.

Not going to add it to the documentation yet as the format may need to change but gives @whit537 something to play with for now.