### PR TITLE
Resolve dependency tree in sidekiq and update with js

### DIFF
--- a/app/controllers/tree_controller.rb
+++ b/app/controllers/tree_controller.rb
@@ -9,8 +9,19 @@ class TreeController < ApplicationController
     end
     @kind = params[:kind] || 'normal'
     @tree_resolver = TreeResolver.new(@version, @kind)
-    @tree = @tree_resolver.tree
-    @project_names = @tree_resolver.project_names
-    @license_names = @tree_resolver.license_names
+
+    if @tree_resolver.cached?
+      @tree = @tree_resolver.tree
+      @project_names = @tree_resolver.project_names
+      @license_names = @tree_resolver.license_names
+    end
+
+    if request.xhr?
+      render :_tree, layout: false, tree: @tree
+    else
+      if !@tree_resolver.cached?
+        @tree_resolver.enqueue_tree_resolution
+      end
+    end
   end
 end

--- a/app/views/tree/_tree.html.erb
+++ b/app/views/tree/_tree.html.erb
@@ -1,0 +1,39 @@
+<% if @tree %>
+  <% cache ['tree', @project, @version, @kind], expires_in: 1.day do  %>
+    <div class="col-sm-8">
+      <%= render 'adsense/banner' %>
+      <div class="tree">
+        <ul class="top-level">
+          <%= render 'dep', dep: @tree %>
+        </ul>
+      </div>
+      <%= render 'adsense/banner' %>
+    </div>
+    <div class="col-sm-4">
+      <%= render 'adsense/sidebar' %>
+      <div>
+        <p class="h4">Unique dependencies:</p>
+        <p class="h1"><%= @project_names.uniq.length %></p>
+        <hr/>
+        <p class="h4">Unique licenses:</p>
+        <p class="h1"><%= @license_names.flatten.uniq.length %></p>
+        <p class="h5"><%= @license_names.flatten.uniq.sort.join(', ') %></p>
+      </div>
+    </div>
+  <% end %>
+<% else %>
+  <div class="col-12">
+    <h3 class='text-center'>
+      <i class="fa fa-refresh fa-spin"></i>
+      Generating dependency tree...
+    </h3>
+  </div>
+  <script type="text/javascript">
+    setTimeout(function() {
+      $.get(window.location, function(data) {
+        $('#tree').html(data);
+        stickFooter()
+      });
+    }, 1000)
+  </script>
+<% end %>

--- a/app/views/tree/show.html.erb
+++ b/app/views/tree/show.html.erb
@@ -8,26 +8,7 @@
 <hr>
 
 <div class="row">
-  <% cache ['tree', @project, @version, @kind], expires_in: 1.day do  %>
-    <div class="col-sm-8">
-      <%= render 'adsense/banner' %>
-      <div class="tree">
-        <ul class="top-level">
-          <%= render 'dep', dep: @tree %>
-        </ul>
-      </div>
-      <%= render 'adsense/banner' %>
-    </div>
-    <div class="col-sm-4">
-      <%= render 'adsense/sidebar' %>
-      <div>
-        <p class="h4">Unique dependencies:</p>
-        <p class="h1"><%= @project_names.uniq.length %></p>
-        <hr/>
-        <p class="h4">Unique licenses:</p>
-        <p class="h1"><%= @license_names.flatten.uniq.length %></p>
-        <p class="h5"><%= @license_names.flatten.uniq.sort.join(', ') %></p>
-      </div>
-    </div>
-  <% end %>
+  <div id="tree">
+    <%= render 'tree/tree', tree: @tree %>
+  </div>
 </div>

--- a/app/workers/tree_resolver_worker.rb
+++ b/app/workers/tree_resolver_worker.rb
@@ -1,0 +1,9 @@
+class TreeResolverWorker
+  include Sidekiq::Worker
+  sidekiq_options unique: :until_executed
+
+  def perform(version_id, kind)
+    version = Version.find(version_id)
+    TreeResolver.new(version, kind).load_dependencies_tree if version
+  end
+end


### PR DESCRIPTION
Fixes #864 

Web page checks every second to see if the tree is cached and then renders it and stops checking