### PR TITLE
Allow sorting by dependent_repos_count in elasticsearch

### DIFF
--- a/app/controllers/api/bower_search_controller.rb
+++ b/app/controllers/api/bower_search_controller.rb
@@ -15,6 +15,6 @@ class Api::BowerSearchController < Api::ApplicationController
   private
 
   def allowed_sorts
-    ['rank', 'stars', 'dependents_count', 'latest_release_published_at', 'created_at']
+    ['rank', 'stars', 'dependents_count', 'dependent_repos_count', 'latest_release_published_at', 'created_at']
   end
 end

--- a/app/controllers/api/search_controller.rb
+++ b/app/controllers/api/search_controller.rb
@@ -17,6 +17,6 @@ class Api::SearchController < Api::ApplicationController
   private
 
   def allowed_sorts
-    ['rank', 'stars', 'dependents_count', 'latest_release_published_at', 'created_at']
+    ['rank', 'stars', 'dependents_count', 'dependent_repos_count', 'latest_release_published_at', 'created_at']
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -16,7 +16,7 @@ class SearchController < ApplicationController
   private
 
   def allowed_sorts
-    ['rank', 'stars', 'dependents_count', 'latest_release_published_at', 'created_at', 'github_contributions_count']
+    ['rank', 'stars', 'dependents_count', 'dependent_repos_count', 'latest_release_published_at', 'created_at', 'github_contributions_count']
   end
 
   def page_title

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,6 +9,7 @@ module ApplicationHelper
       ['SourceRank', 'rank'],
       ['GitHub Stars', 'stars'],
       ['Dependents', 'dependents_count'],
+      ['Most Used', 'dependent_repos_count'],
       ['Latest Release', 'latest_release_published_at'],
       ['Contributors', 'github_contributions_count'],
       ['Newest', 'created_at']

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -32,6 +32,7 @@ module Searchable
         indexes :stars, type: 'integer'
         indexes :versions_count, type: 'integer'
         indexes :dependents_count, type: 'integer'
+        indexes :dependent_repos_count, type: 'integer'
         indexes :github_repository_id, type: 'integer'
         indexes :github_contributions_count, type: 'integer'
       end
@@ -40,7 +41,11 @@ module Searchable
     after_save() { __elasticsearch__.index_document }
 
     def as_indexed_json(_options)
-      as_json methods: [:stars, :repo_name, :exact_name, :github_contributions_count, :pushed_at]
+      as_json methods: [:stars, :repo_name, :exact_name, :github_contributions_count, :pushed_at, :dependent_repos_count]
+    end
+
+    def dependent_repos_count
+      read_attribute(:dependent_repos_count) || 0
     end
 
     def exact_name


### PR DESCRIPTION
Part 4 of #912 

Waiting on #917 being merged, will require reindexing all projects in elasticsearch (i.e partial downtime)