### PR TITLE
Improved display of sidebar filters on overview pages

### DIFF
--- a/app/views/keywords/show.html.erb
+++ b/app/views/keywords/show.html.erb
@@ -89,23 +89,32 @@
   <div class="col-md-4">
     <div class='row'>
       <%= render 'adsense/sidebar' %>
-      <% if @languages.any? %>
+      <% if @languages.many? %>
       <div class='col-md-12 col-sm-4'>
-        <h4>Popular "<%= @keyword %>" Languages</h4>
+        <h4>
+          <%= fa_icon 'code' %>
+          Top "<%= @keyword %>" Languages
+        </h4>
         <%= render partial: 'languages/list_language', collection: @languages, as: :language %>
       </div>
       <% end %>
 
-      <% if @platforms.any? %>
+      <% if @platforms.many? %>
       <div class='col-md-12 col-sm-4'>
-        <h4>Popular "<%= @keyword %>" Platforms</h4>
+        <h4>
+          <%= fa_icon 'archive' %>
+          Top "<%= @keyword %>" Package Managers
+        </h4>
         <%= render partial: 'platforms/list_platform', collection: @platforms, as: :platform %>
       </div>
       <% end %>
 
-      <% if @licenses.any? %>
+      <% if @licenses.many? %>
       <div class='col-md-12 col-sm-4'>
-        <h4>Popular "<%= @keyword %>" Licenses</h4>
+        <h4>
+          <%= fa_icon 'gavel' %>
+          Top "<%= @keyword %>" Licenses
+        </h4>
         <%= render partial: 'licenses/list_license', collection: @licenses, as: :license %>
       </div>
       <% end %>

--- a/app/views/languages/show.html.erb
+++ b/app/views/languages/show.html.erb
@@ -88,23 +88,32 @@
   <div class="col-md-4">
     <%= render 'adsense/sidebar' %>
     <div class="row">
-      <% if @licenses.any? %>
+      <% if @licenses.many? %>
         <div class='col-md-12 col-sm-4'>
-          <h4>Popular <%= @language %> Licenses</h4>
+          <h4>
+            <%= fa_icon 'gavel' %>
+            Top <%= @language %> Licenses
+          </h4>
           <%= render partial: 'licenses/list_license', collection: @licenses, as: :license %>
         </div>
       <% end %>
 
-      <% if @platforms.length > 1 %>
+      <% if @platforms.many? %>
         <div class='col-md-12 col-sm-4'>
-          <h4>Popular <%= @language %> Platforms</h4>
+          <h4>
+            <%= fa_icon 'archive' %>
+            Top <%= @language %> Package Managers
+          </h4>
           <%= render partial: 'platforms/list_platform', collection: @platforms, as: :platform %>
         </div>
       <% end %>
 
-      <% if @keywords.length > 1 %>
+      <% if @keywords.many? %>
         <div class='col-md-12 col-sm-4'>
-          <h4>Popular <%= @language %> Keywords</h4>
+          <h4>
+            <%= fa_icon 'tags' %>
+            Top <%= @language %> Keywords
+          </h4>
           <%= render partial: 'keywords/list_keyword', collection: @keywords, as: :keyword %>
         </div>
       <% end %>

--- a/app/views/licenses/show.html.erb
+++ b/app/views/licenses/show.html.erb
@@ -96,23 +96,32 @@
   <div class="col-md-4">
     <%= render 'adsense/sidebar' %>
     <div class="row">
-      <% if @languages.any? %>
+      <% if @languages.many? %>
       <div class='col-md-12 col-sm-4'>
-        <h4>Popular <%= @license.id %> Languages</h4>
+        <h4>
+          <%= fa_icon 'code' %>
+          Top <%= @license.id %> Languages
+        </h4>
         <%= render partial: 'languages/list_language', collection: @languages, as: :language %>
       </div>
       <% end %>
 
-      <% if @platforms.any? %>
+      <% if @platforms.many? %>
       <div class='col-md-12 col-sm-4'>
-        <h4>Popular <%= @license.id %> Platforms</h4>
+        <h4>
+          <%= fa_icon 'archive' %>
+          Top <%= @license.id %> Package Managers
+        </h4>
         <%= render partial: 'platforms/list_platform', collection: @platforms, as: :platform %>
       </div>
       <% end %>
 
-      <% if @keywords.length > 1 %>
+      <% if @keywords.many? %>
         <div class='col-md-12 col-sm-4'>
-          <h4>Popular <%= @license.id %> Keywords</h4>
+          <h4>
+            <%= fa_icon 'gavel' %>
+            Top <%= @license.id %> Keywords
+          </h4>
           <%= render partial: 'keywords/list_keyword', collection: @keywords, as: :keyword %>
         </div>
       <% end %>

--- a/app/views/platforms/show.html.erb
+++ b/app/views/platforms/show.html.erb
@@ -98,21 +98,30 @@
   <div class="col-md-4">
     <%= render 'adsense/sidebar' %>
     <div class='row'>
-      <% if @languages.any? %>
+      <% if @languages.many? %>
         <div class='col-md-12 col-sm-4'>
-          <h4>Popular <%= platform_name(@platform_name) %> Languages</h4>
+          <h4>
+            <%= fa_icon 'code' %>
+            Top <%= platform_name(@platform_name) %> Languages
+          </h4>
           <%= render partial: 'languages/list_language', collection: @languages, as: :language %>
         </div>
       <% end %>
-      <% if @licenses.any? %>
+      <% if @licenses.many? %>
         <div class='col-md-12 col-sm-4'>
-          <h4>Popular <%= platform_name(@platform_name) %> Licenses</h4>
+          <h4>
+            <%= fa_icon 'gavel' %>
+            Top <%= platform_name(@platform_name) %> Licenses
+          </h4>
           <%= render partial: 'licenses/list_license', collection: @licenses, as: :license %>
         </div>
       <% end %>
-      <% if @keywords.length > 1 %>
+      <% if @keywords.many? %>
         <div class='col-md-12 col-sm-4'>
-          <h4>Popular <%= platform_name(@platform_name) %> Keywords</h4>
+          <h4>
+            <%= fa_icon 'tags' %>
+            Top <%= platform_name(@platform_name) %> Keywords
+          </h4>
           <%= render partial: 'keywords/list_keyword', collection: @keywords, as: :keyword %>
         </div>
       <% end %>


### PR DESCRIPTION
Making them look more like the [Explore](https://libraries.io/explore) sidebar:

![screen shot 2016-11-22 at 3 02 00 pm](https://cloud.githubusercontent.com/assets/1060/20528584/bba22696-b0c4-11e6-9879-2a3385512a16.png)
