### PR TITLE
Usage statistics for projects

### DIFF
--- a/app/assets/stylesheets/_usage.scss
+++ b/app/assets/stylesheets/_usage.scss
@@ -36,19 +36,20 @@
   color: #AAA;
 }
 
-#q-graph tbody th {bottom: -1.75em; vertical-align: top;
-font-weight: normal; color: #333;}
+#q-graph tbody th {
+  bottom: -1.75em;
+  vertical-align: top;
+  font-weight: normal;
+  color: #333;
+  overflow: hidden;
+}
 #q-graph .bar {
+  left: 10px;
   width: 40px;
-  border: 1px solid;
   border-bottom: none;
   color: #000;
 }
 #q-graph .bar p {
   margin: -20px 0 0;
   opacity: .6;
-}
-#q-graph .sent {
-  left: 10px;
-  border-color: transparent;
 }

--- a/app/assets/stylesheets/_usage.scss
+++ b/app/assets/stylesheets/_usage.scss
@@ -1,72 +1,54 @@
-dl {
-  display: flex;
-  background-color: white;
-  flex-direction: column;
-  width: 100%;
-  max-width: 700px;
-  position: relative;
-  padding: 20px;
-}
-
-dt {
-  align-self: flex-start;
-  width: 100%;
+#q-graph {
   display: block;
-  text-align: center;
-  margin-bottom: 20px;
-  margin-left: 130px;
+  position: relative;
+  height: 400px;
+  margin: 70px 0 30px;
+  padding: 0;
+  background: transparent;
+  font-size: 12px;
 }
 
-.text {
-  display: flex;
-  align-items: center;
-  height: 40px;
-  width: 130px;
-  background-color: white;
+#q-graph caption {
+  caption-side: top;
+  width: 600px;
+  text-transform: uppercase;
+  letter-spacing: .5px;
+  top: -60px;
+  position: relative;
+  z-index: 10;
+  font-weight: bold;
+}
+
+#q-graph tr, #q-graph th, #q-graph td {
   position: absolute;
-  left: 0;
-  justify-content: flex-end;
+  bottom: 0;
+  width: 60px;
+  z-index: 2;
+  margin: 0;
+  padding: 0;
+  text-align: center;
 }
 
-.percentage {
-  line-height: 1;
-  width: 100%;
-  height: 40px;
-  margin-left: 130px;
-  background: repeating-linear-gradient(
-  to right,
-  #ddd,
-  #ddd 1px,
-  #fff 1px,
-  #fff 5%
-);
-
-  &:after {
-    content: "";
-    display: block;
-    background-color: #3d9970;
-    width: 50px;
-    margin-bottom: 10px;
-    height: 90%;
-    position: relative;
-    top: 50%;
-    transform: translateY(-50%);
-    transition: background-color .3s ease;
-    cursor: pointer;
-  }
-  &:hover,
-  &:focus {
-    &:after {
-       background-color: #aaa;
-    }
-  }
+#q-graph tbody tr {
+  height: 400px;
+  padding-top: 2px;
+  border-right: 1px dotted #C4C4C4;
+  color: #AAA;
 }
 
-@for $i from 1 through 100 {
-  .percentage-#{$i} {
-    &:after {
-      $value: ($i * 1%);
-      width: $value;
-    }
-  }
+#q-graph tbody th {bottom: -1.75em; vertical-align: top;
+font-weight: normal; color: #333;}
+#q-graph .bar {
+  width: 40px;
+  border: 1px solid;
+  border-bottom: none;
+  color: #000;
+}
+#q-graph .bar p {
+  margin: -20px 0 0;
+  opacity: .6;
+}
+#q-graph .sent {
+  left: 10px;
+  border-color: transparent;
 }

--- a/app/assets/stylesheets/_usage.scss
+++ b/app/assets/stylesheets/_usage.scss
@@ -1,0 +1,72 @@
+dl {
+  display: flex;
+  background-color: white;
+  flex-direction: column;
+  width: 100%;
+  max-width: 700px;
+  position: relative;
+  padding: 20px;
+}
+
+dt {
+  align-self: flex-start;
+  width: 100%;
+  display: block;
+  text-align: center;
+  margin-bottom: 20px;
+  margin-left: 130px;
+}
+
+.text {
+  display: flex;
+  align-items: center;
+  height: 40px;
+  width: 130px;
+  background-color: white;
+  position: absolute;
+  left: 0;
+  justify-content: flex-end;
+}
+
+.percentage {
+  line-height: 1;
+  width: 100%;
+  height: 40px;
+  margin-left: 130px;
+  background: repeating-linear-gradient(
+  to right,
+  #ddd,
+  #ddd 1px,
+  #fff 1px,
+  #fff 5%
+);
+
+  &:after {
+    content: "";
+    display: block;
+    background-color: #3d9970;
+    width: 50px;
+    margin-bottom: 10px;
+    height: 90%;
+    position: relative;
+    top: 50%;
+    transform: translateY(-50%);
+    transition: background-color .3s ease;
+    cursor: pointer;
+  }
+  &:hover,
+  &:focus {
+    &:after {
+       background-color: #aaa;
+    }
+  }
+}
+
+@for $i from 1 through 100 {
+  .percentage-#{$i} {
+    &:after {
+      $value: ($i * 1%);
+      width: $value;
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,6 +6,7 @@
 @import "highlight";
 @import "tree";
 @import "readme";
+@import "usage";
 
 body {
   background-color: #fff;

--- a/app/controllers/project_usage_controller.rb
+++ b/app/controllers/project_usage_controller.rb
@@ -1,0 +1,8 @@
+class ProjectUsageController < ApplicationController
+  before_action :find_project
+  def show
+    @counts = @project.repository_dependencies.group(:requirements).count
+    @total = @counts.sum{|k,v| v }
+    @highest_percentage = @counts.map{|k,v| v.to_f/@total*100 }.max
+  end
+end

--- a/app/controllers/project_usage_controller.rb
+++ b/app/controllers/project_usage_controller.rb
@@ -2,13 +2,15 @@ class ProjectUsageController < ApplicationController
   before_action :find_project
   def show
     @all_counts = @project.repository_dependencies.group(:requirements).count
-    @kinds = @project.repository_dependencies.group(:kind).count
-    @total = @all_counts.sum{|k,v| v }
-    @counts = @all_counts.sort_by{|_k,v| -v}.first(18).sort_by{|k,_v| k.gsub(/\~|\>|\<|\^|\=|\*|\s/,'').split('.').map{|i| i.to_i} }
-    @highest_percentage = @counts.map{|_k,v| v.to_f/@total*100 }.max
-    scope = @project.dependent_repositories.open_source
-    scope = scope.where("repository_dependencies.requirements = ?", params[:requirements]) if params[:requirements].present?
-    scope = scope.where("repository_dependencies.kind = ?", params[:kind]) if params[:kind].present?
-    @repos = scope.paginate(page: page_number, per_page: 20)
+    if @all_counts.any?
+      @kinds = @project.repository_dependencies.group(:kind).count
+      @total = @all_counts.sum{|k,v| v }
+      @counts = @all_counts.sort_by{|_k,v| -v}.first(18).sort_by{|k,_v| k.gsub(/\~|\>|\<|\^|\=|\*|\s/,'').split('.').map{|i| i.to_i} }
+      @highest_percentage = @counts.map{|_k,v| v.to_f/@total*100 }.max
+      scope = @project.dependent_repositories.open_source
+      scope = scope.where("repository_dependencies.requirements = ?", params[:requirements]) if params[:requirements].present?
+      scope = scope.where("repository_dependencies.kind = ?", params[:kind]) if params[:kind].present?
+      @repos = scope.paginate(page: page_number, per_page: 20)
+    end
   end
 end

--- a/app/controllers/project_usage_controller.rb
+++ b/app/controllers/project_usage_controller.rb
@@ -1,8 +1,13 @@
 class ProjectUsageController < ApplicationController
   before_action :find_project
   def show
-    @counts = @project.repository_dependencies.group(:requirements).count
-    @total = @counts.sum{|k,v| v }
+    @all_counts = @project.repository_dependencies.group(:requirements).count
+    @kinds = @project.repository_dependencies.group(:kind).count
+    @total = @all_counts.sum{|k,v| v }
+    @counts = @all_counts.sort_by{|k,v| -v}.first(18).sort_by{|k,v| k.gsub(/\~|\>|\<|\^|\=|\*|\s/,'').split('.').map{|v| v.to_i} }
     @highest_percentage = @counts.map{|k,v| v.to_f/@total*100 }.max
+    scope = @project.dependent_repositories.open_source
+    scope = scope.where("repository_dependencies.requirements = ?", params[:requirements]) if params[:requirements].present?
+    @repos = scope.paginate(page: page_number, per_page: 20)
   end
 end

--- a/app/controllers/project_usage_controller.rb
+++ b/app/controllers/project_usage_controller.rb
@@ -4,10 +4,11 @@ class ProjectUsageController < ApplicationController
     @all_counts = @project.repository_dependencies.group(:requirements).count
     @kinds = @project.repository_dependencies.group(:kind).count
     @total = @all_counts.sum{|k,v| v }
-    @counts = @all_counts.sort_by{|k,v| -v}.first(18).sort_by{|k,v| k.gsub(/\~|\>|\<|\^|\=|\*|\s/,'').split('.').map{|v| v.to_i} }
-    @highest_percentage = @counts.map{|k,v| v.to_f/@total*100 }.max
+    @counts = @all_counts.sort_by{|_k,v| -v}.first(18).sort_by{|k,_v| k.gsub(/\~|\>|\<|\^|\=|\*|\s/,'').split('.').map{|i| i.to_i} }
+    @highest_percentage = @counts.map{|_k,v| v.to_f/@total*100 }.max
     scope = @project.dependent_repositories.open_source
     scope = scope.where("repository_dependencies.requirements = ?", params[:requirements]) if params[:requirements].present?
+    scope = scope.where("repository_dependencies.kind = ?", params[:kind]) if params[:kind].present?
     @repos = scope.paginate(page: page_number, per_page: 20)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -209,4 +209,9 @@ module ApplicationHelper
   def version_tree_path(options={})
     version_path(options.except(:kind)) + "/tree#{options[:kind].present? ? '?kind='+options[:kind] : '' }"
   end
+
+  def usage_cache_length(total)
+    return 1 if total <= 0
+    (Math.log10(total).round+1)*2
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,6 +3,10 @@ require 'uri'
 module ApplicationHelper
   include SanitizeUrl
 
+  def colours
+    Languages::Language.all.map(&:color).compact.uniq.shuffle(random: Random.new(12))
+  end
+
   def sort_options
     [
       ['Relevance', nil],

--- a/app/views/project_usage/show.html.erb
+++ b/app/views/project_usage/show.html.erb
@@ -8,10 +8,18 @@
       <% percentage = count.to_f/@total*100 %>
 
       <tr class="qtr" style='left:<%= index*60 %>px; <% if index == @counts.length - 1 %>border-right:none;<% end %>'>
-          <th scope="row"><%= requirement %></th>
-          <td class="sent bar" style='height:<%= (percentage.round/@highest_percentage.to_f*max_height).round %>px; background-color: <%= colours[index] %>;'>
+          <th scope="row">
+            <% if requirement.length > 10 %>
+              <span class='tip' title='<%= requirement %>'><%= truncate(requirement, length: 10) %></span>
+            <% else %>
+              <%= requirement %>
+            <% end %>
+          </th>
+          <td class="bar" style='height:<%= (percentage.round/@highest_percentage.to_f*max_height).round %>px; background-color: <%= colours[index] %>;'>
             <p>
-              <%= percentage.round(2) %>%
+              <a href='<%= url_for(params.permit(:name, :platform, :kind).merge(requirements: requirement)) %>' class='tip' title="<%= number_to_human(count) %> <%= "repo".pluralize(count) %> specifies this version">
+                <%= percentage.round(2) %>%
+              </a>
             </p>
           </td>
       </tr>
@@ -36,7 +44,7 @@
 
     <h4>
       <%= fa_icon 'link' %>
-      Filter by kind
+      Filter by requirement kind
     </h4>
     <ul class='filter'>
       <% @kinds.sort_by{|k,v| -v}.each do |kind, count| %>

--- a/app/views/project_usage/show.html.erb
+++ b/app/views/project_usage/show.html.erb
@@ -1,7 +1,7 @@
 <h1>Usage stats for <%= link_to @project, project_path(@project.to_param) %></h1>
 
 <table id="q-graph">
-    <caption>Required version breakdown across <%= number_to_human(@total) %> Dependent Repositories</caption>
+    <caption>Required version breakdown across <%= number_to_human(@total) %> open source repositories</caption>
     <tbody>
     <% max_height = 400 %>
     <% @counts.each_with_index do |(requirement, count), index| %>

--- a/app/views/project_usage/show.html.erb
+++ b/app/views/project_usage/show.html.erb
@@ -1,83 +1,87 @@
 <h1>Usage stats for <%= link_to @project, project_path(@project.to_param) %></h1>
 
-<table id="q-graph">
-    <caption>Required version breakdown across <%= number_to_human(@total) %> open source repositories</caption>
-    <tbody>
-    <% max_height = 400 %>
-    <% @counts.each_with_index do |(requirement, count), index| %>
-      <% percentage = count.to_f/@total*100 %>
+<% if @all_counts.any? %>
+  <table id="q-graph">
+      <caption>Required version breakdown across <%= number_to_human(@total) %> open source repositories</caption>
+      <tbody>
+      <% max_height = 400 %>
+      <% @counts.each_with_index do |(requirement, count), index| %>
+        <% percentage = count.to_f/@total*100 %>
 
-      <tr class="qtr" style='left:<%= index*60 %>px; <% if index == @counts.length - 1 %>border-right:none;<% end %>'>
-          <th scope="row">
-            <% if requirement.length > 10 %>
-              <span class='tip' title='<%= requirement %>'><%= truncate(requirement, length: 10) %></span>
+        <tr class="qtr" style='left:<%= index*60 %>px; <% if index == @counts.length - 1 %>border-right:none;<% end %>'>
+            <th scope="row">
+              <% if requirement.length > 10 %>
+                <span class='tip' title='<%= requirement %>'><%= truncate(requirement, length: 10) %></span>
+              <% else %>
+                <%= requirement %>
+              <% end %>
+            </th>
+            <td class="bar" style='height:<%= (percentage.round/@highest_percentage.to_f*max_height).round %>px; background-color: <%= colours[index] %>;'>
+              <p>
+                <a href='<%= url_for(params.permit(:name, :platform, :kind).merge(requirements: requirement)) %>' class='tip' title="<%= number_to_human(count) %> <%= "repo".pluralize(count) %> specifies this version">
+                  <%= percentage.round(2) %>%
+                </a>
+              </p>
+            </td>
+        </tr>
+      <% end %>
+      </tbody>
+  </table>
+  <hr>
+  <div class="row">
+    <div class="col-sm-8">
+      <h4>
+        GitHub Repositories that depend on <%= link_to @project, project_path(@project.to_param) %>
+        <% if params[:requirements].present? %>
+          <code><%= params[:requirements] %></code>
+        <% end %>
+      </h4>
+
+      <%= render @repos, cache: true %>
+      <%= will_paginate @repos, page_links: false %>
+    </div>
+    <div class="col-sm-4">
+      <%= render 'adsense/banner' %>
+
+      <h4>
+        <%= fa_icon 'link' %>
+        Filter by requirement kind
+      </h4>
+      <ul class='filter'>
+        <% @kinds.sort_by{|k,v| -v}.each do |kind, count| %>
+          <% next unless kind.present? %>
+          <% active = kind == params[:kind] %>
+          <li class='<%= 'active' if active %>'>
+            <% if active %>
+              <%= link_to kind, url_for(params.permit(:name, :platform, :requirements).merge(kind: nil, page: nil)) %>
             <% else %>
-              <%= requirement %>
+              <%= link_to kind, url_for(params.permit(:name, :platform, :requirements).merge(kind: kind)) %>
+              <small><%= number_to_human(count) %></small>
             <% end %>
-          </th>
-          <td class="bar" style='height:<%= (percentage.round/@highest_percentage.to_f*max_height).round %>px; background-color: <%= colours[index] %>;'>
-            <p>
-              <a href='<%= url_for(params.permit(:name, :platform, :kind).merge(requirements: requirement)) %>' class='tip' title="<%= number_to_human(count) %> <%= "repo".pluralize(count) %> specifies this version">
-                <%= percentage.round(2) %>%
-              </a>
-            </p>
-          </td>
-      </tr>
-    <% end %>
-    </tbody>
-</table>
-<hr>
-<div class="row">
-  <div class="col-sm-8">
-    <h4>
-      GitHub Repositories that depend on <%= link_to @project, project_path(@project.to_param) %>
-      <% if params[:requirements].present? %>
-        <code><%= params[:requirements] %></code>
-      <% end %>
-    </h4>
+          </li>
+        <% end %>
+      </ul>
 
-    <%= render @repos, cache: true %>
-    <%= will_paginate @repos, page_links: false %>
+      <h4>
+        <%= fa_icon 'arrows-h' %>
+        Filter by required version range
+      </h4>
+      <ul class='filter'>
+        <% @all_counts.sort_by{|k,v| -v}.first(40).sort_by{|k,v| k.gsub(/\~|\>|\<|\^|\=|\*|\s/,'').split('.').map{|v| v.to_i} }.each do |requirements,count| %>
+          <% next unless requirements.present? %>
+          <% active = requirements == params[:requirements] %>
+          <li class='<%= 'active' if active %>'>
+            <% if active %>
+              <%= link_to requirements, url_for(params.permit(:name, :platform, :kind).merge(requirements: nil, page: nil)) %>
+            <% else %>
+              <%= link_to requirements, url_for(params.permit(:name, :platform, :kind).merge(requirements: requirements)) %>
+              <small><%= number_to_human(count) %></small>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
   </div>
-  <div class="col-sm-4">
-    <%= render 'adsense/banner' %>
-
-    <h4>
-      <%= fa_icon 'link' %>
-      Filter by requirement kind
-    </h4>
-    <ul class='filter'>
-      <% @kinds.sort_by{|k,v| -v}.each do |kind, count| %>
-        <% next unless kind.present? %>
-        <% active = kind == params[:kind] %>
-        <li class='<%= 'active' if active %>'>
-          <% if active %>
-            <%= link_to kind, url_for(params.permit(:name, :platform, :requirements).merge(kind: nil, page: nil)) %>
-          <% else %>
-            <%= link_to kind, url_for(params.permit(:name, :platform, :requirements).merge(kind: kind)) %>
-            <small><%= number_to_human(count) %></small>
-          <% end %>
-        </li>
-      <% end %>
-    </ul>
-
-    <h4>
-      <%= fa_icon 'arrows-h' %>
-      Filter by required version range
-    </h4>
-    <ul class='filter'>
-      <% @all_counts.sort_by{|k,v| -v}.first(40).sort_by{|k,v| k.gsub(/\~|\>|\<|\^|\=|\*|\s/,'').split('.').map{|v| v.to_i} }.each do |requirements,count| %>
-        <% next unless requirements.present? %>
-        <% active = requirements == params[:requirements] %>
-        <li class='<%= 'active' if active %>'>
-          <% if active %>
-            <%= link_to requirements, url_for(params.permit(:name, :platform, :kind).merge(requirements: nil, page: nil)) %>
-          <% else %>
-            <%= link_to requirements, url_for(params.permit(:name, :platform, :kind).merge(requirements: requirements)) %>
-            <small><%= number_to_human(count) %></small>
-          <% end %>
-        </li>
-      <% end %>
-    </ul>
-  </div>
-</div>
+<% else %>
+  No dependent repositories found.
+<% end %>

--- a/app/views/project_usage/show.html.erb
+++ b/app/views/project_usage/show.html.erb
@@ -21,7 +21,12 @@
 <hr>
 <div class="row">
   <div class="col-sm-8">
-    <h4>GitHub Repositories that depend on <%= link_to @project, project_path(@project.to_param) %> <code><%= params[:requirements] %></code></h4>
+    <h4>
+      GitHub Repositories that depend on <%= link_to @project, project_path(@project.to_param) %>
+      <% if params[:requirements].present? %>
+        <code><%= params[:requirements] %></code>
+      <% end %>
+    </h4>
 
     <%= render @repos, cache: true %>
     <%= will_paginate @repos, page_links: false %>

--- a/app/views/project_usage/show.html.erb
+++ b/app/views/project_usage/show.html.erb
@@ -1,32 +1,34 @@
 <h1>Usage stats for <%= link_to @project, project_path(@project.to_param) %></h1>
 
 <% if @all_counts.any? %>
-  <table id="q-graph">
-      <caption>Required version breakdown across <%= number_to_human(@total) %> open source repositories</caption>
-      <tbody>
-      <% max_height = 400 %>
-      <% @counts.each_with_index do |(requirement, count), index| %>
-        <% percentage = count.to_f/@total*100 %>
+  <% cache ['usage', @project.id], expires_in: usage_cache_length(@total).week, race_condition_ttl: 1.minute do %>
+    <table id="q-graph">
+        <caption>Required version breakdown across <%= number_to_human(@total) %> open source repositories</caption>
+        <tbody>
+        <% max_height = 400 %>
+        <% @counts.each_with_index do |(requirement, count), index| %>
+          <% percentage = count.to_f/@total*100 %>
 
-        <tr class="qtr" style='left:<%= index*60 %>px; <% if index == @counts.length - 1 %>border-right:none;<% end %>'>
-            <th scope="row">
-              <% if requirement.length > 10 %>
-                <span class='tip' title='<%= requirement %>'><%= truncate(requirement, length: 10) %></span>
-              <% else %>
-                <%= requirement %>
-              <% end %>
-            </th>
-            <td class="bar" style='height:<%= (percentage.round/@highest_percentage.to_f*max_height).round %>px; background-color: <%= colours[index] %>;'>
-              <p>
-                <a href='<%= url_for(params.permit(:name, :platform, :kind).merge(requirements: requirement)) %>' class='tip' title="<%= number_to_human(count) %> <%= "repo".pluralize(count) %> specifies this version">
-                  <%= percentage.round(2) %>%
-                </a>
-              </p>
-            </td>
-        </tr>
-      <% end %>
-      </tbody>
-  </table>
+          <tr class="qtr" style='left:<%= index*60 %>px; <% if index == @counts.length - 1 %>border-right:none;<% end %>'>
+              <th scope="row">
+                <% if requirement.length > 10 %>
+                  <span class='tip' title='<%= requirement %>'><%= truncate(requirement, length: 10) %></span>
+                <% else %>
+                  <%= requirement %>
+                <% end %>
+              </th>
+              <td class="bar" style='height:<%= (percentage.round/@highest_percentage.to_f*max_height).round %>px; background-color: <%= colours[index] %>;'>
+                <p>
+                  <a href='<%= url_for(params.permit(:name, :platform).merge(requirements: requirement)) %>' class='tip' title="<%= number_to_human(count) %> <%= "repo".pluralize(count) %> specifies this version">
+                    <%= percentage.round(2) %>%
+                  </a>
+                </p>
+              </td>
+          </tr>
+        <% end %>
+        </tbody>
+    </table>
+  <% end %>
   <hr>
   <div class="row">
     <div class="col-sm-8">

--- a/app/views/project_usage/show.html.erb
+++ b/app/views/project_usage/show.html.erb
@@ -1,0 +1,13 @@
+<h1>Usage stats for <%= link_to @project, project_path(@project.to_param) %></h1>
+<dl>
+  <dt>
+    Required version breakdown across <%= @total %> Dependent Repositories
+  </dt>
+  <% @counts.sort_by{|k,v| k}.each do |requirement, count| %>
+    <% percentage = count.to_f/@total*100 %>
+    <% next if percentage < 1 %>
+    <li>
+      <dd class="percentage percentage-<%= (percentage.round/@highest_percentage.to_f*100).round %>"><span class="text"><%= requirement %>: <%= percentage.round(2) %>%</span></dd>
+    </li>
+  <% end %>
+</dl>

--- a/app/views/project_usage/show.html.erb
+++ b/app/views/project_usage/show.html.erb
@@ -1,13 +1,70 @@
 <h1>Usage stats for <%= link_to @project, project_path(@project.to_param) %></h1>
-<dl>
-  <dt>
-    Required version breakdown across <%= @total %> Dependent Repositories
-  </dt>
-  <% @counts.sort_by{|k,v| k}.each do |requirement, count| %>
-    <% percentage = count.to_f/@total*100 %>
-    <% next if percentage < 1 %>
-    <li>
-      <dd class="percentage percentage-<%= (percentage.round/@highest_percentage.to_f*100).round %>"><span class="text"><%= requirement %>: <%= percentage.round(2) %>%</span></dd>
-    </li>
-  <% end %>
-</dl>
+
+<table id="q-graph">
+    <caption>Required version breakdown across <%= number_to_human(@total) %> Dependent Repositories</caption>
+    <tbody>
+    <% max_height = 400 %>
+    <% @counts.each_with_index do |(requirement, count), index| %>
+      <% percentage = count.to_f/@total*100 %>
+
+      <tr class="qtr" style='left:<%= index*60 %>px; <% if index == @counts.length - 1 %>border-right:none;<% end %>'>
+          <th scope="row"><%= requirement %></th>
+          <td class="sent bar" style='height:<%= (percentage.round/@highest_percentage.to_f*max_height).round %>px; background-color: <%= colours[index] %>;'>
+            <p>
+              <%= percentage.round(2) %>%
+            </p>
+          </td>
+      </tr>
+    <% end %>
+    </tbody>
+</table>
+<hr>
+<div class="row">
+  <div class="col-sm-8">
+    <h4>GitHub Repositories that depend on <%= link_to @project, project_path(@project.to_param) %> <code><%= params[:requirements] %></code></h4>
+
+    <%= render @repos, cache: true %>
+    <%= will_paginate @repos, page_links: false %>
+  </div>
+  <div class="col-sm-4">
+    <%= render 'adsense/banner' %>
+
+    <h4>
+      <%= fa_icon 'link' %>
+      Filter by kind
+    </h4>
+    <ul class='filter'>
+      <% @kinds.sort_by{|k,v| -v}.each do |kind, count| %>
+        <% next unless kind.present? %>
+        <% active = kind == params[:kind] %>
+        <li class='<%= 'active' if active %>'>
+          <% if active %>
+            <%= link_to kind, url_for(params.permit(:name, :platform, :requirements).merge(kind: nil, page: nil)) %>
+          <% else %>
+            <%= link_to kind, url_for(params.permit(:name, :platform, :requirements).merge(kind: kind)) %>
+            <small><%= number_to_human(count) %></small>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+
+    <h4>
+      <%= fa_icon 'arrows-h' %>
+      Filter by required version range
+    </h4>
+    <ul class='filter'>
+      <% @all_counts.sort_by{|k,v| -v}.first(40).sort_by{|k,v| k.gsub(/\~|\>|\<|\^|\=|\*|\s/,'').split('.').map{|v| v.to_i} }.each do |requirements,count| %>
+        <% next unless requirements.present? %>
+        <% active = requirements == params[:requirements] %>
+        <li class='<%= 'active' if active %>'>
+          <% if active %>
+            <%= link_to requirements, url_for(params.permit(:name, :platform, :kind).merge(requirements: nil, page: nil)) %>
+          <% else %>
+            <%= link_to requirements, url_for(params.permit(:name, :platform, :kind).merge(requirements: requirements)) %>
+            <small><%= number_to_human(count) %></small>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -184,6 +184,7 @@ Rails.application.routes.draw do
   post '/:platform/:name/suggestions', to: 'project_suggestions#create', constraints: { :name => /.*/ }
 
   # project routes
+  get '/:platform/:name/usage', to: 'project_usage#show', as: :project_usage, constraints: { :name => /.*/ }, :defaults => { :format => 'html' }
   post '/:platform/:name/mute', to: 'projects#mute', as: :mute_project, constraints: { :name => /.*/ }
   delete '/:platform/:name/unmute', to: 'projects#unmute', as: :unmute_project, constraints: { :name => /.*/ }
   get '/:platform/:name/tree', to: 'tree#show', constraints: { :name => /[\w\.\-\%]+/ }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1060/20575173/10314750-b1b0-11e6-872e-7ddf98ddfca1.png)

To do after shipping:

- [ ] Link from project page
- [ ] Async caching for very popular projects, similar to https://github.com/librariesio/libraries.io/pull/908
- [ ] Mobile friendly graphs
- [ ] Pie chart for `kind`?
- [ ] Disable pagination for really popular libraries?