### PR TITLE
Allow all h1/.h1 elements to wrap mid-word

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -388,3 +388,7 @@ tr.top td{
 .header{
   margin-bottom: 25px;
 }
+
+h1, .h1 {
+  word-wrap: break-word;
+}


### PR DESCRIPTION
Fixes https://github.com/librariesio/support/issues/123. Probably. I committed this with toast in one hand.