### PR TITLE
Only show usage stats for non-forked repos

### DIFF
--- a/app/controllers/project_usage_controller.rb
+++ b/app/controllers/project_usage_controller.rb
@@ -1,13 +1,13 @@
 class ProjectUsageController < ApplicationController
   before_action :find_project
   def show
-    @all_counts = @project.repository_dependencies.joins(:manifest).distinct('manifests.github_repository_id').group('repository_dependencies.requirements').count
+    @all_counts = @project.repository_dependencies.where('github_repositories.fork = ?', false).joins(manifest: :github_repository).distinct('manifests.github_repository_id').group('repository_dependencies.requirements').count
     @total = @all_counts.sum{|k,v| v }
     if @all_counts.any?
-      @kinds = @project.repository_dependencies.joins(:manifest).distinct('manifests.github_repository_id').group('repository_dependencies.kind').count
+      @kinds = @project.repository_dependencies.where('github_repositories.fork = ?', false).joins(manifest: :github_repository).distinct('manifests.github_repository_id').group('repository_dependencies.kind').count
       @counts = sort_by_semver_range(18)
       @highest_percentage = @counts.map{|_k,v| v.to_f/@total*100 }.max
-      scope = @project.dependent_repositories.open_source
+      scope = @project.dependent_repositories.open_source.source
       scope = scope.where("repository_dependencies.requirements = ?", params[:requirements]) if params[:requirements].present?
       scope = scope.where("repository_dependencies.kind = ?", params[:kind]) if params[:kind].present?
       @repos = scope.paginate(page: page_number, per_page: 20)


### PR DESCRIPTION
Forks may be skewing the numbers slightly, only showing non-forked repo usage data until we have a reliable way of determining if a fork is being used or just github mess left behind after a pull request.

Related to #934