### PR TITLE
Drop unused user fields, fixes #1040

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -35,7 +35,7 @@ class SessionsController < ApplicationController
       end
     else
       if identity.user.nil?
-        user = identity.find_existing_user || User.new
+        user = User.new
         user.assign_from_auth_hash(auth)
         identity.user = user
         identity.save

--- a/app/models/concerns/github_identity.rb
+++ b/app/models/concerns/github_identity.rb
@@ -3,6 +3,11 @@ module GithubIdentity
     token
   end
 
+  def github_user
+    return unless github_enabled?
+    GithubUser.find_by_id(github_identity.uid)
+  end
+
   def hidden
     github_user.try(:hidden)
   end

--- a/app/models/concerns/github_identity.rb
+++ b/app/models/concerns/github_identity.rb
@@ -87,16 +87,12 @@ module GithubIdentity
     private_repo_token.presence || public_repo_token.presence || github_token
   end
 
-  def uid
-    github_identity.try(:uid).presence || read_attribute(:uid)
-  end
-
   def public_repo_token
-    github_public_identity.try(:token).presence || read_attribute(:public_repo_token)
+    github_public_identity.try(:token)
   end
 
   def github_token
-    github_identity.try(:token).presence || read_attribute(:token)
+    github_identity.try(:token)
   end
 
   def github_identity
@@ -108,7 +104,7 @@ module GithubIdentity
   end
 
   def private_repo_token
-    github_private_identity.try(:token).presence || read_attribute(:private_repo_token)
+    github_private_identity.try(:token)
   end
 
   def github_private_identity
@@ -117,10 +113,6 @@ module GithubIdentity
 
   def github_client
     AuthToken.new_client(token)
-  end
-
-  def github_avatar_url(size = 60)
-    "https://avatars.githubusercontent.com/u/#{uid}?size=#{size}"
   end
 
   def github_url

--- a/app/models/github_repository.rb
+++ b/app/models/github_repository.rb
@@ -361,7 +361,7 @@ class GithubRepository < ApplicationRecord
 
   def self.update_from_hook(github_id, sender_id)
     github_repository = GithubRepository.find_by_github_id(github_id)
-    user = User.find_by_uid(sender_id)
+    user = Identity.where('provider ILIKE ?', 'github%').where(uid: sender_id).first.try(:user)
     if user.present? && github_repository.present?
       github_repository.download_manifests(user.token)
       github_repository.update_all_info_async(user.token)

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -10,18 +10,13 @@ class Identity < ApplicationRecord
     create(uid: auth['uid'], provider: auth['provider'])
   end
 
-  def find_existing_user
-    return nil unless provider =~ /github/
-    User.find_by_uid(uid)
-  end
-
   def update_from_auth_hash(auth_hash)
     self.token = auth_hash.fetch('credentials', {}).fetch('token')
 
     case auth_hash['provider']
     when 'github'
       self.nickname   = auth_hash.fetch('info', {}).fetch('nickname')
-      self.avatar_url = "https://avatars1.githubusercontent.com/u/#{self.uid}?v=3"
+      self.avatar_url = "https://avatars1.githubusercontent.com/u/#{self.uid}"
     when 'gitlab'
       self.nickname   = auth_hash.fetch('info', {}).fetch('username')
       self.avatar_url = auth_hash.fetch('info', {}).fetch('image')

--- a/app/models/recommendable.rb
+++ b/app/models/recommendable.rb
@@ -51,7 +51,7 @@ module Recommendable
   def favourite_languages(limit = 3)
     @favourite_languages ||= begin
       # your github Repositories
-      languages = github_repositories.pluck(:language).compact
+      languages = all_github_repositories.pluck(:language).compact
 
       # repositories you've contributed to
       languages += github_user.contributed_repositories.pluck(:language).compact if github_user.present?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,12 +47,16 @@ class User < ApplicationRecord
     update_attributes({email: hash.fetch('info', {}).fetch('email', nil)})
   end
 
+  def uid
+    identities.first.uid
+  end
+
   def avatar_url(size = 60)
-    identities.first.try(:avatar_url, size) || github_avatar_url(size)
+    identities.first.try(:avatar_url, size)
   end
 
   def nickname
-    identities.first.try(:nickname).presence || read_attribute(:nickname)
+    identities.first.try(:nickname).presence
   end
 
   def all_subscribed_projects
@@ -60,11 +64,7 @@ class User < ApplicationRecord
   end
 
   def to_s
-    full_name
-  end
-
-  def full_name
-    name.presence || nickname
+    nickname
   end
 
   def all_subscribed_project_ids

--- a/app/views/admin/project_suggestions/_project_suggestion.html.erb
+++ b/app/views/admin/project_suggestions/_project_suggestion.html.erb
@@ -3,7 +3,7 @@
   <%= link_to project_suggestion.project, project_path(project_suggestion.project.to_param) %>
   <% if project_suggestion.user %>
     <small>
-      By <%= link_to project_suggestion.user, user_path(project_suggestion.user.nickname) %>
+      By <%= link_to project_suggestion.user, mail_to(project_suggestion.user.email) %>
       <%= timeago_tag project_suggestion.created_at %>
     </small>
   <% end %>

--- a/app/views/admin/stats/index.html.erb
+++ b/app/views/admin/stats/index.html.erb
@@ -8,7 +8,7 @@
   <div class="col-md-12">
     <h5><strong>Recent Signups</strong></h5>
     <% @recent_users.each do |user| %>
-      <%= link_to image_tag(user.avatar_url(120), width: 60, height: 60, alt: user, class: 'pull-left'), user_path(user.nickname), class: 'tip', style: 'display:block; float:left;', title: "#{user.nickname}: #{pluralize(user.subscriptions.count, 'subs')}, #{pluralize(user.github_repositories.count, 'repo')}, #{pluralize(user.repository_subscriptions.count, 'track')}" %>
+      <%= image_tag(user.avatar_url(120), width: 60, height: 60, alt: user, class: 'pull-left') %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/stats/index.html.erb
+++ b/app/views/admin/stats/index.html.erb
@@ -18,7 +18,7 @@
     <% @recent_subscriptions.each do |sub| %>
       <div style='min-height:30px;'>
         <% if sub.user %>
-        <%= link_to image_tag(sub.user.avatar_url(40), width: 20, height: 20, alt: sub.user, class: 'pull-left'), user_path(sub.user.nickname), class: 'tip', style: 'display:block; float:left; margin-right:5px;', title: "#{sub.user.nickname}: #{pluralize(sub.user.subscriptions.count, 'subs')}, #{pluralize(sub.user.github_repositories.count, 'repo')}, #{pluralize(sub.user.repository_subscriptions.count, 'track')}" %>
+        <%= link_to image_tag(sub.user.avatar_url(40), width: 20, height: 20, alt: sub.user, class: 'pull-left'), user_path(sub.user.nickname), class: 'tip', style: 'display:block; float:left; margin-right:5px;', title: "#{sub.user.nickname}: #{pluralize(sub.user.subscriptions.count, 'subs')}, #{pluralize(sub.user.all_github_repositories.count, 'repo')}, #{pluralize(sub.user.repository_subscriptions.count, 'track')}" %>
          <%= link_to sub.user, user_path(sub.user.nickname) %>
         <% else %>Deleted<% end %>
         subscribed to <%= link_to sub.project, project_path(sub.project.to_param) %>
@@ -34,7 +34,7 @@
     <% @recent_watches.each do |sub| %>
       <div style='min-height:30px;'>
         <% if sub.user %>
-        <%= link_to image_tag(sub.user.avatar_url(40), width: 20, height: 20, alt: sub.user, class: 'pull-left'), user_path(sub.user.nickname), class: 'tip', style: 'display:block; float:left; margin-right:5px;', title: "#{sub.user.nickname}: #{pluralize(sub.user.subscriptions.count, 'subs')}, #{pluralize(sub.user.github_repositories.count, 'repo')}, #{pluralize(sub.user.repository_subscriptions.count, 'track')}" %>
+        <%= link_to image_tag(sub.user.avatar_url(40), width: 20, height: 20, alt: sub.user, class: 'pull-left'), user_path(sub.user.nickname), class: 'tip', style: 'display:block; float:left; margin-right:5px;', title: "#{sub.user.nickname}: #{pluralize(sub.user.subscriptions.count, 'subs')}, #{pluralize(sub.user.all_github_repositories.count, 'repo')}, #{pluralize(sub.user.repository_subscriptions.count, 'track')}" %>
          <%= link_to sub.user, user_path(sub.user.nickname) %>
         <% else %>Deleted<% end %>
         watched

--- a/app/views/dashboard/home.html.erb
+++ b/app/views/dashboard/home.html.erb
@@ -28,7 +28,7 @@
         </small>
       </p>
     <% else %>
-      <h2>Hi there <%= current_user.full_name %>!</h2>
+      <h2>Hi there <%= current_user %>!</h2>
       <p>
         Libraries.io lets you watch libraries that you depend on and notifies you when there's a new release.
         When you follow a library, new releases will show up here in your newsfeed.

--- a/db/migrate/20170105065900_drop_old_user_fields.rb
+++ b/db/migrate/20170105065900_drop_old_user_fields.rb
@@ -1,0 +1,10 @@
+class DropOldUserFields < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :users, :uid
+    remove_column :users, :nickname
+    remove_column :users, :token
+    remove_column :users, :name
+    remove_column :users, :public_repo_token
+    remove_column :users, :private_repo_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170104223028) do
+ActiveRecord::Schema.define(version: 20170105065900) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -416,18 +416,12 @@ ActiveRecord::Schema.define(version: 20170104223028) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "uid"
-    t.string   "nickname"
-    t.string   "token"
-    t.string   "name"
     t.string   "email"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "public_repo_token"
-    t.string   "private_repo_token"
-    t.boolean  "currently_syncing",  default: false, null: false
+    t.boolean  "currently_syncing", default: false, null: false
     t.datetime "last_synced_at"
-    t.boolean  "emails_enabled",     default: true
+    t.boolean  "emails_enabled",    default: true
     t.index ["created_at"], name: "index_users_on_created_at", using: :btree
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -72,15 +72,16 @@ FactoryGirl.define do
   end
 
   factory :user do
-    sequence(:uid)
-    nickname { Faker::Name.name.parameterize }
     email
-    token { SecureRandom.hex }
-    public_repo_token { SecureRandom.hex }
+    after(:create) do |user, evaluator|
+      create(:identity, user: user)
+    end
   end
 
   factory :identity do
     user
+    sequence(:uid)
+    provider 'github'
     nickname { Faker::Name.name.parameterize }
     token { SecureRandom.hex }
     avatar_url { "http://github.com/#{Faker::Name.name.parameterize}.png" }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,7 +10,6 @@ describe User, type: :model do
   it { should have_many(:adminable_repository_permissions) }
   it { should have_many(:adminable_github_repositories) }
   it { should have_many(:adminable_github_orgs) }
-  it { should have_many(:github_repositories) }
   it { should have_many(:source_github_repositories) }
   it { should have_many(:watched_github_repositories) }
   it { should have_many(:watched_dependencies) }
@@ -24,8 +23,6 @@ describe User, type: :model do
   it { should have_many(:muted_projects) }
   it { should have_many(:payola_subscriptions) }
   it { should have_many(:project_suggestions) }
-
-  it { should have_one(:github_user) }
 
   it { should validate_presence_of(:email).on(:update) }
 end

--- a/spec/support/login_helpers.rb
+++ b/spec/support/login_helpers.rb
@@ -6,13 +6,13 @@ module LoginHelpers
   def mock_github_auth(user)
     OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(
       provider:    'github',
-      uid:         user.uid,
+      uid:         user.github_identity.uid,
       info:        {
-        nickname: user.nickname,
+        nickname: user.github_identity.nickname,
         email:    user.email
       },
       credentials: {
-        token: user.token
+        token: user.github_identity.token
       }
     )
   end


### PR DESCRIPTION
I've moved all oauth data into identities so we can drop a lot of fields from the User model, only thing left to do is hook up the owning of github repositories to a user:

```ruby
has_many :github_repositories, primary_key: :uid, foreign_key: :owner_id
has_one :github_user, primary_key: :uid, foreign_key: :github_id
```