### PR TITLE
Allow users to connect multiple accounts from settings page

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,7 +2,10 @@ class SessionsController < ApplicationController
   skip_before_action :verify_authenticity_token, only: [:create, :failure]
 
   def new
-
+    if !params[:source].nil?
+      session[:pre_login_destination] = '/account'
+      redirect_to "/auth/" + params[:source]
+    end
   end
 
   def enable_public
@@ -46,9 +49,10 @@ class SessionsController < ApplicationController
     end
 
     identity.user.update_repo_permissions_async
+    login_destination = pre_login_destination
 
-    redirect_to(root_path) && return unless pre_login_destination
-    redirect_to pre_login_destination
+    redirect_to(root_path) && return unless login_destination
+    redirect_to login_destination
   end
 
   def destroy
@@ -63,6 +67,8 @@ class SessionsController < ApplicationController
   private
 
   def pre_login_destination
-    session[:pre_login_destination]
+    destination = session[:pre_login_destination]
+    session.delete :pre_login_destination
+    return destination
   end
 end

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -38,6 +38,29 @@
     </div>
 
     <div class="panel panel-default">
+      <div class="panel-heading">Connect Accounts</div>
+      <div class="panel-body">
+        <a class="btn btn-default" href="/auth/gitlab">
+          <%= fa_icon('gitlab') %> GitLab
+        </a>
+        <a class="btn btn-default" href="/auth/bitbucket">
+          <%= fa_icon('bitbucket') %> Bitbucket
+        </a>
+      </div>
+    </div>
+
+    <div class="panel panel-default">
+      <div class="panel-heading">Connected Accounts</div>
+      <div class="panel-body">
+        <% current_user.identities.each do |identity| %>
+          <button class="btn btn-default">
+            <%= fa_icon(identity.provider) %> <%= identity.nickname %>
+          </button>
+        <%end %>
+      </div>
+    </div>
+
+    <div class="panel panel-default">
       <div class="panel-heading">API Key</div>
       <div class="panel-body">
         <p>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -38,20 +38,15 @@
     </div>
 
     <div class="panel panel-default">
-      <div class="panel-heading">Connect Accounts</div>
+      <div class="panel-heading">Accounts</div>
       <div class="panel-body">
-        <a class="btn btn-default" href="/auth/gitlab">
-          <%= fa_icon('gitlab') %> GitLab
-        </a>
-        <a class="btn btn-default" href="/auth/bitbucket">
-          <%= fa_icon('bitbucket') %> Bitbucket
-        </a>
-      </div>
-    </div>
-
-    <div class="panel panel-default">
-      <div class="panel-heading">Connected Accounts</div>
-      <div class="panel-body">
+        <%= link_to login_path(:source => "gitlab"), class: 'btn btn-primary' do %>
+          <%= fa_icon('gitlab') %> Connect GitLab
+        <% end %>
+        <%= link_to login_path(:source => "bitbucket"), class: 'btn btn-primary' do %>
+          <%= fa_icon('bitbucket') %> Connect Bitbucket
+        <% end %>
+        <h4>Connected Accounts</h4>
         <% current_user.identities.each do |identity| %>
           <button class="btn btn-default">
             <%= fa_icon(identity.provider) %> <%= identity.nickname %>


### PR DESCRIPTION
**headlines**

1) Lets make it so users can connect multiple bitbucket and gitlab accounts to their user profile!
(also why not multiple github accounts too)

Fixes #1074

**TODO's**

- [x] Can we redirect from the OAuth2 flow back to the settings page for that user (currently when connecting it takes you to the home page)

- [x] Better styling of the connect and connected accounts (any ideas? I can ask the UX guy at work but I'm open to all suggestions!)

- [x] Be able to delete a connected account (do we want this feature, we dont for now)


**latest screenshot**

<img width="1009" alt="screen shot 2017-01-16 at 21 51 21" src="https://cloud.githubusercontent.com/assets/1868592/22000331/7c0ace82-dc36-11e6-8fc7-412a05a881dc.png">
