### PR TITLE
Index rank in repo and issue search

### DIFF
--- a/app/controllers/api/github_repositories_controller.rb
+++ b/app/controllers/api/github_repositories_controller.rb
@@ -38,6 +38,6 @@ class Api::GithubRepositoriesController < Api::ApplicationController
   end
 
   def allowed_sorts
-    ['stargazers_count', 'github_contributions_count', 'created_at', 'pushed_at', 'subscribers_count', 'open_issues_count', 'forks_count', 'size']
+    ['rank', 'stargazers_count', 'github_contributions_count', 'created_at', 'pushed_at', 'subscribers_count', 'open_issues_count', 'forks_count', 'size']
   end
 end

--- a/app/controllers/github_repositories_controller.rb
+++ b/app/controllers/github_repositories_controller.rb
@@ -103,7 +103,7 @@ class GithubRepositoriesController < ApplicationController
   end
 
   def allowed_sorts
-    ['stargazers_count', 'github_contributions_count', 'created_at', 'pushed_at', 'subscribers_count', 'open_issues_count', 'forks_count', 'size']
+    ['rank', 'stargazers_count', 'github_contributions_count', 'created_at', 'pushed_at', 'subscribers_count', 'open_issues_count', 'forks_count', 'size']
   end
 
   def page_title

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,6 +27,7 @@ module ApplicationHelper
   def repo_sort_options
     [
       ['Relevance', nil],
+      ['SourceRank', 'rank'],
       ['Stars', 'stargazers_count'],
       ['Forks', 'forks_count'],
       ['Watchers', 'subscribers_count'],

--- a/app/models/concerns/issue_search.rb
+++ b/app/models/concerns/issue_search.rb
@@ -17,6 +17,7 @@ module IssueSearch
         indexes :stars, type: 'integer'
         indexes :github_id, type: 'integer'
         indexes :contributions_count, type: 'integer'
+        indexes :rank, type: 'integer'
 
         indexes :language, :analyzer => 'keyword'
         indexes :license, :analyzer => 'keyword'
@@ -32,7 +33,7 @@ module IssueSearch
     after_commit lambda { __elasticsearch__.delete_document rescue nil },  on: :destroy
 
     def as_indexed_json(_options)
-      as_json methods: [:title, :contributions_count, :stars, :language, :license]
+      as_json methods: [:title, :contributions_count, :stars, :language, :license, :rank]
     end
 
     def exact_title
@@ -57,7 +58,7 @@ module IssueSearch
                  }
               }
             },
-            field_value_factor: { field: "stars", "modifier": "square" }
+            field_value_factor: { field: "rank", "modifier": "square" }
           }
         },
         facets: issues_facet_filters(options, options[:labels_to_keep]),
@@ -104,7 +105,7 @@ module IssueSearch
                  }
               }
             },
-            field_value_factor: { field: "stars", "modifier": "square" }
+            field_value_factor: { field: "rank", "modifier": "square" }
           }
         },
         facets: issues_facet_filters(options, GithubIssue::FIRST_PR_LABELS),
@@ -117,7 +118,7 @@ module IssueSearch
     end
 
     def self.default_sort
-      [{'comments_count' => 'asc'}, {'stars' => 'desc'}, {'created_at' => 'asc'}, {'contributions_count' => 'asc'}]
+      [{'comments_count' => 'asc'}, {'rank' => 'desc'}, {'created_at' => 'asc'}, {'contributions_count' => 'asc'}]
     end
 
     def self.issues_facet_filters(options, labels)

--- a/app/models/concerns/repo_search.rb
+++ b/app/models/concerns/repo_search.rb
@@ -42,6 +42,7 @@ module RepoSearch
         indexes :subscribers_count, type: 'integer'
         indexes :github_id, type: 'integer'
         indexes :github_contributions_count, type: 'integer'
+        indexes :rank, type: 'integer'
 
         indexes :fork
         indexes :has_issues
@@ -160,7 +161,7 @@ module RepoSearch
       if query.present?
         search_definition[:query][:function_score][:query][:filtered][:query] = Project.query_options(query, FIELDS)
       elsif options[:sort].blank?
-        search_definition[:sort]  = [{'stargazers_count' => 'desc'}]
+        search_definition[:sort]  = [{'rank' => 'desc'}, {'stargazers_count' => 'desc'}]
       end
 
       __elasticsearch__.search(search_definition)

--- a/app/models/github_issue.rb
+++ b/app/models/github_issue.rb
@@ -68,6 +68,10 @@ class GithubIssue < ApplicationRecord
     github_repository.try(:stargazers_count) || 0
   end
 
+  def rank
+    github_repository.try(:rank) || 0
+  end
+
   def self.update_from_github(name_with_owner, issue_number, token = nil)
     token ||= AuthToken.token
     repo = GithubRepository.create_from_github(name_with_owner, token)


### PR DESCRIPTION
Fixes #1022
Fixes #1021

Don't merged until the majority of popular GitHub repos have had a rank calculated for them

These two rake commands need to be ran once this is merged and deployed:

    rake github:reindex_issues
    rake github:reindex_repos