### PR TITLE
Move GitHub specific constant + methods to `GithubRepository`

### DIFF
--- a/app/models/concerns/github_identity.rb
+++ b/app/models/concerns/github_identity.rb
@@ -67,7 +67,7 @@ module GithubIdentity
     remove_ids = existing_repo_ids - current_repo_ids
     repository_permissions.where(repository_id: remove_ids).delete_all if remove_ids.any?
 
-  rescue *Repository::IGNORABLE_GITHUB_EXCEPTIONS
+  rescue *GithubRepository::IGNORABLE_GITHUB_EXCEPTIONS
     nil
   ensure
     self.update_columns(last_synced_at: Time.now, currently_syncing: false)
@@ -84,7 +84,7 @@ module GithubIdentity
     github_client.orgs.each do |org|
       GithubCreateOrgWorker.perform_async(org.login)
     end
-  rescue *Repository::IGNORABLE_GITHUB_EXCEPTIONS
+  rescue *GithubRepository::IGNORABLE_GITHUB_EXCEPTIONS
     nil
   end
 

--- a/app/models/github_organisation.rb
+++ b/app/models/github_organisation.rb
@@ -84,7 +84,7 @@ class GithubOrganisation < ApplicationRecord
       org.assign_attributes r.slice(*GithubOrganisation::API_FIELDS)
       org.save
       org
-    rescue *Repository::IGNORABLE_GITHUB_EXCEPTIONS
+    rescue *GithubRepository::IGNORABLE_GITHUB_EXCEPTIONS
       false
     end
   end
@@ -109,7 +109,7 @@ class GithubOrganisation < ApplicationRecord
 
   def download_from_github_by(id_or_login)
     GithubOrganisation.create_from_github(github_client.org(id_or_login))
-  rescue *Repository::IGNORABLE_GITHUB_EXCEPTIONS
+  rescue *GithubRepository::IGNORABLE_GITHUB_EXCEPTIONS
     nil
   end
 
@@ -117,7 +117,7 @@ class GithubOrganisation < ApplicationRecord
     github_client.org_repos(login).each do |repo|
       CreateRepositoryWorker.perform_async('GitHub', repo.full_name)
     end
-  rescue *Repository::IGNORABLE_GITHUB_EXCEPTIONS
+  rescue *GithubRepository::IGNORABLE_GITHUB_EXCEPTIONS
     nil
   end
 end

--- a/app/models/github_user.rb
+++ b/app/models/github_user.rb
@@ -65,7 +65,7 @@ class GithubUser < ApplicationRecord
 
   def download_from_github_by(id_or_login)
     GithubUser.create_from_github(github_client.user(id_or_login))
-  rescue *Repository::IGNORABLE_GITHUB_EXCEPTIONS
+  rescue *GithubRepository::IGNORABLE_GITHUB_EXCEPTIONS
     nil
   end
 
@@ -74,7 +74,7 @@ class GithubUser < ApplicationRecord
       GithubCreateOrgWorker.perform_async(org.login)
     end
     true
-  rescue *Repository::IGNORABLE_GITHUB_EXCEPTIONS
+  rescue *GithubRepository::IGNORABLE_GITHUB_EXCEPTIONS
     nil
   end
 
@@ -84,7 +84,7 @@ class GithubUser < ApplicationRecord
     end
 
     true
-  rescue *Repository::IGNORABLE_GITHUB_EXCEPTIONS
+  rescue *GithubRepository::IGNORABLE_GITHUB_EXCEPTIONS
     nil
   end
 

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -9,8 +9,6 @@ class Repository < ApplicationRecord
   include GitlabRepository
   include BitbucketRepository
 
-  IGNORABLE_GITHUB_EXCEPTIONS = [Octokit::Unauthorized, Octokit::InvalidRepository, Octokit::RepositoryUnavailable, Octokit::NotFound, Octokit::Conflict, Octokit::Forbidden, Octokit::InternalServerError, Octokit::BadGateway, Octokit::ClientError]
-
   STATUSES = ['Active', 'Deprecated', 'Unmaintained', 'Help Wanted', 'Removed']
 
   API_FIELDS = [:full_name, :description, :fork, :created_at, :updated_at, :pushed_at, :homepage,
@@ -300,30 +298,25 @@ class Repository < ApplicationRecord
   end
 
   def create_webhook(token)
-    github_client(token).create_hook(
-      full_name,
-      'web',
-      {
-        :url => 'https://libraries.io/hooks/github',
-        :content_type => 'json'
-      },
-      {
-        :events => ['push', 'pull_request'],
-        :active => true
-      }
-    )
-  rescue Octokit::UnprocessableEntity
-    nil
+    case host_type
+    when 'GitHub'
+      send("#{host_type.downcase}_create_webhook", token)
+    when 'GitLab'
+      # not implemented yet
+    when 'Bitbucket'
+      # not implemented yet
+    end
   end
 
   def download_issues(token = nil)
-    github_client = AuthToken.new_client(token)
-    issues = github_client.issues(full_name, state: 'all')
-    issues.each do |issue|
-      Issue.create_from_hash(self, issue)
+    case host_type
+    when 'GitHub'
+      send("download_#{host_type.downcase}_issues", token)
+    when 'GitLab'
+      # not implemented yet
+    when 'Bitbucket'
+      # not implemented yet
     end
-  rescue *IGNORABLE_GITHUB_EXCEPTIONS
-    nil
   end
 
   def self.create_from_host(host_type, full_name, token = nil)


### PR DESCRIPTION
GitHub specific methods + constant belong in `GithubRepository`, not `Repository`.