### PR TITLE
Add gascrolldown fork

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -34,7 +34,10 @@ document.addEventListener('turbolinks:load', function(){
     userTiming: false,
     percentage: false,
     pixelDepth: false,
-    nonInteraction: false
+    nonInteraction: false, 
+    eventHandler: function(data) {
+      console.log(data);
+    }
   });
 
 })

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -28,6 +28,18 @@
 document.addEventListener('turbolinks:load', function(){
   $('.tip').tooltip({placement: 'bottom'})
   stickFooter()
+  
+  gascrolldepth.init({         
+    elements: $('body').data('ga_scroll_ids').split(','),
+    userTiming: false,
+    percentage: false,
+    pixelDepth: false,
+    nonInteraction: false, 
+    eventHandler: function(data) {
+      console.log(data);
+    }
+  });
+
 })
 
 $('.rss').on('click', function(){

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -28,8 +28,8 @@
 document.addEventListener('turbolinks:load', function(){
   $('.tip').tooltip({placement: 'bottom'})
   stickFooter()
-  
-  gascrolldepth.init({         
+
+  gascrolldepth.init({
     elements: $('body').data('ga_scroll_ids').split(','),
     userTiming: false,
     percentage: false,

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -34,10 +34,7 @@ document.addEventListener('turbolinks:load', function(){
     userTiming: false,
     percentage: false,
     pixelDepth: false,
-    nonInteraction: false, 
-    eventHandler: function(data) {
-      console.log(data);
-    }
+    nonInteraction: false
   });
 
 })

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,6 +21,7 @@
 //= require bootstrap/tooltip
 //= require js.cookie
 //= require rails-timeago
+//= require gascrolldepth
 //= require subtome
 //= require turbolinks
 

--- a/app/assets/javascripts/gascrolldepth.js
+++ b/app/assets/javascripts/gascrolldepth.js
@@ -1,0 +1,457 @@
+/*!
+ * @preserve
+ * gascrolldepth.js | v0.9
+ * Copyright (c) 2015 Rob Flaherty (@robflaherty), Leigh McCulloch (@___leigh___)
+ * Licensed under the MIT and GPL licenses.
+ */
+;(function ( window, document, undefined ) {
+
+  "use strict";
+
+  /*
+   * Extend a series of objects with the properties of each.
+   * Ref: http://stackoverflow.com/a/11197343/159762
+   */
+
+  function extend(){
+    for ( var i=1; i<arguments.length; i++ )
+      for ( var key in arguments[i] )
+        if ( arguments[i].hasOwnProperty(key) )
+          arguments[0][key] = arguments[i][key];
+    return arguments[0];
+  }
+
+  /*
+   * Returns true if the element is in the array. Exact comparison is used.
+   */
+
+  function inArray(array, element) {
+    for ( var i=0; i<array.length; i++ )
+      if ( array[i] === element )
+        return true;
+    return false;
+  }
+
+  /*
+   * Returns true if the object is an array.
+   */
+  function isArray(object) {
+    return Object.prototype.toString.call(object) === '[object Array]';
+  }
+
+  /*
+   * Reliably get the document height.
+   * Borrowed from:
+   * jQuery
+   * https://jquery.org/
+   * Ref: https://github.com/jquery/jquery/blob/a644101ed04d0beacea864ce805e0c4f86ba1cd1/src/dimensions.js#L33
+   * Copyright: jQuery Foundation and other contributors
+   * License: https://github.com/jquery/jquery/blob/a644101ed04d0beacea864ce805e0c4f86ba1cd1/LICENSE.txt
+   */
+
+  function getDocumentHeight() {
+    return Math.max(
+      document.documentElement["scrollHeight"], document.body["scrollHeight"],
+      document.documentElement["offsetHeight"], document.body["offsetHeight"],
+      document.documentElement["clientHeight"]
+    );
+  }
+
+  /*
+   * Reliably get the window height.
+   * Ref: http://www.w3schools.com/js/js_window.asp
+   */
+
+  function getWindowHeight() {
+    return window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight;
+  }
+
+  /*
+   * Reliably get the page y-axis offset due to scrolling.
+   * Ref: https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY
+   */
+
+  function getPageYOffset() {
+    return window.pageYOffset || (document.compatMode === "CSS1Compat" ? document.documentElement.scrollTop : document.body.scrollTop);
+  }
+
+  /*
+   * Reliably get the element's y-axis offset to the document top.
+   * Ref: https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect
+   */
+
+  function getElementYOffsetToDocumentTop(element) {
+    return element.getBoundingClientRect().top + getPageYOffset();
+  }
+
+  /*
+   * Try really hard to get the first element matching a selector.
+   * Aims to support all browsers at least for selectors starting with `#`.
+   */
+
+  function getElementBySelector(selector) {
+    if (typeof window['jQuery'] !== 'undefined') {
+      return window['jQuery'](selector).get(0);
+    } else if (typeof document.querySelector !== 'undefined') {
+      return document.querySelector(selector);
+    } else if (selector.charAt(0) == '#') {
+      return document.getElementById(selector.substr(1));
+    }
+    return undefined;
+  }
+
+  /*
+   * Register and Deregister for `eventName` on `element`.
+   * Aims to support all browsers.
+   */
+
+  function addEventListener(element, eventName, handler) {
+    if ( element.addEventListener ) {
+      element.addEventListener(eventName, handler, false);
+    } else if ( element.attachEvent )  {
+      element.attachEvent('on' + eventName, handler);
+    } else {
+      element['on' + eventName] = handler;
+    }
+  }
+
+  function removeEventListener(element, eventName, handler) {
+    if ( element.removeEventListener ) {
+      element.removeEventListener(eventName, handler, false);
+    } else if ( element.detachEvent ) {
+      element.detachEvent('on' + eventName, handler);
+    } else {
+      element['on' + type] = null;
+    }
+  }
+
+  /*
+   * Module variables.
+   */
+  var defaults = {
+    minHeight: 0,
+    elements: [],
+    percentage: true,
+    userTiming: true,
+    pixelDepth: true,
+    nonInteraction: true,
+    gaGlobal: false,
+    gtmOverride: false
+  };
+
+  var options = extend({}, defaults),
+    cache = [],
+    scrollEventBound = false,
+    lastPixelDepth = 0,
+    universalGA,
+    classicGA,
+    gaGlobal,
+    standardEventHandler,
+    scrollEventHandler;
+
+  /*
+   * Bind and unbind the scroll event handler.
+   */
+
+  function bindScrollDepth(scrollEventHandler) {
+    scrollEventBound = true;
+    addEventListener(window, 'scroll', scrollEventHandler);
+  }
+
+  function unbindScrollDepth(scrollEventHandler) {
+    scrollEventBound = false;
+    removeEventListener(window, 'scroll', scrollEventHandler);
+  }
+
+  /*
+   * Library Interface
+   */
+
+  // Initialize the library.
+  var init = function(initOptions) {
+
+    var startTime = +new Date;
+
+    options = extend({}, defaults, initOptions);
+
+    // Return early if document height is too small
+    if ( getDocumentHeight() < options.minHeight ) {
+      return;
+    }
+
+    /*
+     * Determine which version of GA is being used
+     * "ga", "__gaTracker", _gaq", and "dataLayer" are the possible globals
+     */
+
+    if (options.gaGlobal) {
+      universalGA = true;
+      gaGlobal = options.gaGlobal;
+    } else if (typeof ga === "function") {
+      universalGA = true;
+      gaGlobal = 'ga';
+    } else if (typeof __gaTracker === "function") {
+      universalGA = true;
+      gaGlobal = '__gaTracker';
+    }
+
+    if (typeof _gaq !== "undefined" && typeof _gaq.push === "function") {
+      classicGA = true;
+    }
+
+    if (typeof options.eventHandler === "function") {
+      standardEventHandler = options.eventHandler;
+    } else if (typeof dataLayer !== "undefined" && typeof dataLayer.push === "function" && !options.gtmOverride) {
+
+      standardEventHandler = function(data) {
+        dataLayer.push(data);
+      };
+    }
+
+    /*
+     * Functions
+     */
+
+    function sendEvent(action, label, scrollDistance, timing) {
+
+      if (standardEventHandler) {
+
+        standardEventHandler({'event': 'ScrollDistance', 'eventCategory': 'Scroll Depth', 'eventAction': action, 'eventLabel': label, 'eventValue': 1, 'eventNonInteraction': options.nonInteraction});
+
+        if (options.pixelDepth && arguments.length > 2 && scrollDistance > lastPixelDepth) {
+          lastPixelDepth = scrollDistance;
+          standardEventHandler({'event': 'ScrollDistance', 'eventCategory': 'Scroll Depth', 'eventAction': 'Pixel Depth', 'eventLabel': rounded(scrollDistance), 'eventValue': 1, 'eventNonInteraction': options.nonInteraction});
+        }
+
+        if (options.userTiming && arguments.length > 3) {
+          standardEventHandler({'event': 'ScrollTiming', 'eventCategory': 'Scroll Depth', 'eventAction': action, 'eventLabel': label, 'eventTiming': timing});
+        }
+
+      } else {
+
+        if (universalGA) {
+
+          window[gaGlobal]('send', 'event', 'Scroll Depth', action, label, 1, {'nonInteraction': options.nonInteraction});
+
+          if (options.pixelDepth && arguments.length > 2 && scrollDistance > lastPixelDepth) {
+            lastPixelDepth = scrollDistance;
+            window[gaGlobal]('send', 'event', 'Scroll Depth', 'Pixel Depth', rounded(scrollDistance), 1, {'nonInteraction': options.nonInteraction});
+          }
+
+          if (options.userTiming && arguments.length > 3) {
+            window[gaGlobal]('send', 'timing', 'Scroll Depth', action, timing, label);
+          }
+
+        }
+
+        if (classicGA) {
+
+          _gaq.push(['_trackEvent', 'Scroll Depth', action, label, 1, options.nonInteraction]);
+
+          if (options.pixelDepth && arguments.length > 2 && scrollDistance > lastPixelDepth) {
+            lastPixelDepth = scrollDistance;
+            _gaq.push(['_trackEvent', 'Scroll Depth', 'Pixel Depth', rounded(scrollDistance), 1, options.nonInteraction]);
+          }
+
+          if (options.userTiming && arguments.length > 3) {
+            _gaq.push(['_trackTiming', 'Scroll Depth', action, timing, label, 100]);
+          }
+
+        }
+
+      }
+
+    }
+
+    function calculateMarks(docHeight) {
+      return {
+        '25%' : parseInt(docHeight * 0.25, 10),
+        '50%' : parseInt(docHeight * 0.50, 10),
+        '75%' : parseInt(docHeight * 0.75, 10),
+        // Cushion to trigger 100% event in iOS
+        '100%': docHeight - 5
+      };
+    }
+
+    function checkMarks(marks, scrollDistance, timing) {
+      // Check each active mark
+      for ( var key in marks ) {
+        if ( !marks.hasOwnProperty(key) )
+          continue;
+        var val = marks[key];
+        if ( !inArray(cache, key) && scrollDistance >= val ) {
+          sendEvent('Percentage', key, scrollDistance, timing);
+          cache.push(key);
+        }
+      }
+    }
+
+    function checkElements(elements, scrollDistance, timing) {
+      for ( var i=0; i<elements.length; i++) {
+        var elem = elements[i];
+        if ( !inArray(cache, elem) ) {
+          var elemNode = (typeof elem === "string") ? getElementBySelector(elem) : elem;
+          if ( elemNode ) {
+            var elemYOffset = getElementYOffsetToDocumentTop(elemNode);
+            if ( scrollDistance >= elemYOffset ) {
+              sendEvent('Elements', elem, scrollDistance, timing);
+              cache.push(elem);
+            }
+          }
+        }
+      };
+    }
+
+    function rounded(scrollDistance) {
+      // Returns String
+      return (Math.floor(scrollDistance/250) * 250).toString();
+    }
+
+    /*
+     * Throttle function borrowed from:
+     * Underscore.js 1.5.2
+     * http://underscorejs.org
+     * (c) 2009-2013 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+     * Underscore may be freely distributed under the MIT license.
+     */
+
+    function throttle(func, wait) {
+      var context, args, result;
+      var timeout = null;
+      var previous = 0;
+      var later = function() {
+        previous = new Date;
+        timeout = null;
+        result = func.apply(context, args);
+      };
+      return function() {
+        var now = new Date;
+        if (!previous) previous = now;
+        var remaining = wait - (now - previous);
+        context = this;
+        args = arguments;
+        if (remaining <= 0) {
+          clearTimeout(timeout);
+          timeout = null;
+          previous = now;
+          result = func.apply(context, args);
+        } else if (!timeout) {
+          timeout = setTimeout(later, remaining);
+        }
+        return result;
+      };
+    }
+
+    /*
+     * Scroll Event
+     */
+
+    scrollEventHandler = throttle(function() {
+      /*
+       * We calculate document and window height on each scroll event to
+       * account for dynamic DOM changes.
+       */
+
+      var docHeight = getDocumentHeight(),
+        winHeight = getWindowHeight(),
+        scrollDistance = getPageYOffset() + winHeight,
+
+        // Recalculate percentage marks
+        marks = calculateMarks(docHeight),
+
+        // Timing
+        timing = +new Date - startTime;
+
+      // If all marks already hit, unbind scroll event
+      if (cache.length >= 4 + options.elements.length) {
+        unbindScrollDepth();
+        return;
+      }
+
+      // Check specified DOM elements
+      if (options.elements) {
+        checkElements(options.elements, scrollDistance, timing);
+      }
+
+      // Check standard marks
+      if (options.percentage) {
+        checkMarks(marks, scrollDistance, timing);
+      }
+    }, 500);
+
+    bindScrollDepth(scrollEventHandler);
+  };
+
+  // Reset Scroll Depth with the originally initialized options
+  var reset = function() {
+    cache = [];
+    lastPixelDepth = 0;
+
+    if (typeof scrollEventHandler == "undefined") {
+      return;
+    }
+
+    unbindScrollDepth(scrollEventHandler);
+    bindScrollDepth(scrollEventHandler);
+  };
+
+  // Add DOM elements to be tracked
+  var addElements = function(elems) {
+    if (typeof elems == "undefined" || !isArray(elems)) {
+      return;
+    }
+
+    for (var i=0; i<elems.length; i++) {
+      var elem = elems[i];
+      var elemIndex = options.elements.indexOf(elem);
+      if (elemIndex == -1) {
+        options.elements.push(elem);
+      }
+    }
+
+    if (!scrollEventBound) {
+      bindScrollDepth();
+    }
+  };
+
+  // Remove DOM elements currently tracked
+  var removeElements = function(elems) {
+    if (typeof elems == "undefined" || !isArray(elems)) {
+      return;
+    }
+
+    for (var i=0; i<elems.length; i++) {
+      var elem = elems[i];
+
+      var elementsIndex = options.elements.indexOf(elem);
+      if (elementsIndex > -1) {
+        options.elements.splice(elementsIndex, 1);
+      }
+
+      var cacheIndex = cache.indexOf(elem);
+      if (cacheIndex > -1) {
+        cache.splice(cacheIndex, 1);
+      }
+    }
+  };
+
+  /*
+   * Globals
+   */
+
+  window.gascrolldepth = {
+    init: init,
+    reset: reset,
+    addElements: addElements,
+    removeElements: removeElements
+  };
+
+  /*
+   * jQuery Plugin
+   */
+
+  if ( typeof window['jQuery'] !== 'undefined' ) {
+    window['jQuery'].gascrolldepth = init;
+  }
+
+})( window, document );

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -66,7 +66,7 @@ module ApplicationHelper
   end
 
   def ga_scroll_ids(ids)
-    content_for(:ga_scroll_ids) { ids.join(',') }
+    content_for(:ga_scroll_ids) { ids.join(',')+',' }
   end
 
   def description(page_description)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -65,6 +65,10 @@ module ApplicationHelper
     page_title
   end
 
+  def ga_scroll_ids(ids)
+    content_for(:ga_scroll_ids) { ids.join(',') }
+  end
+
   def description(page_description)
     content_for(:description) { truncate(page_description, length: 160) }
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -77,7 +77,7 @@
     }
   </script>
 </head>
-<body>
+<body data-ga_scroll_ids="<%= content_for(:ga_scroll_ids) %>" >
   <div class="navbar navbar-inverse navbar-static-top">
     <div class="container">
       <div class="navbar-header">

--- a/app/views/projects/_statistics.html.erb
+++ b/app/views/projects/_statistics.html.erb
@@ -1,5 +1,7 @@
 <% cache(['v1', @project, 'stats'], :expires_in => 1.day) do %>
-  <h4>Project Statistics</h4>
+<% ga_scroll_ids ['#project-statistics'] %>
+
+  <h4 id='project-statistics'>Project Statistics</h4>
   <table class='table table-striped'>
     <tr>
       <td>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -26,7 +26,7 @@
 
 <hr>
 <%= render 'adsense/banner' %>
-<h3>
+<h3 id='search-by-language'>
   Search Projects by Language
   <small class='more'>
     <%= link_to 'See more &raquo;'.html_safe, languages_path %>
@@ -38,7 +38,7 @@
 
 <hr>
 <%= render 'adsense/banner' %>
-<h3>
+<h3 id='search-by-license'>
   Search Projects by License
   <small class='more'>
     <%= link_to 'See more &raquo;'.html_safe, licenses_path %>
@@ -50,7 +50,7 @@
 
 <hr>
 <%= render 'adsense/banner' %>
-<h3>
+<h3 id='search-by-keyword'>
   Search Projects by Keyword
   <small class='more'>
     <%= link_to 'See more &raquo;'.html_safe, keywords_path %>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,3 +1,5 @@
+<% ga_scroll_ids ['#search-by-language','#search-by-license','#search-by-keyword'] %>
+
 <div class='row'>
   <div class="col-md-12 leaderboard">
     <h1>Libraries.io <small>The Open Source Discovery Service. <%= link_to 'Find out more &raquo;'.html_safe, about_path, class: 'visible-xs' %></small></h1>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,6 +1,7 @@
 <% title "#{@project} #{@version} on #{@project.platform_name} - Libraries.io" %>
 <% description project_description(@project, @version) %>
 <% content_for :atom, auto_discovery_link_tag(:atom, rss_url(@project)) %>
+<% ga_scroll_ids ['#dependent-projects','#dependent-repositories','#releases', '#tagged-releases', 'top-contributors', 'your-dependent-repositories'] %>
 
 <%= content_for :meta, render_meta(@project) %>
 
@@ -238,7 +239,7 @@
           <% if dependent_repos.length > 0 || dependents.length > 0 %>
             <% if dependents.length > 0 %>
               <div class="col-sm-6">
-                <h4>Dependent Projects</h4>
+                <h4 id='dependent-projects'>Dependent Projects</h4>
                 <ul>
                   <% dependents.each do |project| %>
                   <li>
@@ -251,7 +252,7 @@
             <% end %>
             <% if dependent_repos.length > 0 %>
               <div class="col-sm-6">
-                <h4>Dependent Repositories</h4>
+                <h4 id='dependent-repositories'>Dependent Repositories</h4>
                 <ul>
                   <% dependent_repos.each do |repo| %>
                   <li>
@@ -275,7 +276,7 @@
     <%= render 'adsense/sidebar' %>
     <% cache([@project, @version, 'projects:sidebar', 'v1'], :expires_in => 1.day) do %>
       <% if @version_count > 0 %>
-        <h4>
+        <h4 id='releases'>
           <%= link_to project_versions_url(@project.to_param.merge(format: :atom)), class: 'rss' do %>
             <%= fa_icon "rss-square" %>
           <% end %>
@@ -295,7 +296,7 @@
           <%= link_to "See all #{pluralize(@project.versions.size, 'releases')}", project_versions_path(@project.to_param) %>
         <% end %>
       <% elsif @repository && @tags.length > 0 %>
-        <h4>
+        <h4 id='tagged-releases'>
           <%= link_to project_tags_url(@project.to_param.merge(format: :atom)), class: 'rss' do %>
             <%= fa_icon "rss-square" %>
           <% end %>
@@ -321,7 +322,7 @@
       <% if @contributors.length > 0 %>
         <div class="row">
           <div class="col-md-12">
-            <h4>Top Contributors <small><%= link_to 'See all', repository_contributors_path(@repository.to_param) %></small></h4>
+            <h4 id='top-contributors'>Top Contributors <small><%= link_to 'See all', repository_contributors_path(@repository.to_param) %></small></h4>
             <%= render @contributors %>
           </div>
         </div>
@@ -333,7 +334,7 @@
       <% if your_dependent_repos.length > 0 %>
         <div class="row">
           <div class="col-md-12">
-            <h4>Your Dependent Repositories</h4>
+            <h4 id='your-dependent-repositories'>Your Dependent Repositories</h4>
             <ul>
               <% your_dependent_repos.limit(10).each do |repo| %>
                 <li>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,7 +1,7 @@
 <% title "#{@project} #{@version} on #{@project.platform_name} - Libraries.io" %>
 <% description project_description(@project, @version) %>
 <% content_for :atom, auto_discovery_link_tag(:atom, rss_url(@project)) %>
-<% ga_scroll_ids ['#dependent-projects','#dependent-repositories','#releases', '#tagged-releases', 'top-contributors', 'your-dependent-repositories'] %>
+<% ga_scroll_ids ['#dependencies','#dependent-projects','#dependent-repositories','#releases', '#tagged-releases', 'top-contributors', 'your-dependent-repositories'] %>
 
 <%= content_for :meta, render_meta(@project) %>
 
@@ -175,7 +175,7 @@
             <div class="col-md-12 table-responsive">
             <% @dependencies.group_by(&:kind).each do |kind, deps| %>
               <% if deps.length > 0 %>
-                <table class='table table-hover table-condensed'>
+                <table id='dependencies' class='table table-hover table-condensed'>
                   <thead>
                     <th>
                       <%= kind.humanize unless kind == 'runtime' %> Dependencies

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,7 +1,7 @@
 <% title "#{@project} #{@version} on #{@project.platform_name} - Libraries.io" %>
 <% description project_description(@project, @version) %>
 <% content_for :atom, auto_discovery_link_tag(:atom, rss_url(@project)) %>
-<% ga_scroll_ids ['#dependencies','#dependent-projects','#dependent-repositories','#releases', '#tagged-releases', 'top-contributors', 'your-dependent-repositories'] %>
+<% ga_scroll_ids ['#dependencies','#dependent-projects','#dependent-repositories','#releases', '#tagged-releases', '#top-contributors', '#your-dependent-repositories'] %>
 
 <%= content_for :meta, render_meta(@project) %>
 


### PR DESCRIPTION
In order to track elements of 

* homepage
* project page

Using fork rather than jquery extension but can amend if needed. 

? Doesn’t allow nesting of tags in _partial templates. Could I declare ga_scroll_ids as a variable within application_helper and append to that? Showing my lack of golden path knowledge here. 