### PR TITLE
Add rake task to generate package manager support matrix

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -16,6 +16,10 @@ module PackageManager
       end
     end
 
+    def self.language
+      Languages::Language.all.find{|l| l.color == color }.try(:name)
+    end
+
     def self.format_name(platform)
       return nil if platform.nil?
       platforms.find{|p| p.to_s.demodulize.downcase == platform.downcase }.to_s.demodulize

--- a/app/models/package_manager/cran.rb
+++ b/app/models/package_manager/cran.rb
@@ -4,7 +4,7 @@ module PackageManager
     HAS_DEPENDENCIES = true
     BIBLIOTHECARY_SUPPORT = true
     URL = 'https://cran.r-project.org/'
-    COLOR = '#198ce7'
+    COLOR = '#198CE7'
 
     def self.package_link(project, _version = nil)
       "https://cran.r-project.org/package=#{project.name}"

--- a/app/models/package_manager/dub.rb
+++ b/app/models/package_manager/dub.rb
@@ -4,7 +4,7 @@ module PackageManager
     HAS_DEPENDENCIES = true
     BIBLIOTHECARY_SUPPORT = true
     URL = 'http://code.dlang.org'
-    COLOR = '#fcd46d'
+    COLOR = '#ba595e'
 
     def self.package_link(project, version = nil)
       "http://code.dlang.org/packages/#{project.name}" + (version ? "/#{version}" : "")

--- a/app/models/package_manager/homebrew.rb
+++ b/app/models/package_manager/homebrew.rb
@@ -5,7 +5,7 @@ module PackageManager
     BIBLIOTHECARY_PLANNED = true
     SECURITY_PLANNED = false
     URL = 'http://brew.sh/'
-    COLOR = '#a1804c'
+    COLOR = '#555555'
 
     def self.package_link(project, version = nil)
       "http://brewformulas.org/#{project.name}"

--- a/app/models/package_manager/pub.rb
+++ b/app/models/package_manager/pub.rb
@@ -4,7 +4,7 @@ module PackageManager
     HAS_DEPENDENCIES = true
     BIBLIOTHECARY_SUPPORT = true
     URL = 'https://pub.dartlang.org'
-    COLOR = '#98BAD6'
+    COLOR = '#00B4AB'
 
     def self.package_link(project, _version = nil)
       "https://pub.dartlang.org/packages/#{project.name}"

--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -5,7 +5,7 @@ module PackageManager
     BIBLIOTHECARY_SUPPORT = true
     SECURITY_PLANNED = true
     URL = 'https://pypi.python.org'
-    COLOR = '#3581ba'
+    COLOR = '#3572A5'
 
     def self.package_link(project, version = nil)
       "https://pypi.python.org/pypi/#{project.name}/#{version}"

--- a/app/models/package_manager/sublime.rb
+++ b/app/models/package_manager/sublime.rb
@@ -3,6 +3,7 @@ module PackageManager
     HAS_VERSIONS = true
     HAS_DEPENDENCIES = false
     URL = 'https://packagecontrol.io'
+    COLOR = '#3572A5'
 
     def self.package_link(project, version = nil)
       "https://packagecontrol.io/packages/#{project.name}"

--- a/lib/tasks/documentation.rake
+++ b/lib/tasks/documentation.rake
@@ -1,0 +1,13 @@
+namespace :documentation do
+  desc 'Generate Package Manager Matrix'
+  task package_manager_matrix: :environment do
+    puts '| Name  | Website | Main Language | Versions | Dependencies | Biblothecary support |'
+    puts '| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |'
+    Dir[Rails.root.join('app', 'models', 'package_manager', '*.rb')].each do|file|
+      require file unless file.match(/base.rb$/)
+    end
+    PackageManager::Base.platforms.each do |platform|
+      puts "| #{platform.formatted_name} | #{platform::URL} | #{platform.language} | #{platform::HAS_VERSIONS} | #{platform::HAS_DEPENDENCIES} | #{platform::BIBLIOTHECARY_SUPPORT} |"
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/librariesio/documentation/issues/28

    rake documentation:package_manager_matrix

Doesn't require any production data so can be ran locally in development environment.

Updated matrix in documentation using the output here: https://github.com/librariesio/documentation/blob/23bfcbade4a80200d016d54103e6e1adccff6e8d/packagemanagers.md