### PR TITLE
Introduce GithubHookHandler

### DIFF
--- a/app/controllers/hooks_controller.rb
+++ b/app/controllers/hooks_controller.rb
@@ -4,11 +4,18 @@ class HooksController < ApplicationController
   def github
     if params[:payload]
       payload = JSON.parse(params[:payload])
-      GithubHookWorker.perform_async(payload["repository"]["id"], payload["sender"]["id"])
     else
-      GithubHookWorker.perform_async(params["repository"]["id"], params["sender"]["id"])
+      payload = params
     end
 
+    handler.run(request.env['HTTP_X_GITHUB_EVENT'], payload)
+
     render json: nil, status: :ok
+  end
+
+  private
+
+  def handler
+    @handler ||= GithubHookHandler.new
   end
 end

--- a/app/services/github_hook_handler.rb
+++ b/app/services/github_hook_handler.rb
@@ -1,0 +1,10 @@
+class GithubHookHandler
+  def run(event, payload)
+    case event
+    when "push", "pull_request"
+      GithubHookWorker.perform_async(payload["repository"]["id"], payload["sender"]["id"])
+    else
+      puts "GithubHookHandler: received unknown '#{event}' event"
+    end
+  end
+end

--- a/spec/requests/hooks_spec.rb
+++ b/spec/requests/hooks_spec.rb
@@ -3,7 +3,10 @@ require "rails_helper"
 describe "HooksController" do
   describe "POST /hooks/github", type: :request do
     it "renders successfully" do
-      post "/hooks/github", params: {repository: {id: 1}, sender: {id: 1}}
+      post "/hooks/github",
+        params: {repository: {id: 1}, sender: {id: 1}},
+        headers: { "X-GitHub-Event" => "push" }
+
       expect(response).to have_http_status(:success)
     end
   end

--- a/spec/services/github_hook_handler_spec.rb
+++ b/spec/services/github_hook_handler_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe GithubHookHandler do
+  describe "#run" do
+    describe "push, pull_request events" do
+      it "enqueues GithubHookWorker" do
+        ["push", "pull_request"]. each do |event|
+          expect(GithubHookWorker).to receive(:perform_async)
+          subject.run(event, { "repository" => {}, "sender" => {} })
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
An abstract way of dealing with different kinds of GitHub webhooks. Will
be useful when solving #1174.

cc @andrew 