### PR TITLE
Upgrade simplecov gem to 0.14.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,7 +103,7 @@ group :test do
   gem 'database_cleaner'
   gem 'rspec_junit_formatter'
   gem 'shoulda'
-  gem 'simplecov', '0.14.1', require: false
+  gem 'simplecov', require: false
   gem 'codeclimate-test-reporter', require: false
   gem 'faker'
   gem 'poltergeist'

--- a/Gemfile
+++ b/Gemfile
@@ -103,7 +103,7 @@ group :test do
   gem 'database_cleaner'
   gem 'rspec_junit_formatter'
   gem 'shoulda'
-  gem 'simplecov', require: false
+  gem 'simplecov', '0.14.1', require: false
   gem 'codeclimate-test-reporter', require: false
   gem 'faker'
   gem 'poltergeist'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -615,7 +615,7 @@ DEPENDENCIES
   sidekiq-unique-jobs
   simple-rss
   simple_form
-  simplecov (= 0.14.1)
+  simplecov
   sitemap_generator
   spdx
   spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -455,7 +455,7 @@ GEM
       actionpack (> 4, < 5.1)
       activemodel (> 4, < 5.1)
     simple_oauth (0.3.1)
-    simplecov (0.14.0)
+    simplecov (0.14.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
@@ -615,7 +615,7 @@ DEPENDENCIES
   sidekiq-unique-jobs
   simple-rss
   simple_form
-  simplecov
+  simplecov (= 0.14.1)
   sitemap_generator
   spdx
   spring


### PR DESCRIPTION
Upgrade of the simplecov gem. Explicitly sets version in Gemfile to
0.14.1 and updates Gemfile.lock file.

Fixes #1297

