### PR TITLE
Add `/hooks/package` endpoint

### DIFF
--- a/app/controllers/hooks_controller.rb
+++ b/app/controllers/hooks_controller.rb
@@ -13,6 +13,12 @@ class HooksController < ApplicationController
     render json: nil, status: :ok
   end
 
+  def package
+    PackageManagerDownloadWorker.perform_async(params['platform'], params['name'])
+
+    render json: nil, status: :ok
+  end
+
   private
 
   def handler

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -187,6 +187,7 @@ Rails.application.routes.draw do
   get '/privacy', to: 'pages#privacy', as: :privacy
   get '/compatibility', to: 'pages#compatibility', as: :compatibility
 
+  post '/hooks/package', to: 'hooks#package'
 
   if Rails.env.development?
     get '/rails/mailers'         => "rails/mailers#index"

--- a/spec/requests/hooks_spec.rb
+++ b/spec/requests/hooks_spec.rb
@@ -10,4 +10,20 @@ describe "HooksController" do
       expect(response).to have_http_status(:success)
     end
   end
+
+  describe "POST /hooks/package", type: :request do
+    it "renders successfully" do
+      post "/hooks/package",
+        params: { platform: 'Rubygems', name: 'rails' }
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it "enqueues PackageManagerDownloadWorker" do
+      expect(PackageManagerDownloadWorker).to receive(:perform_async)
+
+      post "/hooks/package",
+        params: { platform: 'Rubygems', name: 'rails' }
+    end
+  end
 end


### PR DESCRIPTION
To be used by "watcher". Called when new package versions are released,
and need to be processed.

cc @andrew 