### PR TITLE
Release and diff urls for versions and tags

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -82,7 +82,8 @@ class Repository < ApplicationRecord
            :download_fork_source, :download_tags, :download_contributions, :url,
            :create_webhook, :download_issues, :download_forks, :stargazers_url,
            :formatted_host, :get_file_list, :get_file_contents, :issues_url,
-           :source_url, :contributors_url, :blob_url, :raw_url, :commits_url, to: :repository_host
+           :source_url, :contributors_url, :blob_url, :raw_url, :commits_url,
+           :compare_url, to: :repository_host
 
   def self.language(language)
     where('lower(repositories.language) = ?', language.try(:downcase))

--- a/app/models/repository_host/base.rb
+++ b/app/models/repository_host/base.rb
@@ -31,6 +31,10 @@ module RepositoryHost
       "#{url}/raw/#{sha}/"
     end
 
+    def compare_url(branch_one, branch_two)
+      "#{url}/compare/#{branch_one}...#{branch_two}"
+    end
+
     def watchers_url
       nil
     end

--- a/app/models/repository_host/bitbucket.rb
+++ b/app/models/repository_host/bitbucket.rb
@@ -24,6 +24,10 @@ module RepositoryHost
       "#{url}/commits"
     end
 
+    def compare_url(branch_one, branch_two)
+      "#{url}/compare/#{branch_two}..#{branch_one}#diff"
+    end
+
     def get_file_list(token = nil)
       api_client(token).get_request("1.0/repositories/#{repository.full_name}/directory/")[:values]
     rescue *IGNORABLE_EXCEPTIONS

--- a/app/models/repository_host/github.rb
+++ b/app/models/repository_host/github.rb
@@ -36,10 +36,6 @@ module RepositoryHost
       "#{url}/commits#{author_param}"
     end
 
-    def compare_url(branch_one, branch_two)
-      "#{url}/compare/#{branch_one}...#{branch_two}#files_bucket"
-    end
-
     def self.fetch_repo(full_name, token = nil)
       AuthToken.fallback_client(token).repo(full_name, accept: 'application/vnd.github.drax-preview+json').to_hash
     rescue *IGNORABLE_EXCEPTIONS

--- a/app/models/repository_host/github.rb
+++ b/app/models/repository_host/github.rb
@@ -36,6 +36,10 @@ module RepositoryHost
       "#{url}/commits#{author_param}"
     end
 
+    def compare_url(branch_one, branch_two)
+      "#{url}/compare/#{branch_one}...#{branch_two}#files_bucket"
+    end
+
     def self.fetch_repo(full_name, token = nil)
       AuthToken.fallback_client(token).repo(full_name, accept: 'application/vnd.github.drax-preview+json').to_hash
     rescue *IGNORABLE_EXCEPTIONS

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -89,4 +89,31 @@ class Tag < ApplicationRecord
       "#{repository.url}/commits/tag/#{name}"
     end
   end
+
+  def related_tags
+    repository.tags.sort
+  end
+
+  def tag_index
+    related_tags.index(self)
+  end
+
+  def next_tag
+    related_tags[tag_index - 1]
+  end
+
+  def previous_tag
+    related_tags[tag_index + 1]
+  end
+
+  alias_method :previous_version, :previous_tag
+
+  def related_tag
+    true
+  end
+
+  def diff_url
+    return nil unless repository && previous_tag && previous_tag
+    repository.compare_url(previous_tag.number, number)
+  end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -21,6 +21,7 @@ class Tag < ApplicationRecord
 
   def send_notifications
     if has_projects?
+      repository.download_tags rescue nil
       notify_subscribers
       notify_firehose
       notify_web_hooks

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -64,6 +64,7 @@ class Version < ApplicationRecord
   end
 
   def send_notifications
+    project.try(:repository).try(:download_tags) rescue nil
     notify_subscribers
     notify_firehose
     notify_web_hooks

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -102,4 +102,38 @@ class Version < ApplicationRecord
   def load_dependencies_tree(kind, date = nil)
     TreeResolver.new(self, kind, date).load_dependencies_tree
   end
+
+  def related_tag
+    return nil unless project && project.repository
+    @related_tag ||= project.repository.tags.find{|t| t.clean_number == clean_number }
+  end
+
+  def repository_url
+    related_tag.try(:repository_url)
+  end
+
+  def related_versions
+    @related_versions ||= project.try(:versions).try(:sort)
+  end
+
+  def related_versions_with_tags
+    @related_versions_with_tags ||= related_versions.select(&:related_tag)
+  end
+
+  def version_index
+    related_versions_with_tags.index(self)
+  end
+
+  def next_version
+    related_versions_with_tags[version_index - 1]
+  end
+
+  def previous_version
+    related_versions_with_tags[version_index + 1]
+  end
+
+  def diff_url
+    return nil unless project && project.repository && related_tag && previous_version && previous_version.related_tag
+    project.repository.compare_url(previous_version.related_tag.number, related_tag.number)
+  end
 end

--- a/app/services/firehose.rb
+++ b/app/services/firehose.rb
@@ -13,7 +13,9 @@ class Firehose
           version: version_or_tag.number,
           package_manager_url: project.package_manager_url(version_or_tag.number),
           published_at: version_or_tag.published_at.to_s,
-          project: project.as_json(only: Project::API_FIELDS, methods: [:package_manager_url, :stars, :forks, :keywords])
+          project: project.as_json(only: Project::API_FIELDS, methods: [:package_manager_url, :stars, :forks, :keywords]),
+          diff_url: version_or_tag.diff_url,
+          repository_url: version_or_tag.repository_url
         }),
         headers: { 'Content-Type' => 'application/json' }).run
     end

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -281,16 +281,40 @@
           <% end %>
           Releases
         </h4>
-        <ul>
+        <table class='table'>
           <% @versions.each do |version| %>
-          <li>
-            <%= link_to version, version_path(version.to_param) %>
+          <tr>
+            <td>
+              <%= link_to version, version_path(version.to_param) %>
+            </td>
             <% if version.published_at.present? %>
-            - <%= version.published_at.to_s(:long) %>
+              <td>
+                <small class='text-muted'>
+                  <%= version.published_at.to_date.to_s(:long) %>
+                </small>
+              </td>
             <% end %>
-          </li>
+            <% if version.related_tag %>
+            <td>
+              <small class='text-muted'>
+                <%= link_to version.related_tag.repository_url, class: 'tip', title: "Browse source on #{version.project.repository.host_type}" do %>
+                  <%= fa_icon('tag') %>
+                <% end %>
+              </small>
+            </td>
+            <td>
+                <% if version.previous_version %>
+                  <small class='text-muted'>
+                    <%= link_to version.diff_url, class: 'tip', title: "View diff between #{version} and #{version.previous_version}" do %>
+                      <%= fa_icon('random') %>
+                    <% end %>
+                  </small>
+                <% end %>
+              </td>
+            <% end %>
+          </tr>
           <% end %>
-        </ul>
+        </table>
         <% if @project.versions.size > 10 %>
           <%= link_to "See all #{pluralize(@project.versions.size, 'releases')}", project_versions_path(@project.to_param) %>
         <% end %>
@@ -301,16 +325,38 @@
           <% end %>
           Tagged Releases
         </h4>
-        <ul>
+        <table class='table'>
           <% @tags.each do |tag| %>
-          <li>
-            <%= link_to tag, version_path(@project.to_param.merge(number: tag.name)) %>
+          <tr>
+            <td>
+              <%= link_to tag, version_path(@project.to_param.merge(number: tag.name)) %>
+            </td>
             <% if tag.published_at.present? %>
-            - <%= tag.published_at.to_s(:long) %>
+              <td>
+                <small class='text-muted'>
+                  <%= tag.published_at.to_date.to_s(:long) %>
+                </small>
+              </td>
             <% end %>
-          </li>
+            <td>
+              <small class='text-muted'>
+                <%= link_to tag.repository_url, class: 'tip', title: "Browse source on #{tag.repository.host_type}" do %>
+                  <%= fa_icon('tag') %>
+                <% end %>
+              </small>
+            </td>
+            <td>
+              <% if tag.previous_tag %>
+                <small class='text-muted'>
+                  <%= link_to tag.diff_url, class: 'tip', title: "View diff between #{tag} and #{tag.previous_tag}" do %>
+                    <%= fa_icon('random') %>
+                  <% end %>
+                </small>
+              <% end %>
+            </td>
+          </tr>
           <% end %>
-        </ul>
+        </table>
         <% if @repository.tags.published.count > 10 %>
           <%= link_to "See all #{pluralize(@repository.tags.published.count, 'tags')}", project_tags_path(@project.to_param) %>
         <% end %>

--- a/app/views/projects/tags.html.erb
+++ b/app/views/projects/tags.html.erb
@@ -2,21 +2,45 @@
 <% content_for :atom, auto_discovery_link_tag(:atom, project_tags_url({format: "atom"}.merge(@project.to_param))) %>
 
 <h1><%= link_to @project, project_path(@project.to_param) %> tagged releases</h1>
-<hr>
 <div class="row">
   <div class="col-sm-8">
     <%= render 'adsense/banner' %>
     <% if @tags.any? %>
-      <ul>
+      <table class='table'>
         <% @tags.each do |tag| %>
-        <li>
-          <%= link_to tag, version_path(@project.to_param.merge(number: tag.name)) %>
+        <tr>
+          <td>
+            <%= link_to tag, version_path(@project.to_param.merge(number: tag.name)) %>
+          </td>
           <% if tag.published_at.present? %>
-          - <%= tag.published_at.to_s(:long) %>
+            <td>
+              <small class='text-muted'>
+                <%= tag.published_at.to_s(:long_ordinal) %>
+              </small>
+            </td>
           <% end %>
-        </li>
+          <td>
+            <small class='text-muted'>
+              <%= link_to tag.repository_url do %>
+                <%= fa_icon('tag') %>
+                Browse source on <%= tag.repository.host_type %>
+              <% end %>
+            </small>
+          </td>
+          <td>
+            <% if tag.previous_tag %>
+              <small class='text-muted'>
+                <%= link_to tag.diff_url do %>
+                  <%= fa_icon('random') %>
+                  View diff between <%= tag %> and <%= tag.previous_tag %>
+                <% end %>
+              </small>
+            <% end %>
+          </td>
+        </tr>
         <% end %>
-      </ul>
+      </table>
+
       <%= will_paginate @tags, page_links: false %>
       <%= link_to project_tags_path(@project.to_param.merge(format: :atom)) do %>
         <%= fa_icon "rss-square" %>

--- a/app/views/projects/versions.html.erb
+++ b/app/views/projects/versions.html.erb
@@ -4,21 +4,47 @@
 <h1>
   <%= link_to @project, project_path(@project.to_param) %> Releases
 </h1>
-<hr>
+
 <div class="row">
   <div class="col-sm-8">
     <%= render 'adsense/banner' %>
     <% if @versions.any? %>
-      <ul>
+      <table class='table'>
         <% @versions.each do |version| %>
-        <li>
-          <%= link_to version, version_path(version.to_param) %>
+        <tr>
+          <td>
+            <%= link_to version, version_path(version.to_param) %>
+          </td>
           <% if version.published_at.present? %>
-          - <%= version.published_at.to_s(:long) %>
+            <td>
+              <small class='text-muted'>
+                <%= version.published_at.to_s(:long_ordinal) %>
+              </small>
+            </td>
           <% end %>
-        </li>
+          <% if version.related_tag %>
+          <td>
+            <small class='text-muted'>
+              <%= link_to version.related_tag.repository_url do %>
+                <%= fa_icon('tag') %>
+                Browse source on <%= version.project.repository.host_type %>
+              <% end %>
+            </small>
+          </td>
+          <td>
+            <% if version.previous_version %>              
+              <small class='text-muted'>
+                <%= link_to version.diff_url do %>
+                  <%= fa_icon('random') %>
+                  View diff between <%= version %> and <%= version.previous_version %>
+                <% end %>
+              </small>
+            <% end %>
+          </td>
+          <% end %>
+        </tr>
         <% end %>
-      </ul>
+      </table>
       <%= will_paginate @versions, page_links: false %>
       <p>
         <%= link_to project_versions_path(@project.to_param.merge(format: :atom)) do %>

--- a/app/views/repositories/show.html.erb
+++ b/app/views/repositories/show.html.erb
@@ -203,6 +203,47 @@
         <%= render @projects, cache: true %>
       <% end %>
 
+      <% if repo.tags.published.length > 0 %>
+        <div class="row"></div>
+        <hr>
+        <h4>
+          Tags
+          <small><%= link_to 'See all', repository_tags_path(@repository.to_param) %></small>
+        </h4>
+        <table class='table'>
+          <% repo.tags.published.order('published_at DESC, name DESC').limit(30).to_a.each do |tag| %>
+          <tr>
+            <td>
+              <%= link_to tag, tag.repository_url %>
+            </td>
+            <% if tag.published_at.present? %>
+              <td>
+                <small class='text-muted'>
+                  <%= tag.published_at.to_date.to_s(:long) %>
+                </small>
+              </td>
+            <% end %>
+            <td>
+              <small class='text-muted'>
+                <%= link_to tag.repository_url, class: 'tip', title: "Browse source on #{tag.repository.host_type}" do %>
+                  <%= fa_icon('tag') %>
+                <% end %>
+              </small>
+            </td>
+            <td>
+              <% if tag.previous_tag %>
+                <small class='text-muted'>
+                  <%= link_to tag.diff_url, class: 'tip', title: "View diff between #{tag} and #{tag.previous_tag}" do %>
+                    <%= fa_icon('random') %>
+                  <% end %>
+                </small>
+              <% end %>
+            </td>
+          </tr>
+          <% end %>
+        </table>
+      <% end %>
+
       <% if @forks.length > 0 %>
         <div class="row"></div>
         <hr>
@@ -213,24 +254,6 @@
         <%= render @forks, cache: true %>
       <% end %>
 
-      <% if repo.tags.published.length > 0 %>
-        <div class="row"></div>
-        <hr>
-        <h4>
-          Tags
-          <small><%= link_to 'See all', repository_tags_path(@repository.to_param) %></small>
-        </h4>
-        <ul>
-          <% repo.tags.published.order('published_at DESC, name DESC').limit(30).to_a.each do |tag| %>
-            <li>
-              <%= link_to tag, tag.repository_url %>
-              <% if tag.published_at.present? %>
-              - <%= tag.published_at.to_s(:long) %>
-              <% end %>
-            </li>
-          <% end %>
-        </ul>
-      <% end %>
       <div class="row"></div>
       <br>
       <p>

--- a/app/views/repositories/tags.html.erb
+++ b/app/views/repositories/tags.html.erb
@@ -6,16 +6,40 @@
   <div class="col-sm-8">
     <%= render 'adsense/banner' %>
     <% if @tags.any? %>
-      <ul>
-        <% @tags.each do |tag| %>
-        <li>
+    <table class='table'>
+      <% @tags.each do |tag| %>
+      <tr>
+        <td>
           <%= link_to tag, tag.repository_url %>
-          <% if tag.published_at.present? %>
-          - <%= tag.published_at.to_s(:long) %>
-          <% end %>
-        </li>
+        </td>
+        <% if tag.published_at.present? %>
+          <td>
+            <small class='text-muted'>
+              <%= tag.published_at.to_s(:long_ordinal) %>
+            </small>
+          </td>
         <% end %>
-      </ul>
+        <td>
+          <small class='text-muted'>
+            <%= link_to tag.repository_url do %>
+              <%= fa_icon('tag') %>
+              Browse source on <%= tag.repository.host_type %>
+            <% end %>
+          </small>
+        </td>
+        <td>
+          <% if tag.previous_tag %>
+            <small class='text-muted'>
+              <%= link_to tag.diff_url do %>
+                <%= fa_icon('random') %>
+                View diff between <%= tag %> and <%= tag.previous_tag %>
+              <% end %>
+            </small>
+          <% end %>
+        </td>
+      </tr>
+      <% end %>
+    </table>
       <%= will_paginate @tags, page_links: false %>
     <% else %>
       <p>

--- a/app/views/versions_mailer/new_version.html.erb
+++ b/app/views/versions_mailer/new_version.html.erb
@@ -23,9 +23,20 @@
 </p>
 
 <% if @project.repository.present? %>
-<p>
-  You can also browse the latest commits on <%= @project.repository.formatted_host %>: <%= link_to @project.repository.commits_url, @project.repository.commits_url %>
-</p>
+  <% if @version.related_tag %>
+    <p>
+      Browse the code for <%= @version %> on <%= @project.repository.formatted_host %>: <%= link_to @version.repository_url, @version.repository_url %>
+    </p>
+    <% if @version.previous_version %>
+      <p>
+        View diff between <%= @version %> and <%= @version.previous_version %>: <%= link_to @version.diff_url, @version.diff_url %>
+      </p>
+    <% end %>
+  <% else %>
+    <p>
+      You can also browse the latest commits on <%= @project.repository.formatted_host %>: <%= link_to @project.repository.commits_url, @project.repository.commits_url %>
+    </p>
+  <% end %>
 <% end %>
 
 <p>

--- a/app/views/versions_mailer/new_version.text.erb
+++ b/app/views/versions_mailer/new_version.text.erb
@@ -9,7 +9,14 @@ You depend on <%= @project %> in the following repos: <%= @repos.map{|repo| repo
 Check out all the details here: <%= version_url(@project.to_param.merge(number: @version.number)) %>
 
 <% if @project.repository.present? %>
+<% if @version.related_tag %>
+Browse the code for <%= @version %> on <%= @project.repository.formatted_host %>: <%= @version.repository_url %>
+<% if @version.previous_version %>
+View diff between <%= @version %> and <%= @version.previous_version %>: <%= @version.diff_url %>
+<% end %>
+<% else %>
 You can also browse the latest commits on <%= @project.repository.formatted_host %>: <%= @project.repository.commits_url %>
+<% end %>
 <% end %>
 
 From your friendly neighborhood robot, Libby.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -191,11 +191,6 @@ Rails.application.routes.draw do
 
   post '/hooks/package', to: 'hooks#package'
 
-  if Rails.env.development?
-    get '/rails/mailers'         => "rails/mailers#index"
-    get '/rails/mailers/*path'   => "rails/mailers#preview"
-  end
-
   get '/:platform/:name/suggestions', to: 'project_suggestions#new', as: :project_suggestions, constraints: { :name => /.*/ }
   post '/:platform/:name/suggestions', to: 'project_suggestions#create', constraints: { :name => /.*/ }
 


### PR DESCRIPTION
For projects that have their source hosted on GH/GL/BB and push tags their when they release new versions we can do some cool things:

- Link to view the changelog or browse source for the tagged release: https://github.com/splitrb/split/releases/tag/v2.2.0
- Link to a diff between the current and previous version: https://github.com/splitrb/split/compare/v2.1.0...v2.2.0

This PR adds those links for versions and tags on projects and tags on repositories with a slightly redesigned list view:

![screen shot 2017-03-29 at 1 13 11 pm](https://cloud.githubusercontent.com/assets/1060/24456533/36331b98-148b-11e7-910c-cfd381c06d22.png)

Also adds the browse and compare links to new version emails if available and adds the links to the firehose json payload for lib2issues and lib2slack to use.