### PR TITLE
Change relationship between repository and repository user to be via primary key rather than uuid

### DIFF
--- a/app/models/repository_host/github.rb
+++ b/app/models/repository_host/github.rb
@@ -124,7 +124,7 @@ module RepositoryHost
     end
 
     def download_owner
-      return if repository.owner && repository.owner.login == repository.owner_name
+      return if repository.owner && repository.repository_user_id && repository.owner.login == repository.owner_name
       o = api_client.user(repository.owner_name)
       if o.type == "Organization"
         go = RepositoryOrganisation.create_from_github(repository.owner_id.to_i)
@@ -133,7 +133,11 @@ module RepositoryHost
           repository.save
         end
       else
-        RepositoryUser.create_from_github(o)
+        u = RepositoryUser.create_from_github(o)
+        if u
+          repository.repository_user_id = u.id
+          repository.save
+        end
       end
     rescue *IGNORABLE_EXCEPTIONS
       nil

--- a/db/migrate/20170413091907_add_repository_user_id_to_repositories.rb
+++ b/db/migrate/20170413091907_add_repository_user_id_to_repositories.rb
@@ -1,0 +1,6 @@
+class AddRepositoryUserIdToRepositories < ActiveRecord::Migration[5.0]
+  def change
+    add_column :repositories, :repository_user_id, :integer
+    add_index :repositories, :repository_user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170412143657) do
+ActiveRecord::Schema.define(version: 20170413091907) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -305,10 +305,12 @@ ActiveRecord::Schema.define(version: 20170412143657) do
     t.string   "fork_policy"
     t.string   "pull_requests_enabled"
     t.string   "logo_url"
+    t.integer  "repository_user_id"
     t.index "lower((full_name)::text)", name: "index_github_repositories_on_lowercase_full_name", unique: true, using: :btree
     t.index "lower((language)::text)", name: "github_repositories_lower_language", using: :btree
     t.index ["owner_id"], name: "index_repositories_on_owner_id", using: :btree
     t.index ["repository_organisation_id"], name: "index_repositories_on_repository_organisation_id", using: :btree
+    t.index ["repository_user_id"], name: "index_repositories_on_repository_user_id", using: :btree
     t.index ["source_name"], name: "index_repositories_on_source_name", using: :btree
     t.index ["status"], name: "index_repositories_on_status", using: :btree
     t.index ["uuid"], name: "index_repositories_on_uuid", unique: true, using: :btree
@@ -330,7 +332,7 @@ ActiveRecord::Schema.define(version: 20170412143657) do
 
   create_table "repository_organisations", force: :cascade do |t|
     t.string   "login"
-    t.integer  "uuid"
+    t.string   "uuid"
     t.string   "name"
     t.string   "blog"
     t.string   "email"
@@ -341,10 +343,10 @@ ActiveRecord::Schema.define(version: 20170412143657) do
     t.boolean  "hidden",         default: false
     t.datetime "last_synced_at"
     t.string   "host_type"
-    t.index "lower((login)::text)", name: "index_github_organisations_on_lowercase_login", unique: true, using: :btree
+    t.index "lower((host_type)::text), lower((login)::text)", name: "index_repository_organisations_on_host_type_and_login", unique: true, using: :btree
     t.index ["created_at"], name: "index_repository_organisations_on_created_at", using: :btree
     t.index ["hidden"], name: "index_repository_organisations_on_hidden", using: :btree
-    t.index ["uuid"], name: "index_repository_organisations_on_uuid", unique: true, using: :btree
+    t.index ["host_type", "uuid"], name: "index_repository_organisations_on_host_type_and_uuid", unique: true, using: :btree
   end
 
   create_table "repository_permissions", force: :cascade do |t|
@@ -369,7 +371,7 @@ ActiveRecord::Schema.define(version: 20170412143657) do
   end
 
   create_table "repository_users", force: :cascade do |t|
-    t.integer  "uuid"
+    t.string   "uuid"
     t.string   "login"
     t.string   "user_type"
     t.datetime "created_at",                     null: false
@@ -385,12 +387,10 @@ ActiveRecord::Schema.define(version: 20170412143657) do
     t.integer  "followers"
     t.integer  "following"
     t.string   "host_type"
-    t.index "lower((login)::text)", name: "github_users_lower_login", using: :btree
-    t.index "lower((login)::text)", name: "index_github_users_on_lowercase_login", unique: true, using: :btree
+    t.index "lower((host_type)::text), lower((login)::text)", name: "index_repository_users_on_host_type_and_login", unique: true, using: :btree
     t.index ["created_at"], name: "index_repository_users_on_created_at", using: :btree
     t.index ["hidden"], name: "index_repository_users_on_hidden", using: :btree
-    t.index ["login"], name: "index_repository_users_on_login", using: :btree
-    t.index ["uuid"], name: "index_repository_users_on_uuid", unique: true, using: :btree
+    t.index ["host_type", "uuid"], name: "index_repository_users_on_host_type_and_uuid", unique: true, using: :btree
   end
 
   create_table "subscription_plans", force: :cascade do |t|


### PR DESCRIPTION
Part of https://github.com/librariesio/libraries.io/issues/1169

Needs to be merged and migrated before https://github.com/librariesio/libraries.io/pull/1344

Currently repositories have a weird relationship to users:
```ruby
belongs_to :repository_user, primary_key: :uuid, foreign_key: :owner_id
```

This is because when only GitHub repositories where supported we could just save the uuid from GitHub onto the repository model and hope that the user was already in the table without knowing it's id.

This doesn't work anymore because users aren't unique by their uuid, host_type also needs to be involved, so instead let's properly join them by primary keys so it ends up looking like this:

```ruby
belongs_to :repository_user
```

Will require a two stage deployment:

1. Add new column and start saving owner ids to them for every new repository and update all existing ones
2. Drop owner_id column and update relationship to go through `repository_user_id` instead