### PR TITLE
Feature/move slack into lib

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,8 @@ gem 'active_model_serializers'
 gem 'pghero'
 gem 'pg_query'
 gem 'schema_plus_pg_indexes'
+gem 'slack-ruby-client'
+gem 'semantic_range'
 
 group :development do
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,6 +242,7 @@ GEM
       mime-types (>= 1.19)
       rugged (>= 0.25.1)
     github-markup (1.6.0)
+    gli (2.16.0)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     groupdate (3.2.0)
@@ -496,6 +497,14 @@ GEM
     simplecov-html (0.10.0)
     sitemap_generator (5.3.1)
       builder (~> 3.0)
+    slack-ruby-client (0.8.1)
+      activesupport
+      faraday (>= 0.9)
+      faraday_middleware
+      gli
+      hashie
+      json
+      websocket-driver
     spdx (1.3.2)
       fuzzy_match (~> 2.1)
       spdx-licenses (~> 1.0)
@@ -650,6 +659,7 @@ DEPENDENCIES
   simple_form
   simplecov
   sitemap_generator
+  slack-ruby-client
   spdx
   spring
   spring-watcher-listen

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -30,6 +30,6 @@ class AccountsController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:email, :emails_enabled, :hidden)
+    params.require(:user).permit(:email, :emails_enabled, :hidden, :slack_api_token, :slack_channel)
   end
 end

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -59,6 +59,17 @@
     </div>
 
     <div class="panel panel-default">
+      <div class="panel-heading">Slack</div>
+      <div class="panel-body">
+        <%= simple_form_for(current_user, url: account_path, html: { class: 'form-vertical' }) do |form| %>
+          <%= form.input :slack_api_token %>
+          <%= form.input :slack_channel %>
+          <%= form.submit 'Update Slack Preferences', class: 'btn btn-primary' %>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="panel panel-default">
       <div class="panel-heading">API Key</div>
       <div class="panel-body">
         <p>

--- a/db/migrate/20170509155011_add_slack_columns_to_users.rb
+++ b/db/migrate/20170509155011_add_slack_columns_to_users.rb
@@ -1,0 +1,6 @@
+class AddSlackColumnsToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :slack_api_token, :string
+    add_column :users, :slack_channel, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170417160002) do
+ActiveRecord::Schema.define(version: 20170509155011) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -387,6 +387,8 @@ ActiveRecord::Schema.define(version: 20170417160002) do
     t.boolean  "currently_syncing", :default=>false, :null=>false
     t.datetime "last_synced_at"
     t.boolean  "emails_enabled",    :default=>true
+    t.string   "slack_api_token"
+    t.string   "slack_channel"
   end
 
   create_table "versions", force: :cascade do |t|


### PR DESCRIPTION
**headlines**

Move [lib2slack](https://github.com/librariesio/lib2slack) into the libs repo

1) Add `slack_api_token` and `slack_channel` to user model
2) Allow users to fill in these fields from the account page
3) Copy in the [lib2slack](https://github.com/librariesio/lib2slack) slack notification method


**NOTES**
Very much a work in progress! feedback needed! This is more of an initial implementation/feeling out how this functionality would work
