### PR TITLE
Find or create issue opener and store their primary key on issue instead of uuid

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -3,6 +3,7 @@ class Issue < ApplicationRecord
 
   belongs_to :repository
   belongs_to :repository_user
+  belongs_to :repository_user_by_uuid, primary_key: :uuid, anonymous_class: RepositoryUser
 
   API_FIELDS = [:number, :state, :title, :body, :locked, :closed_at, :created_at, :updated_at]
   FIRST_PR_LABELS = ['good first bug', 'good first contribution', 'good-first-bug',

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -3,7 +3,7 @@ class Issue < ApplicationRecord
 
   belongs_to :repository
   belongs_to :repository_user
-  belongs_to :repository_user_by_uuid, primary_key: :uuid, anonymous_class: RepositoryUser
+  belongs_to :repository_user_by_uuid, -> { where(host_type: 'GitHub') }, primary_key: :uuid, foreign_key: :user_uuid, anonymous_class: RepositoryUser
 
   API_FIELDS = [:number, :state, :title, :body, :locked, :closed_at, :created_at, :updated_at]
   FIRST_PR_LABELS = ['good first bug', 'good first contribution', 'good-first-bug',

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -2,7 +2,7 @@ class Issue < ApplicationRecord
   include IssueSearch
 
   belongs_to :repository
-  belongs_to :repository_user, primary_key: :uuid
+  belongs_to :repository_user
 
   API_FIELDS = [:number, :state, :title, :body, :locked, :closed_at, :created_at, :updated_at]
   FIRST_PR_LABELS = ['good first bug', 'good first contribution', 'good-first-bug',
@@ -45,7 +45,8 @@ class Issue < ApplicationRecord
   def self.create_from_hash(repo, issue_hash)
     issue_hash = issue_hash.to_hash
     i = repo.issues.find_or_create_by(uuid: issue_hash[:id])
-    i.repository_user_id = issue_hash[:user][:id]
+    user = RepositoryUser.where(host_type: 'GitHub').find_by_uuid(issue_hash[:user][:id]) || RepositoryOwner::Github.download_user_from_host('GitHub', issue_hash[:user][:login])
+    i.repository_user_id = user.id
     i.repository_id = repo.id
     i.labels = issue_hash[:labels].map{|l| l[:name] }
     i.pull_request = issue_hash[:pull_request].present?

--- a/app/models/repository_user.rb
+++ b/app/models/repository_user.rb
@@ -16,7 +16,7 @@ class RepositoryUser < ApplicationRecord
   RepositoryOwner::Gitlab
 
   has_many :issues
-  has_many :issues_by_uuid, primary_key: :uuid, anonymous_class: Issue
+  has_many :issues_by_uuid, -> { where(host_type: 'GitHub') }, primary_key: :uuid, foreign_key: :user_uuid, anonymous_class: Issue
 
   validate :login_uniqueness_with_case_insenitive_host, if: lambda { self.login_changed? }
   validates :uuid, uniqueness: {scope: :host_type}, if: lambda { self.uuid_changed? }

--- a/app/models/repository_user.rb
+++ b/app/models/repository_user.rb
@@ -15,7 +15,7 @@ class RepositoryUser < ApplicationRecord
   # eager load this module to avoid clashing with Gitlab gem in development
   RepositoryOwner::Gitlab
 
-  has_many :issues, primary_key: :uuid
+  has_many :issues
 
   validate :login_uniqueness_with_case_insenitive_host, if: lambda { self.login_changed? }
   validates :uuid, uniqueness: {scope: :host_type}, if: lambda { self.uuid_changed? }

--- a/app/models/repository_user.rb
+++ b/app/models/repository_user.rb
@@ -16,6 +16,7 @@ class RepositoryUser < ApplicationRecord
   RepositoryOwner::Gitlab
 
   has_many :issues
+  has_many :issues_by_uuid, primary_key: :uuid, anonymous_class: Issue
 
   validate :login_uniqueness_with_case_insenitive_host, if: lambda { self.login_changed? }
   validates :uuid, uniqueness: {scope: :host_type}, if: lambda { self.uuid_changed? }

--- a/db/migrate/20170518105429_rename_repository_user_id_to_uuid_on_issues.rb
+++ b/db/migrate/20170518105429_rename_repository_user_id_to_uuid_on_issues.rb
@@ -1,0 +1,6 @@
+class RenameRepositoryUserIdToUuidOnIssues < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :issues, :repository_user_id, :user_uuid
+    add_column :issues, :repository_user_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170516141712) do
+ActiveRecord::Schema.define(version: 20170518105429) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,7 +73,7 @@ ActiveRecord::Schema.define(version: 20170516141712) do
     t.string   "state"
     t.string   "title"
     t.text     "body"
-    t.integer  "repository_user_id"
+    t.integer  "user_uuid"
     t.boolean  "locked"
     t.integer  "comments_count"
     t.datetime "closed_at"
@@ -83,6 +83,7 @@ ActiveRecord::Schema.define(version: 20170516141712) do
     t.datetime "last_synced_at"
     t.boolean  "pull_request"
     t.string   "host_type"
+    t.integer  "repository_user_id"
   end
 
   create_table "manifests", force: :cascade do |t|


### PR DESCRIPTION
Part 1.5 of https://github.com/librariesio/libraries.io/issues/1170

Previously the `repository_user_id` field on issues was used to store the uuid of github users directly from the API, with https://github.com/librariesio/libraries.io/pull/1431 we'll be storing GitLab and Bitbucket user ids too, so uuid isn't ideal here as active record relations don't really work with the data split across two fields.

Luckily we aren't using the relationship between issues and users yet so we can change the contents without breaking loads of things.

This pr makes a small change so that going forward we'll find/create the github user that opened the issue and save their primary key instead, then we can do the same for GL and BB users in https://github.com/librariesio/libraries.io/pull/1431

It also moves the old data into a column called `user_uuid` and stores the new data in `repository_user_id` which once migrated we can drop the old data column.

Inbetween this being merged and https://github.com/librariesio/libraries.io/pull/1431 being merged I'll kick off a script to convert all the existing uuids to primary keys (including creating missing users or null if user is gone) but it will take a while to process the 23 million or so issues we have! 