### PR TITLE
Fixup Docker configuration for local dev

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.env
+.git
+*.csv
+*.dump
+coverage
+data
+log
+node_modules
+tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
 FROM ruby:2.4.0
 RUN apt-get update -qq && apt-get install -y build-essential
-RUN apt-get install -y libpq-dev
-RUN apt-get install -y libxml2-dev libxslt1-dev
-RUN apt-get install -y nodejs
+RUN apt-get install -y libpq-dev libxml2-dev libxslt1-dev nodejs libicu-dev cmake
 
 ENV APP_HOME /libraries.io
 RUN mkdir $APP_HOME
 WORKDIR $APP_HOME
 
 ADD Gemfile* $APP_HOME/
-RUN bundle install
+RUN bundle install --jobs=4
 
 ADD . $APP_HOME

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,7 +3,6 @@
 production:
   :concurrency: 100
 :timeout: 8
-:verbose: true
 :queues:
   - [user, 40]
   - [critical, 30]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,54 @@
-db:
-  image: postgres
-elasticsearch:
-  image: elasticsearch:2.4
-redis:
-  image: redis
-web:
-  build: .
-  command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
-  volumes:
-    - .:/libraries.io
-  ports:
-    - "3000:3000"
-  links:
-    - db
-    - elasticsearch
-    - redis
+version: '3.0'
+
+volumes:
+  postgres-data:
+    driver: local
+
+  redis-data:
+    driver: local
+
+  elasticsearch-data:
+    driver: local
+
+services:
+  postgres:
+    image: postgres:9.6.3
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=not-a-secret
+      - POSTGRES_USER=librariesio
+
+  elasticsearch:
+    image: elasticsearch:2.4.5
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
+    command: -Daction.auto_create_index=true
+
+  redis:
+    image: redis:3.2.9
+    volumes:
+      - redis-data:/var/lib/redis
+    command: redis-server --appendonly yes
+
+  sidekiq: &app_base
+    build:
+      context: .
+    image: librariesio/libraries.io
+    environment:
+      - DATABASE_URL=postgresql://librariesio:not-a-secret@postgres/librariesio
+      - REDIS_URL=redis://redis:6379/1
+      - ELASTICSEARCH_CLUSTER_URL=elasticsearch:9200
+    volumes:
+      - .:/libraries.io
+    depends_on:
+      - postgres
+      - elasticsearch
+      - redis
+    command: bundle exec sidekiq -C config/sidekiq.yml
+
+  web:
+    <<: *app_base
+    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails server --port 3000 --bind '0.0.0.0'"
+    ports:
+      - "3000:3000"


### PR DESCRIPTION
:wave: This PR attempts to fix and clean up the Docker configuration needed for local dev, as it seemed to be broken. (Running `docker build` failed due to missing system dependencies). Key changes:

* Ignore some unneeded paths when building Docker image
* Parallelize gem installation during `docker build` for speed
* Add missing system deps (libicu-dev and cmake)
* Reduce verbosity of Sidekiq logging as it gets quite overwhelming quickly (let me know if this is not desired)
* Revamp docker-compose with the following improvements:
  * Durable volume stores for the databases
  * Pin versions of database images to avoid inadvertent drift
  * Add Sidekiq container
 
Possible future improvements include adding Mailcatcher (easy), and supporting running tests via Docker (there are multiple implementation paths for this, so I avoided it for now).