### PR TITLE
Update homepage to prioritise /data release

### DIFF
--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -71,9 +71,9 @@
       </div>
       <div class="panel-body">
         <p>
-          Build Libraries.io data into your own applications and services. <em>Open data release coming soon.</em>
+          Use Libraries.io data in your applications, services or research. Use our <%= link_to 'API', '/api'%> to stay up to date.
         </p>
-        <%= link_to 'Documentation', '/api', class:'btn btn-primary center-block'%>
+        <%= link_to 'Documentation', '/data', class:'btn btn-primary center-block'%>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Just a quick update.  Played around with a few other options including:

- having two buttons
- having a fifth panel
- creating a combined data page

Didn’t like em. Rethink later.