### PR TITLE
Fixed typo: repetition of the word is "is is"

### DIFF
--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -58,7 +58,7 @@
       <% else %>
         <h3>Something Missing?</h3>
         <p>
-          If a project from one of these package managers is is missing please <%= link_to 'report it as a bug', "https://github.com/librariesio/libraries.io/issues/new?title=No results for search '#{params[:q]}'" %>.
+          If a project from one of these package managers is missing please <%= link_to 'report it as a bug', "https://github.com/librariesio/libraries.io/issues/new?title=No results for search '#{params[:q]}'" %>.
         </p>
         <div class='row'>
           <%= render partial: 'platforms/platform', collection: @platforms %>


### PR DESCRIPTION
Just noticed this typo today while searching for libraries
