### PR TITLE
Update links to open data release for v1.0.1

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -78,7 +78,7 @@ h3,h4{
   }
 }
 
-dt {
+dt, dd {
   margin-top: 0.5em;
 }
 
@@ -466,7 +466,7 @@ tr.top td{
 
 .well-large{
   max-height: 800px;
-  overflow: scroll; 
+  overflow: scroll;
 }
 
 h4.panel-title{

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -44,7 +44,7 @@ class Identity < ApplicationRecord
     avatar = read_attribute(:avatar_url)
     case provider
     when 'github', 'githubpublic', 'githubprivate'
-      avatar + "?size=#{size}"
+      "#{avatar}?size=#{size}"
     when 'gitlab'
       avatar
     when 'bitbucket'

--- a/app/views/pages/_open_data_downloads.html.erb
+++ b/app/views/pages/_open_data_downloads.html.erb
@@ -1,4 +1,4 @@
-<p>Latest release: <strong>1.0.0 - 15 June, 2017</strong></p>
+<p>Latest release: <strong>1.0.1 - 21 July, 2017</strong></p>
 
 <p>Download an archive of seven csv files from zenodo:</p>
 
@@ -20,16 +20,16 @@
     <tr>
       <td>
         <strong>
-          Libraries.io-open-data-1.0.0.zip
+          Libraries.io-open-data-1.0.1.zip
         </strong>
-        <br><small class='text-muted'>MD5: be8015f7e70481da6b43af63372be626</small>
+        <br><small class='text-muted'>MD5: e73506370d920431cea1ed95c19338b5</small>
       </td>
       <td>
         5.9GB
       </td>
       <td>200 million</td>
       <td>
-        <a href="https://zenodo.org/record/808273/files/Libraries.io-open-data-1.0.0.zip" class='btn btn-primary'>Download</a>
+        <a href="https://zenodo.org/record/833207/files/Libraries.io-open-data-1.0.1.zip" class='btn btn-primary'>Download</a>
       </td>
     </tr>
 </table>

--- a/app/views/pages/data.html.erb
+++ b/app/views/pages/data.html.erb
@@ -119,11 +119,15 @@
     <h2>Releases</h2>
     <hr>
     <dl class='row'>
-        <dt class='col-xs-8'>Next</dt>
-        <dd class='col-xs-4'>August 2017</dd>
-        <dt class='col-xs-8'>Latest</dt>
-        <dd class='col-xs-4'>
+        <dt class='col-xs-6'>Next</dt>
+        <dd class='col-xs-6'>August 2017</dd>
+        <dt class='col-xs-6'>Latest</dt>
+        <dd class='col-xs-6'>
           <a href="https://zenodo.org/record/833207">1.0.1</a> - 21 July, 2017
+        </dd>
+        <dt class='col-xs-6'>Previous</dt>
+        <dd class='col-xs-6'>
+          <a href="https://zenodo.org/record/808273">1.0.0</a> - 15 June, 2017
         </dd>
     </dl>
 

--- a/app/views/pages/data.html.erb
+++ b/app/views/pages/data.html.erb
@@ -123,7 +123,7 @@
         <dd class='col-xs-4'>August 2017</dd>
         <dt class='col-xs-8'>Latest</dt>
         <dd class='col-xs-4'>
-          <a href="https://zenodo.org/record/808273">1.0.0</a> - 15 June, 2017
+          <a href="https://zenodo.org/record/833207">1.0.1</a> - 21 July, 2017
         </dd>
     </dl>
 


### PR DESCRIPTION
Updated links to new zenodo release which should fix the zip errors people have been reporting: https://zenodo.org/record/833207