### PR TITLE
Typosquatting experiment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,7 @@ gem 'pg_query'
 gem 'schema_plus_pg_indexes'
 gem 'autoprefixer-rails', '~> 7.1.2.1'
 gem 'amatch'
+gem 'levenshtein-ffi', :require => 'levenshtein'
 
 group :development do
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,6 +254,8 @@ GEM
     jsonapi-renderer (0.1.3)
     jwt (1.5.6)
     key_struct (0.4.2)
+    levenshtein-ffi (1.1.0)
+      ffi (~> 1.9)
     librariesio-gem-parser (1.0.0)
     license-compatibility (2.0.0)
     listen (3.1.5)
@@ -596,6 +598,7 @@ DEPENDENCIES
   jquery-rails
   js_cookie_rails
   json_spec
+  levenshtein-ffi
   license-compatibility
   listen
   lograge

--- a/app/controllers/experiments/similar_names_controller.rb
+++ b/app/controllers/experiments/similar_names_controller.rb
@@ -1,0 +1,7 @@
+module Experiments
+  class SimilarNamesController < ApplicationController
+    def index
+      @projects = Project.joins(:similar_names).order('created_at DESC').paginate(page: params[:page])
+    end
+  end
+end

--- a/app/models/similar_name.rb
+++ b/app/models/similar_name.rb
@@ -1,0 +1,3 @@
+class SimilarName < ApplicationRecord
+  belongs_to :project
+end

--- a/app/views/experiments/similar_names/index.html.erb
+++ b/app/views/experiments/similar_names/index.html.erb
@@ -1,0 +1,51 @@
+<% title "Possible Typosquatted Libraries" %>
+<% description "Recently created libraries with similar names to existing libraries" %>
+<div class="row">
+  <h1><i class="fa fa-user-secret"></i> Possible Typosquatted Libraries</h1>
+</div>
+<hr>
+
+<div class="row">
+  <div class="col-sm-8">
+
+    <% @projects.each do |project| %>
+      <div class='project' style="border-color: <%= project.color %>;">
+        <h5>
+          <%= link_to project.name, project_path(project.to_param) %>
+          <small><%= project.latest_release_number %></small>
+        </h5>
+
+        <div class="">
+          <%= truncate project.description, :length => 100 %>
+        </div>
+
+        <small>
+          <%= link_to project.platform_name, platform_path(project.platform.downcase) %> -
+          Similar to:
+          <% project.similar_names.first.matches.first(10).each do |name| %>
+            <%= link_to name, project_path(platform: project.platform.downcase, name: name) %>,
+          <% end %>
+        </small>
+      </div>
+    <% end %>
+
+    <%= will_paginate @projects, page_links: false %>
+    <p>
+      <small><%= page_entries_info @projects, model: 'libraries' %></small>
+    </p>
+  </div>
+  <div class="col-sm-4">
+    <%= render 'adsense/sidebar' %>
+    <h3>
+      <strong>
+        What's typosquatting?
+      </strong>
+    </h3>
+    <p>Malicous users will sometimes publish libraries with very similar names to existing, popular libraries.
+      They hope that some users will type the wrong name of the package and install their version instead.</p>
+
+    <p>This page highlights newly published packages that have names that are similar to existing packages, calculated using Levenshtein distance.</p>
+
+    <p>You can read more about typosquatted packages in this excellent blog post on the subject: <%= link_to 'http://incolumitas.com/2016/06/08/typosquatting-package-managers/' %> </p>
+  </div>
+</div>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -45,7 +45,7 @@
           <li><%= link_to 'Bus Factor', bus_factor_path %></li>
           <li><%= link_to 'Digital Infrastructure', digital_infrastructure_path %></li>
           <li><%= link_to 'Unseen Infrastructure', unseen_infrastructure_path %></li>
-          <li><%= link_to 'Typosquatted Libraries', unseen_infrastructure_path %></li>
+          <li><%= link_to 'Typosquatted Libraries', similar_names_path %></li>
         </ul>
         <ul class='list-unstyled'>
           <li><strong><%= link_to 'About', '/about' %></strong></li>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -45,6 +45,7 @@
           <li><%= link_to 'Bus Factor', bus_factor_path %></li>
           <li><%= link_to 'Digital Infrastructure', digital_infrastructure_path %></li>
           <li><%= link_to 'Unseen Infrastructure', unseen_infrastructure_path %></li>
+          <li><%= link_to 'Typosquatted Libraries', unseen_infrastructure_path %></li>
         </ul>
         <ul class='list-unstyled'>
           <li><strong><%= link_to 'About', '/about' %></strong></li>

--- a/app/views/pages/experiments.html.erb
+++ b/app/views/pages/experiments.html.erb
@@ -8,7 +8,7 @@
     </h1>
     <br>
     <p>
-       Libraries.io gathers data from <strong>33</strong> package managers and <strong>3</strong> source code repositories. We track over <strong>2.4m</strong> unique open source projects, <strong>25m</strong> repositories and <strong>121m</strong> interdependencies between them. We publish this data periodically under a creative-commons license to empower and accelerate the work of those seeking to understand and create a stronger open source ecosystem. 
+       Libraries.io gathers data from <strong>33</strong> package managers and <strong>3</strong> source code repositories. We track over <strong>2.4m</strong> unique open source projects, <strong>25m</strong> repositories and <strong>121m</strong> interdependencies between them. We publish this data periodically under a creative-commons license to empower and accelerate the work of those seeking to understand and create a stronger open source ecosystem.
     </p>
     <p>
     	This page contains a number of experiments that we have created ourselves. If you would like to feature research using Libraries.io data on this page please contact <%= mail_to 'data@libraries.io'%>.
@@ -40,7 +40,7 @@
       </div>
       <div class="panel-body">
         <p>
-          Digital infrastructure is the free and open source software contributed as a public good that underpins much of today's technology. As Nadia Edghal posed in her excellent primer <a href='http://www.fordfoundation.org/library/reports-and-studies/roads-and-bridges-the-unseen-labor-behind-our-digital-infrastructure/' target='_blank'>Roads and Bridges' for the Ford Foundation:</a> 'In order to support our digital infrastructure, we must find ways to work together'. These projects are the most-commonly depended upon open source components of over 25m repositories tracked by Libraries.io. 
+          Digital infrastructure is the free and open source software contributed as a public good that underpins much of today's technology. As Nadia Edghal posed in her excellent primer <a href='http://www.fordfoundation.org/library/reports-and-studies/roads-and-bridges-the-unseen-labor-behind-our-digital-infrastructure/' target='_blank'>Roads and Bridges' for the Ford Foundation:</a> 'In order to support our digital infrastructure, we must find ways to work together'. These projects are the most-commonly depended upon open source components of over 25m repositories tracked by Libraries.io.
         </p>
       </div>
     </div>
@@ -55,8 +55,23 @@
       </div>
       <div class="panel-body">
         <p>
-          Unseen infrastructure are projects that are among some of the most depended upon (at least 1,000 dependent repos) and yet receive very little attention and recognition. These projects may become digital infrastructure, but they are unlikely to succeed without more support. 
+          Unseen infrastructure are projects that are among some of the most depended upon (at least 1,000 dependent repos) and yet receive very little attention and recognition. These projects may become digital infrastructure, but they are unlikely to succeed without more support.
         </p>
+      </div>
+    </div>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h2 class="panel-title">
+        	<%= link_to similar_names_path do %>
+        		<%= fa_icon 'user-secret' %>
+        		Possible Typosquatted Libraries
+        	<% end %>
+       	</h2>
+      </div>
+      <div class="panel-body">
+        Malicous users will sometimes publish libraries with very similar names to existing, popular libraries.
+        They hope that some users will type the wrong name of the package and install their version instead.
+        This page highlights newly published packages that have names that are similar to existing packages, calculated using Levenshtein distance.</p>
       </div>
     </div>
   </div>
@@ -67,7 +82,7 @@
   		Libraries.io data is released periodically under a CC-BY-SA 4.0 license. For more information see our <%= link_to 'documentation', data_path %>.
   	</p>
   	<%= render 'releases'%>
-  
+
   	<h3>Subscribe to release notifications</h3>
     <p>
       Join the mailing list to be notified via email whenever we publish a new data set.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -199,6 +199,7 @@ Rails.application.routes.draw do
 
   #experiments
   get '/experiments', to: 'pages#experiments', as: :experiments
+  get '/experiments/similar-names', to: 'experiments/similar_names#index', as: :similar_names
   get '/experiments/bus-factor', to: 'projects#bus_factor', as: :bus_factor
   get '/experiments/unseen-infrastructure', to: 'projects#unseen_infrastructure', as: :unseen_infrastructure
   get '/experiments/digital-infrastructure', to: 'projects#digital_infrastructure', as: :digital_infrastructure

--- a/db/migrate/20170802120718_create_similar_names.rb
+++ b/db/migrate/20170802120718_create_similar_names.rb
@@ -1,0 +1,10 @@
+class CreateSimilarNames < ActiveRecord::Migration[5.0]
+  def change
+    create_table :similar_names do |t|
+      t.references :project, foreign_key: true
+      t.string :matches, array: true, default: []
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170607094720) do
+ActiveRecord::Schema.define(version: 20170802120718) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -355,6 +355,13 @@ ActiveRecord::Schema.define(version: 20170607094720) do
     t.index ["host_type", "uuid"], :name=>"index_repository_users_on_host_type_and_uuid", :unique=>true
   end
 
+  create_table "similar_names", force: :cascade do |t|
+    t.integer  "project_id", :index=>{:name=>"index_similar_names_on_project_id"}
+    t.string   "matches",    :default=>[], :array=>true
+    t.datetime "created_at", :null=>false
+    t.datetime "updated_at", :null=>false
+  end
+
   create_table "subscription_plans", force: :cascade do |t|
     t.integer  "amount"
     t.string   "interval"
@@ -412,4 +419,5 @@ ActiveRecord::Schema.define(version: 20170607094720) do
     t.datetime "updated_at",    :null=>false
   end
 
+  add_foreign_key "similar_names", "projects"
 end


### PR DESCRIPTION
I've added a way for Libraries to detect and record potential typo-squatted names of packages using Levenshtein distance, including a page in the Experiments section that shows recently created packages that match names of similar existing libraries.

![screen shot 2017-08-02 at 1 51 18 pm](https://user-images.githubusercontent.com/1060/28874520-18b5b1c2-778a-11e7-9af4-cefb63a31d0e.png)

Inspired by this tweet: https://twitter.com/o_cee/status/892306836199800836 and this follow up blogpost: https://iamakulov.com/notes/npm-malicious-packages/ about malicous typosquatted packages, could be useful for security researchers.