### PR TITLE
Initial work on supporting Puppet Forge packages

### DIFF
--- a/app/models/package_manager/puppet.rb
+++ b/app/models/package_manager/puppet.rb
@@ -44,8 +44,9 @@ module PackageManager
       end
     end
 
-    def self.dependencies(name, version, project)
-      metadata = project['current_release']['metadata']
+    def self.dependencies(name, version, _project)
+      release = get_json("https://forgeapi.puppetlabs.com/v3/releases/#{name}-#{version}")
+      metadata = release['metadata']
       metadata['dependencies'].map do |dependency|
         {
           project_name: dependency['name'].sub('/', '-'),

--- a/app/models/package_manager/puppet.rb
+++ b/app/models/package_manager/puppet.rb
@@ -1,0 +1,41 @@
+module PackageManager
+  class Puppet < Base
+    HAS_VERSIONS = false
+    HAS_DEPENDENCIES = false
+    BIBLIOTHECARY_SUPPORT = false
+    BIBLIOTHECARY_PLANNED = true
+    URL = 'https://forge.puppet.com'
+    COLOR = '#302B6D'
+
+    def self.project_names
+      offset = 0
+      projects = []
+      while true
+        results = get_json("https://forgeapi.puppetlabs.com/v3/modules?limit=100&offset=#{offset}")['results'].map { |result| result['slug'] }
+	break if results == []
+	projects += results
+	offset +=100
+      end
+      projects
+    end
+
+    def self.project(name)
+      get_json("https://forgeapi.puppetlabs.com/v3/modules/#{name}")
+    end
+
+    def self.mapping(project)
+      {
+        name: project['slug'],
+        homepage: "https://forge.puppet.com/#{project['slug']}",
+        repository_url: project['current_release']['metadata']['source'],
+        description: project['current_release']['metadata']['description'],
+        keywords_array: project['current_release']['tags'],
+        licenses: project['current_release']['metadata']['license']
+      }
+    end
+
+    def self.install_instructions(project, version = nil)
+      "puppet module install #{project.name}" + (version ? " --version #{version}" : "")
+    end
+  end
+end

--- a/lib/tasks/download.rake
+++ b/lib/tasks/download.rake
@@ -47,6 +47,11 @@ namespace :download do
     PackageManager::Clojars.import_recent
   end
 
+  desc 'Download all Puppet packages asynchronously'
+  task puppet_all: :environment do
+    PackageManager::Puppet.import_async
+  end
+
   desc 'Download recent CPAN packages asynchronously'
   task cpan: :environment do
     PackageManager::CPAN.import_recent_async

--- a/spec/models/package_manager/puppet_spec.rb
+++ b/spec/models/package_manager/puppet_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe PackageManager::Puppet do
+  let(:project) { create(:project, name: 'foo-bar', platform: described_class.name) }
+
+  it 'has formatted name of "Puppet"' do
+    expect(described_class.formatted_name).to eq('Puppet')
+  end
+
+  describe '#package_link' do
+    it 'returns a link to project website' do
+      expect(described_class.package_link(project)).to eq("https://forge.puppet.com/foo/bar")
+    end
+
+    it 'handles version' do
+      expect(described_class.package_link(project, '2.0.0')).to eq("https://forge.puppet.com/foo/bar/2.0.0")
+    end
+  end
+
+  describe 'download_url' do
+    it 'returns a link to project tarball' do
+      expect(described_class.download_url('foo', '1.0.0')).to eq("https://forge.puppet.com/v3/files/foo-bar-1.0.0.tar.gz")
+    end
+  end
+
+  describe '#install_instructions' do
+    it 'returns a command to install the project' do
+      expect(described_class.install_instructions(project)).to eq("puppet module install foo-bar")
+    end
+
+    it 'handles version' do
+      expect(described_class.install_instructions(project, '2.0.0')).to eq("puppet module install foo-bar --version 2.0.0")
+    end
+  end
+end


### PR DESCRIPTION
This is pretty much just the minimal methods implemented, but lots of
the others are possible based on the capabilities of the API.

This aims to address #1026 

I'll follow up with additional commits to flesh out the other methods when I get a moment but this imports Puppet package details locally.