### PR TITLE
Add sort/language params to search documentation.

### DIFF
--- a/app/views/api/docs/index.html.erb
+++ b/app/views/api/docs/index.html.erb
@@ -165,9 +165,14 @@
     </p>
     <hr>
     <p>
-      The search endpoint accepts a <code>languages</code> parameter, which may be any of
-      platforms supported by libraries.io.
+      The search endpoint accepts number of other parameters to filter results:
     </p>
+    <ul>
+      <li><code>languages</code></li>
+      <li><code>licenses</code></li>
+      <li><code>keywords</code></li>
+      <li><code>platforms</code></li>
+    </ul>
     <hr>
     <p>
       Example: <strong> <%= link_to "https://libraries.io/api/search?q=grunt&api_key=#{@api_key}", "https://libraries.io/api/search?q=grunt&api_key=#{@api_key}" %> </strong>

--- a/app/views/api/docs/index.html.erb
+++ b/app/views/api/docs/index.html.erb
@@ -154,6 +154,22 @@
     </p>
     <hr>
     <p>
+      The search endpoint accepts a <code>sort</code> parameter, one of
+        <code>rank</code>,
+        <code>stars</code>,
+        <code>dependents_count</code>,
+        <code>dependent_repos_count</code>,
+        <code>latest_release_published_at</code>,
+        <code>contributions_count</code>,
+        <code>created_at</code>.
+    </p>
+    <hr>
+    <p>
+      The search endpoint accepts a <code>languages</code> parameter, which may be any of
+      platforms supported by libraries.io.
+    </p>
+    <hr>
+    <p>
       Example: <strong> <%= link_to "https://libraries.io/api/search?q=grunt&api_key=#{@api_key}", "https://libraries.io/api/search?q=grunt&api_key=#{@api_key}" %> </strong>
     </p>
     <% cache "api-docs-#{@cache_version}-project-search", :expires_in => 1.day do %>


### PR DESCRIPTION
I've added some content to the "project search" section of the API docs that tells the reader they can specify the `sort` and `languages` parameters, with some example values.  Styling probably leaves something to be desired though... happy to refactor to taste. 