### PR TITLE
Read only mode enabled by ENV var, fixes #1801

### DIFF
--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -12,6 +12,12 @@ class Api::ApplicationController < ApplicationController
 
   private
 
+  def disabled_in_read_only
+    if in_read_only_mode?
+      render json: { error: "Error 503, Can't perform this action, the site is in read-only mode temporarily." }, status: :service_unavailable
+    end
+  end
+
   def max_page
     1000
   end

--- a/app/controllers/api/subscriptions_controller.rb
+++ b/app/controllers/api/subscriptions_controller.rb
@@ -2,6 +2,7 @@ class Api::SubscriptionsController < Api::ApplicationController
   before_action :require_api_key
   before_action :find_project, except: :index
   before_action :find_subscription, except: [:index, :create]
+  before_action :disabled_in_read_only, only: [:create, :update, :destroy]
 
   def index
     @subscriptions = current_user.subscriptions.includes(:project)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,13 +35,21 @@ class ApplicationController < ActionController::Base
   end
 
   def ensure_logged_in
+    return if read_only
     unless logged_in?
       session[:pre_login_destination] = request.original_url
       redirect_to login_path, notice: 'You must be logged in to view this content.'
     end
   end
 
+  def read_only
+    if in_read_only_mode?
+      redirect_to root_path, notice: "Can't perform this action, the site is in read-only mode temporarily."
+    end
+  end
+
   def current_user
+    return nil if in_read_only_mode?
     return nil if session[:user_id].blank?
     @current_user ||= User.includes(:identities).find_by_id(session[:user_id])
   end
@@ -234,5 +242,9 @@ class ApplicationController < ActionController::Base
 
     @kind = params[:kind] || 'runtime'
     @tree_resolver = TreeResolver.new(@version, @kind, @date)
+  end
+
+  def in_read_only_mode?
+    ENV['READ_ONLY'].present?
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,6 @@
 class SessionsController < ApplicationController
   skip_before_action :verify_authenticity_token, only: [:create, :failure]
+  before_action :read_only, only: [:new, :create]
 
   def new
     if params[:host_type].present?


### PR DESCRIPTION
Set `ENV['READ_ONLY']` to true to disable all writes to the database via the web interface.

Disables any logged in actions, including logging in itself and disables three actions in the API subscriptions controller that allow changing data.

This doesn't stop incoming hooks being pushed into the redis queue, although it's assumed the workers won't be running whilst in read-only mode