### PR TITLE
Update button copy for subscribed projects

### DIFF
--- a/app/views/projects/_actions.html.erb
+++ b/app/views/projects/_actions.html.erb
@@ -38,7 +38,7 @@
 
   <% if logged_in? && subscription = current_user.subscribed_to?(@project) %>
     <div class="btn-group pull-right-lg">
-      <span class='btn btn-success'>Subscribed to <%= 'stable' unless subscription.include_prerelease? %> releases</span>
+      <span class='btn btn-success'><i class="fa fa-check" aria-hidden="true"></i>&nbsp;Already subscribed</span>
       <button type="button" class="btn btn-success dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         <span class="caret"></span>
         <span class="sr-only">Toggle Dropdown</span>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -8,7 +8,7 @@
 <div class='row'>
   <div class='col-md-8'>
     <div class="row">
-      <div class='col-md-8'>
+      <div class='col-md-7'>
         <h1>
           <%= @project %>
           <br>
@@ -22,7 +22,7 @@
           </small>
         </h1>
       </div>
-      <div class='col-md-4 sidebar'>
+      <div class='col-md-5 sidebar'>
         <%= render 'projects/actions' %>
       </div>
     </div>


### PR DESCRIPTION
- [x] Have you followed the guidelines for [contributors](http://docs.libraries.io/contributorshandbook)?
- [x] Have you checked to ensure there aren't other open pull requests on the repository for a similar change?
- [x] Is there a corresponding ticket for your pull request?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run the project with your changes locally?

- Fixes #1752

This change adds a checkmark to the "subscribe" button and updates the copy to read "Already subscribed" when a user is viewing a project they are subscribed to. As mentioned in the issue, this more clearly differentiates between the two states.

Please note that this removes the conditional that would show the word "stable." Also, the Bootstrap grid widths were adjusted to accommodate the larger button size.