### PR TITLE
Revert "Disable test for issue/pull request events from GH"

### DIFF
--- a/app/services/github_hook_handler.rb
+++ b/app/services/github_hook_handler.rb
@@ -11,11 +11,11 @@ class GithubHookHandler
         TagWorker.perform_async(payload["repository"]["full_name"])
       end
     when "issue_comment", "issues"
-      # return nil if event == "issues" && !VALID_ISSUE_ACTIONS.include?(payload["action"])
-      #
-      # IssueWorker.perform_async('GitHub', payload["repository"]["full_name"], payload["issue"]["number"], 'issue', nil)
+      return nil if event == "issues" && !VALID_ISSUE_ACTIONS.include?(payload["action"])
+
+      IssueWorker.perform_async('GitHub', payload["repository"]["full_name"], payload["issue"]["number"], 'issue', nil)
     when "pull_request"
-      # IssueWorker.perform_async('GitHub', payload["repository"]["full_name"], payload["pull_request"]["number"], 'pull_request', nil)
+      IssueWorker.perform_async('GitHub', payload["repository"]["full_name"], payload["pull_request"]["number"], 'pull_request', nil)
     when "push"
       GithubHookWorker.perform_async(payload["repository"]["id"], payload["sender"]["id"])
     when "public", "release", "repository"

--- a/spec/services/github_hook_handler_spec.rb
+++ b/spec/services/github_hook_handler_spec.rb
@@ -25,30 +25,30 @@ describe GithubHookHandler do
       end
     end
 
-    # describe "issue_comment event" do
-    #   it "enqueues IssueWorker" do
-    #     expect(IssueWorker).to receive(:perform_async)
-    #     subject.run("issue_comment", { "issue" => {}, "repository" => {} })
-    #   end
-    # end
-    #
-    # describe "issues event" do
-    #   context "valid action" do
-    #     it "enqueues IssueWorker" do
-    #       GithubHookHandler::VALID_ISSUE_ACTIONS.each do |action|
-    #         expect(IssueWorker).to receive(:perform_async)
-    #         subject.run("issues", { "action" => action, "issue" => {}, "repository" => {} })
-    #       end
-    #     end
-    #   end
-    #
-    #   context "invalid action" do
-    #     it "does not enqueue IssueWorker" do
-    #       expect(IssueWorker).to_not receive(:perform_async)
-    #       subject.run("issues", { "action" => "lala", "issue" => {}, "repository" => {} })
-    #     end
-    #   end
-    # end
+    describe "issue_comment event" do
+      it "enqueues IssueWorker" do
+        expect(IssueWorker).to receive(:perform_async)
+        subject.run("issue_comment", { "issue" => {}, "repository" => {} })
+      end
+    end
+
+    describe "issues event" do
+      context "valid action" do
+        it "enqueues IssueWorker" do
+          GithubHookHandler::VALID_ISSUE_ACTIONS.each do |action|
+            expect(IssueWorker).to receive(:perform_async)
+            subject.run("issues", { "action" => action, "issue" => {}, "repository" => {} })
+          end
+        end
+      end
+
+      context "invalid action" do
+        it "does not enqueue IssueWorker" do
+          expect(IssueWorker).to_not receive(:perform_async)
+          subject.run("issues", { "action" => "lala", "issue" => {}, "repository" => {} })
+        end
+      end
+    end
 
     describe "pull_request event" do
       let(:params) do


### PR DESCRIPTION
This reverts commit 96b822d584b46d60aef83918d4d46046af365be0.

Now that we have upgraded the database server we can start drinking from the full firehose again 🎉 