### PR TITLE
Be more permissive in package names in the API

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,13 +49,17 @@ Rails.application.routes.draw do
       get '/:host_type/:login', to: 'repository_users#show'
     end
 
-    get '/:platform/:name/contributors', to: 'projects#contributors', constraints: { :platform => /[\w\-]+/, :name => /[\w\.\-\%@]+/ }
-    get '/:platform/:name/:version/tree', to: 'tree#show', constraints: { :platform => /[\w\-]+/, :name => /[\w\-\%@]+/, :version => /[\w\.\-]+/ }, as: :version_tree
-    get '/:platform/:name/:version/dependencies', to: 'projects#dependencies', constraints: { :platform => /[\w\-]+/, :name => /[\w\-\%@]+/, :version => /[\w\.\-]+/ }
-    get '/:platform/:name/dependent_repositories', to: 'projects#dependent_repositories', constraints: { :platform => /[\w\-]+/, :name => /[\w\.\-\%@]+/ }
-    get '/:platform/:name/dependents', to: 'projects#dependents', constraints: { :platform => /[\w\-]+/, :name => /[\w\.\-\%@]+/ }
-    get '/:platform/:name/tree', to: 'tree#show', constraints: { :platform => /[\w\-]+/, :name => /[\w\.\-\%@]+/ }, as: :tree
-    get '/:platform/:name', to: 'projects#show', constraints: { :platform => /[\w\-]+/, :name => /[\w\.\-\%@]+/ }
+    PLATFORM_CONSTRAINT = /[\w\-]+/
+    PROJECT_CONSTRAINT = /[^\/]+/
+    VERSION_CONSTRAINT = /[\w\.\-]+/
+
+    get '/:platform/:name/contributors', to: 'projects#contributors', constraints: { :platform => PLATFORM_CONSTRAINT, :name => PROJECT_CONSTRAINT }
+    get '/:platform/:name/:version/tree', to: 'tree#show', constraints: { :platform => /[\w\-]+/, :name => PROJECT_CONSTRAINT, :version => VERSION_CONSTRAINT }, as: :version_tree
+    get '/:platform/:name/:version/dependencies', to: 'projects#dependencies', constraints: { :platform => PLATFORM_CONSTRAINT, :name => PROJECT_CONSTRAINT, :version => VERSION_CONSTRAINT }
+    get '/:platform/:name/dependent_repositories', to: 'projects#dependent_repositories', constraints: { :platform => PLATFORM_CONSTRAINT, :name => PROJECT_CONSTRAINT }
+    get '/:platform/:name/dependents', to: 'projects#dependents', constraints: { :platform => PLATFORM_CONSTRAINT, :name => PROJECT_CONSTRAINT }
+    get '/:platform/:name/tree', to: 'tree#show', constraints: { :platform => PLATFORM_CONSTRAINT, :name => PROJECT_CONSTRAINT }, as: :tree
+    get '/:platform/:name', to: 'projects#show', constraints: { :platform => PLATFORM_CONSTRAINT, :name => PROJECT_CONSTRAINT }
   end
 
   namespace :admin do

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Api::ProjectsController" do
-  let!(:project) { create(:project) }
+  let!(:project) { create(:project, name: 'foo.bar@baz:bah,name') }
   let!(:dependent_project) { create(:project) }
   let!(:version) { create(:version, project: project) }
   let!(:dependent_version) { create(:version, project: dependent_project) }


### PR DESCRIPTION
Some package names (notably java ones) have colons in their name.  Stick them in the set of allowed characters for the API similar to allowing @ in 0e7c59ecd3534badd56e14a55afca673baeeb7ff