### PR TITLE
Add API endpoint to return the sourcerank breakdown

### DIFF
--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -5,6 +5,10 @@ class Api::ProjectsController < Api::ApplicationController
     render json: @project
   end
 
+  def sourcerank
+    render json: @project.source_rank_breakdown
+  end
+
   def dependents
     dependents = paginate(@project.dependent_projects).includes(:versions, :repository)
     render json: dependents

--- a/app/views/api/docs/index.html.erb
+++ b/app/views/api/docs/index.html.erb
@@ -143,6 +143,24 @@
 <%= JSON.pretty_generate @project.contributors.paginate(page: 1).map{|p| RepositoryUserSerializer.new(p) }.as_json %></pre>
     <% end %>
 
+    <h3 id="project-sourcerank">Project SourceRank</h3>
+
+    <p>
+      Get breakdown of SourceRank score for a given project.
+    </p>
+
+    <p>
+      <code>GET https://libraries.io/api/:platform/:name/sourcerank?api_key=<%= @api_key %></code>
+    </p>
+    <hr>
+    <p>
+      Example: <strong> <%= link_to "https://libraries.io/api/npm/grunt/sourcerank?api_key=#{@api_key}", "https://libraries.io/api/npm/grunt/sourcerank?api_key=#{@api_key}" %> </strong>
+    </p>
+    <% cache "api-docs-#{@cache_version}sourcerank", :expires_in => 1.day do %>
+      <pre class='well well-small'>
+<%= JSON.pretty_generate @project.source_rank.as_json %></pre>
+    <% end %>
+
     <h3 id="project-search">Project Search</h3>
 
     <p>
@@ -431,6 +449,7 @@
       <li><a href="#project-dependents">Project Dependents</a></li>
       <li><a href="#project-dependent-repositories">Project Dependent Repositories</a></li>
       <li><a href="#project-contributors">Project Contributors</a></li>
+      <li><a href="#project-sourcerank">Project SourceRank</a></li>
       <li><a href="#project-search">Project Search</a></li>
     </ul>
     <ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,7 @@ Rails.application.routes.draw do
     PROJECT_CONSTRAINT = /[^\/]+/
     VERSION_CONSTRAINT = /[\w\.\-]+/
 
+    get '/:platform/:name/sourcerank', to: 'projects#sourcerank', constraints: { :platform => PLATFORM_CONSTRAINT, :name => PROJECT_CONSTRAINT }
     get '/:platform/:name/contributors', to: 'projects#contributors', constraints: { :platform => PLATFORM_CONSTRAINT, :name => PROJECT_CONSTRAINT }
     get '/:platform/:name/:version/tree', to: 'tree#show', constraints: { :platform => /[\w\-]+/, :name => PROJECT_CONSTRAINT, :version => VERSION_CONSTRAINT }, as: :version_tree
     get '/:platform/:name/:version/dependencies', to: 'projects#dependencies', constraints: { :platform => PLATFORM_CONSTRAINT, :name => PROJECT_CONSTRAINT, :version => VERSION_CONSTRAINT }

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -97,4 +97,32 @@ describe "Api::ProjectsController" do
       expect(response.body).to be_json_eql([].to_json)
     end
   end
+
+  describe "GET /api/:platform/:name/sourcerank", type: :request do
+    it "renders successfully" do
+      get "/api/#{project.platform}/#{project.name}/sourcerank"
+      expect(response).to have_http_status(:success)
+      expect(response.content_type).to eq('application/json')
+      expect(response.body).to be_json_eql({
+       "all_prereleases": 0,
+       "any_outdated_dependencies": 0,
+       "basic_info_present": 1,
+       "contributors": 0,
+       "dependent_projects": 0,
+       "dependent_repositories": 0,
+       "follows_semver": 1,
+       "is_deprecated": 0,
+       "is_removed": 0,
+       "is_unmaintained": 0,
+       "license_present": 1,
+       "not_brand_new": 0,
+       "one_point_oh": 1,
+       "readme_present": 0,
+       "recent_release": 1,
+       "repository_present": 0,
+       "stars": 0,
+       "subscribers": 0,
+       "versions_present": 0}.to_json)
+    end
+  end
 end


### PR DESCRIPTION
Useful for what @havocp is working on

![screen shot 2017-12-20 at 16 41 55](https://user-images.githubusercontent.com/1060/34217990-e4380d08-e5a4-11e7-9aec-645fe88b9ce0.png)
