### PR TITLE
Upgrade license-compatibility to version 3.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'foreman', require: false
 gem 'puma'
 gem 'rack-timeout'
 gem 'semantic_range'
-gem 'license-compatibility'
+gem 'license-compatibility', '3.0.0'
 gem 'escape_utils'
 gem 'mail', require: ['mail', 'mail/utilities', 'mail/parsers']
 gem 'pictogram'


### PR DESCRIPTION
Link to corresponding ticket: https://github.com/librariesio/libraries.io/issues/1928
In order to ensure that the project is using the above latest version of gem, we need to specify the same version in the Gemfile. With this, for both existing and new gem installations in the project, we will be installing version 3.0.0. Tested it though bundle install.
