### PR TITLE
Handle cocoapods license fields sometimes being a hash rather than string

### DIFF
--- a/app/models/package_manager/cocoa_pods.rb
+++ b/app/models/package_manager/cocoa_pods.rb
@@ -39,7 +39,7 @@ module PackageManager
         :name => project['name'],
         :description => project["summary"],
         :homepage => project["homepage"],
-        :licenses => project["license"],
+        :licenses => parse_license(project["license"]),
         :repository_url => repo_fallback(project['source']['git'], '')
       }
     end
@@ -50,6 +50,10 @@ module PackageManager
           :number => v.to_s
         }
       end
+    end
+
+    def self.parse_license(project_license)
+      project_license.is_a?(Hash) ? project_license["type"] : project_license
     end
   end
 end

--- a/spec/models/package_manager/cocoa_pods_spec.rb
+++ b/spec/models/package_manager/cocoa_pods_spec.rb
@@ -36,4 +36,14 @@ describe PackageManager::CocoaPods do
       expect(described_class.documentation_url('foo', '2.0.0')).to eq("http://cocoadocs.org/docsets/foo/2.0.0")
     end
   end
+
+  describe '#parse_license' do
+    it 'returns the license when its a string' do
+      expect(described_class.parse_license('foobar')).to eq("foobar")
+    end
+
+    it 'returns the license type when its a hash' do
+      expect(described_class.parse_license({'type' => 'foobar'})).to eq("foobar")
+    end
+  end
 end


### PR DESCRIPTION
Discovered whilst investigating https://github.com/librariesio/spdx/issues/42