### PR TITLE
Replace most instances of "project" and "library" text with "package"

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -172,7 +172,7 @@ module ApplicationHelper
   def project_description(project, version)
     text = project.description || project.name
     text += " - #{version}" if version
-    library_text = [project.language, "library"].compact.join(' ').with_indefinite_article
+    library_text = [project.language, "package"].compact.join(' ').with_indefinite_article
     text + " - #{library_text} on #{project.platform_name} - Libraries.io"
   end
 

--- a/app/helpers/sourcerank_helper.rb
+++ b/app/helpers/sourcerank_helper.rb
@@ -26,7 +26,7 @@ module SourcerankHelper
       one_point_oh:               '1.0.0 or greater?',
       all_prereleases:            'Prerelease?',
       stars:                      'Stars',
-      dependent_projects:         'Dependent Projects',
+      dependent_projects:         'Dependent Packages',
       dependent_repositories:     'Dependent Repositories',
       contributors:               'Contributors',
       subscribers:                'Libraries.io subscribers',
@@ -37,7 +37,7 @@ module SourcerankHelper
   def source_rank_explainations
     {
       basic_info_present:         'Description, homepage/repository link and keywords present?',
-      versions_present:           'Has the project had more than one release?',
+      versions_present:           'Has the package had more than one release?',
       follows_semver:             'Every version has a valid SemVer number',
       recent_release:             'Within the past 6 months?',
       not_brand_new:              'Existed for at least 6 months',

--- a/app/views/admin/projects/deprecated.html.erb
+++ b/app/views/admin/projects/deprecated.html.erb
@@ -1,5 +1,5 @@
 <%= render 'admin/nav' %>
-<h1>Deprecated projects</h1>
+<h1>Deprecated packages</h1>
 <%= page_entries_info @projects %>
 <div class="row">
   <div class="col-md-8">

--- a/app/views/admin/projects/index.html.erb
+++ b/app/views/admin/projects/index.html.erb
@@ -1,5 +1,5 @@
 <%= render 'admin/nav' %>
-<h1>Popular projects without repo links</h1>
+<h1>Popular packages without repo links</h1>
 <%= page_entries_info @projects %>
 <div class="row">
   <div class="col-md-8">

--- a/app/views/admin/projects/unmaintained.html.erb
+++ b/app/views/admin/projects/unmaintained.html.erb
@@ -1,5 +1,5 @@
 <%= render 'admin/nav' %>
-<h1>Unmaintained projects</h1>
+<h1>Unmaintained packages</h1>
 <%= page_entries_info @projects %>
 <div class="row">
   <div class="col-md-8">

--- a/app/views/admin/stats/graphs.html.erb
+++ b/app/views/admin/stats/graphs.html.erb
@@ -1,5 +1,5 @@
-<%= render 'admin/nav' %>
-<% title 'Admin Graphs - Libraries' %>
+ Packages <%= render 'admin/nav' %>
+<% title 'Admin Graphs - Libraries.io' %>
 <%= javascript_include_tag 'admin', 'data-turbolinks-track' => true, integrity: true %>
 
 <div class="row">
@@ -18,7 +18,7 @@
 <div class="row">
   <div class="col-md-12">
     <p>
-      <strong><%= @platform %> Projects by created_at</strong>
+      <strong><%= @platform %> Packages by created_at</strong>
     </p>
     <%= line_chart @projects %>
     <% if @versions.any? %>

--- a/app/views/admin/stats/index.html.erb
+++ b/app/views/admin/stats/index.html.erb
@@ -1,5 +1,5 @@
 <%= render 'admin/nav' %>
-<% title 'Stats - Libraries' %>
+<% title 'Stats - Libraries.io' %>
 <h1>
   Stats
 </h1>
@@ -56,7 +56,7 @@
 <div class="row">
   <%= stats_for('Users', @new_users) %>
   <%= stats_for('Subscriptions', @new_subscriptions) %>
-  <%= stats_for('Projects', @new_projects) %>
+  <%= stats_for('Packages', @new_projects) %>
   <%= stats_for('Versions', @new_versions) %>
 </div>
 

--- a/app/views/admin/stats/overview.html.erb
+++ b/app/views/admin/stats/overview.html.erb
@@ -1,5 +1,5 @@
 <%= render 'admin/nav' %>
-<% title 'Admin Overview - Libraries' %>
+<% title 'Admin Overview - Libraries.io' %>
 <div class="row">
   <div class="col-md-6">
     <h2>
@@ -7,7 +7,7 @@
     </h2>
 
     <h2>
-      <%= number_to_human Project.fast_total %> Projects
+      <%= number_to_human Project.fast_total %> Packages
     </h2>
 
     <h2>

--- a/app/views/admin/stats/repositories.html.erb
+++ b/app/views/admin/stats/repositories.html.erb
@@ -1,5 +1,5 @@
 <%= render 'admin/nav' %>
-<% title 'Repo Stats - Libraries' %>
+<% title 'Repo Stats - Libraries.io' %>
 <h1>
   Repo Stats
 </h1>

--- a/app/views/api/docs/index.html.erb
+++ b/app/views/api/docs/index.html.erb
@@ -57,7 +57,7 @@
     <h3 id='project'>Project</h3>
 
     <p>
-      Get information about a project and it's versions.
+      Get information about a package and it's versions.
     </p>
 
     <p>
@@ -91,7 +91,7 @@
     <h3 id="project-dependents">Project Dependents</h3>
 
     <p>
-      Get projects that have at least one version that depends on a given project.
+      Get packages that have at least one version that depends on a given project.
     </p>
 
 
@@ -234,7 +234,7 @@
     <h3 id="repository-projects">Repository Projects</h3>
 
     <p>
-      Get a list of projects referencing the given repository.
+      Get a list of packages referencing the given repository.
     </p>
     <p>
       <code>GET https://libraries.io/api/github/:owner/:name/projects?api_key=<%= @api_key %></code>
@@ -282,10 +282,10 @@
 <%= JSON.pretty_generate @repository_user.open_source_repositories.paginate(page: 1).as_json(except: [:id, :repository_organisation_id, :repository_user_id], methods: [:github_contributions_count, :github_id]) %></pre>
     <% end %>
 
-    <h3 id="user-projects">User Projects</h3>
+    <h3 id="user-projects">User Packages</h3>
 
     <p>
-      Get a list of projects referencing the given users repositories.
+      Get a list of packages referencing the given users repositories.
     </p>
 
     <p>
@@ -300,10 +300,10 @@
 <%= JSON.pretty_generate @repository_user.projects.includes(:versions, :repository).paginate(page: 1).map{|p| ProjectSerializer.new(p) }.as_json %></pre>
     <% end %>
 
-    <h3 id="user-project-contributions">User Project Contributions</h3>
+    <h3 id="user-project-contributions">User Packages Contributions</h3>
 
     <p>
-      Get a list of projects that the given users has contributed to.
+      Get a list of packages that the given users has contributed to.
     </p>
 
     <p>
@@ -338,7 +338,7 @@
 
     <h3 id='subscriptions-index'>User Subscriptions</h3>
     <p>
-      List projects that a user is subscribed to recieved notifications about new releases
+      List packages that a user is subscribed to recieved notifications about new releases
     </p>
 
     <p>
@@ -461,7 +461,7 @@
       <li><a href="#user">User</a></li>
       <li><a href="#user-repositories">User Repositories</a></li>
       <li><a href="#user-projects">User Projects</a></li>
-      <li><a href="#user-project-contributions">User Project Contributions</a></li>
+      <li><a href="#user-project-contributions">User Package Contributions</a></li>
       <li><a href="#user-repository-contributions">User Repository Contributions</a></li>
     </ul>
     <ul>

--- a/app/views/collections/index.html.erb
+++ b/app/views/collections/index.html.erb
@@ -1,5 +1,5 @@
 <% title "Explore - Libraries.io" %>
-<% description "Find popular and trending libraries by language and keyword" %>
+<% description "Find popular and trending packages by language and keyword" %>
 
 <h1>
   <%= fa_icon 'binoculars' %>
@@ -24,7 +24,7 @@
             <% next if keyword.blank? %>
             <li>
               <a href="/explore/<%= ERB::Util.url_encode(language.downcase) %>-<%= keyword %>-libraries">
-                <%= keyword %> libraries
+                <%= keyword %> packages
               </a>
             </li>
           <% end %>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -1,9 +1,9 @@
-<% title "#{params[:keywords]}  #{params[:keyword]} libraries written in #{@language} - Libraries.io" %>
-<% description "Find popular and trending #{params[:keywords]} #{params[:keyword]} libraries written in #{@language}" %>
+<% title "#{params[:keywords]}  #{params[:keyword]} packages written in #{@language} - Libraries.io" %>
+<% description "Find popular and trending #{params[:keywords]} #{params[:keyword]} packages written in #{@language}" %>
 
 <h1>
   <div class="pictogram pictogram-lg pictogram-<%= @language.downcase %>"></div>
-  <%= params[:keywords] %> <%= params[:keyword] %> libraries written in <%= @language %>
+  <%= params[:keywords] %> <%= params[:keyword] %> packages written in <%= @language %>
 </h1>
 
 <div class="col-sm-8">

--- a/app/views/dashboard/_monitoring_promo.html.erb
+++ b/app/views/dashboard/_monitoring_promo.html.erb
@@ -1,10 +1,10 @@
 <p>
   Libraries.io can automatically keep track of all
-  of the libraries that your repositories depend upon across many different package managers.
+  of the packages that your repositories depend upon across many different package managers.
 </p>
 <p>
   Once synced, Libraries.io will email you about new versions of your dependencies,
-  if you add or remove a new dependency it will change the notifications settings for that library
+  if you add or remove a new dependency it will change the notifications settings for that package
   as soon as you push to your repositories.
 </p>
 <p><strong>Supported Package Managers:</strong></p>

--- a/app/views/dashboard/home.html.erb
+++ b/app/views/dashboard/home.html.erb
@@ -9,12 +9,12 @@
           <% if current_user.muted_projects.length > 0 %>
             <% if params[:include_muted].present? %>
               Showing <%= pluralize current_user.muted_projects.length, 'muted project' %> -
-              <%= link_to 'Hide muted projects', url_for(params.except(:include_muted).permit!) %> -
+              <%= link_to 'Hide muted packages', url_for(params.except(:include_muted).permit!) %> -
             <% else %>
               Not showing <%= pluralize current_user.muted_projects.length, 'muted project' %> -
-              <%= link_to 'Show muted projects', url_for(params.except(:host).merge(include_muted: true).permit!) %> -
+              <%= link_to 'Show muted packages', url_for(params.except(:host).merge(include_muted: true).permit!) %> -
             <% end %>
-            <%= link_to 'Manage muted projects', muted_path %> -
+            <%= link_to 'Manage muted packages', muted_path %> -
           <% end %>
           <%= link_to 'Manage your subscriptions', subscriptions_path %>
         </small>
@@ -30,8 +30,8 @@
     <% else %>
       <h2>Hi there <%= current_user %>!</h2>
       <p>
-        Libraries.io lets you watch libraries that you depend on and notifies you when there's a new release.
-        When you follow a library, new releases will show up here in your newsfeed.
+        Libraries.io lets you watch packages that you depend on and notifies you when there's a new release.
+        When you follow a package, new releases will show up here in your newsfeed.
       </p>
       <%= render 'dashboard/monitoring_promo' %>
     <% end %>
@@ -42,7 +42,7 @@
       <%= render 'dashboard/monitoring_promo' %>
     <% end %>
     <h3>
-      Recommended Libraries
+      Recommended Packages
       <small>
         <%= link_to 'See more &raquo;'.html_safe, recommendations_path %>
       </small>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -104,11 +104,11 @@
       <h5>How does this work?</h5>
       <p>
         With the help of a webhook, Libraries.io can automatically keep track of all
-        of the libraries that your repositories depends upon across many different package managers.
+        of the packages that your repositories depends upon across many different package managers.
       </p>
       <p>
         Once synced, Libraries.io will email you about new versions of your dependencies,
-        if you add or remove a new dependency it will change the notifications settings for that library
+        if you add or remove a new dependency it will change the notifications settings for that package
         as soon as you push to your repositories.
       </p>
       <p><strong>Supported Package Managers:</strong></p>

--- a/app/views/dashboard/muted.html.erb
+++ b/app/views/dashboard/muted.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-md-12">
-    <h2>Muted Projects</h2>
+    <h2>Muted Packages</h2>
     <br>
   </div>
 </div>

--- a/app/views/dependencies/_flags.html.erb
+++ b/app/views/dependencies/_flags.html.erb
@@ -1,14 +1,14 @@
 <% if dependency.project.is_removed? %>
-  <%= fa_icon 'exclamation-triangle', class: 'text-danger tip', title: "This project is no longer available on #{dependency.project.platform}" %>
+  <%= fa_icon 'exclamation-triangle', class: 'text-danger tip', title: "This package is no longer available on #{dependency.project.platform}" %>
 <% elsif dependency.project.is_deprecated? %>
-  <%= fa_icon 'exclamation-triangle', class: 'text-danger tip', title: 'This project has been marked as deprecated' %>
+  <%= fa_icon 'exclamation-triangle', class: 'text-danger tip', title: 'This package has been marked as deprecated' %>
 <% elsif dependency.project.is_unmaintained? %>
-  <%= fa_icon 'exclamation-triangle', class: 'text-danger tip', title: 'This project is no longer maintained' %>
+  <%= fa_icon 'exclamation-triangle', class: 'text-danger tip', title: 'This package is no longer maintained' %>
 <% elsif dependency.outdated? %>
   <%= fa_icon 'exclamation-triangle', class: 'text-warning tip', title: 'Out of date version' %>
 <% end %>
 <% if !dependency.project.license_present? %>
-  <%= fa_icon 'exclamation-triangle', class: 'text-warning tip', title: "This project doesn't appear to have a license" %>
+  <%= fa_icon 'exclamation-triangle', class: 'text-warning tip', title: "This package doesn't appear to have a license" %>
 <% elsif dependency.incompatible_license? %>
-  <%= fa_icon 'exclamation-triangle', class: 'text-info tip', title: 'This project may have a conflicting license' %>
+  <%= fa_icon 'exclamation-triangle', class: 'text-info tip', title: 'This package may have a conflicting license' %>
 <% end %>

--- a/app/views/explore/index.html.erb
+++ b/app/views/explore/index.html.erb
@@ -1,5 +1,5 @@
 <% title "Explore - Libraries.io" %>
-<% description "Find trending and popular libraries and repositories" %>
+<% description "Find trending and popular packages and repositories" %>
 
 <div class="row">
   <div class="col-md-12">
@@ -38,7 +38,7 @@
           <%= render @trending_projects, cache: true %>
         <% end %>
         <%= link_to trending_projects_path, class: 'text-muted' do %>
-          See more trending projects &raquo;
+          See more trending packages &raquo;
         <% end %>
       </div>
       <div class="tab-pane" id="new_projects">
@@ -46,7 +46,7 @@
           <%= render @new_projects, cache: true %>
         <% end %>
         <%= link_to search_path(sort: 'created_at'), class: 'text-muted' do %>
-          See more new projects &raquo;
+          See more new packages &raquo;
         <% end %>
       </div>
       <div class="tab-pane" id="dependend_projects">
@@ -54,7 +54,7 @@
           <%= render project_search('dependents_count'), cache: true %>
         <% end %>
         <%= link_to search_path(sort: 'dependents_count'), class: 'text-muted' do %>
-          See more most used projects &raquo;
+          See more most used packages &raquo;
         <% end %>
       </div>
     </div>

--- a/app/views/keywords/_keyword.html.erb
+++ b/app/views/keywords/_keyword.html.erb
@@ -3,7 +3,7 @@
     <h4>
       <div class="blurb">
         <%= link_to keyword['key'], keyword_path(keyword['key']) %>
-        <small><%= number_to_human keyword['doc_count'] %> Projects</small>
+        <small><%= number_to_human keyword['doc_count'] %> Packages</small>
       </div>
     </h4>
   </div>

--- a/app/views/keywords/index.html.erb
+++ b/app/views/keywords/index.html.erb
@@ -1,5 +1,5 @@
 <% title "Keywords - Libraries.io" %>
-<% description "All the Keywords that projects have been tagged with" %>
+<% description "All the Keywords that packages have been tagged with" %>
 <h1>
   <%= fa_icon 'tags' %>
   Keywords

--- a/app/views/keywords/show.html.erb
+++ b/app/views/keywords/show.html.erb
@@ -1,13 +1,13 @@
-<% title "Projects tagged with '#{@keyword}' - Libraries.io" %>
-<% description "A detailed listing of the most popular, recently updated and most watched #{@keyword} projects online" %>
-<% content_for :atom, auto_discovery_link_tag(:atom, search_url(keywords: @keyword, sort: 'latest_release_published_at', order: 'desc', format: :atom), title: "Updated #{@keyword} Projects") %>
-<% content_for :atom, auto_discovery_link_tag(:atom, search_url(keywords: @keyword, sort: 'created_at', order: 'desc', format: :atom), title: "New #{@keyword} Projects") %>
+<% title "Packages tagged with '#{@keyword}' - Libraries.io" %>
+<% description "A detailed listing of the most popular, recently updated and most watched #{@keyword} packages online" %>
+<% content_for :atom, auto_discovery_link_tag(:atom, search_url(keywords: @keyword, sort: 'latest_release_published_at', order: 'desc', format: :atom), title: "Updated #{@keyword} Packages") %>
+<% content_for :atom, auto_discovery_link_tag(:atom, search_url(keywords: @keyword, sort: 'created_at', order: 'desc', format: :atom), title: "New #{@keyword} Packages") %>
 
 <% cache([@keyword, 'keywords:show', 'v1'], :expires_in => 1.hour) do %>
 <div class="row">
   <div class="col-sm-6">
     <h1>
-      Projects tagged with "<%= @keyword %>"
+      Packages tagged with "<%= @keyword %>"
     </h1>
   </div>
   <div class="col-sm-6">
@@ -25,7 +25,7 @@
       <% if @popular.any? %>
       <div class='col-sm-6 platform-column'>
         <h4>
-          Popular "<%= @keyword %>" Projects
+          Popular "<%= @keyword %>" Packages
           <small class='more'>
             <%= link_to 'See more &raquo;'.html_safe, search_path(keywords: @keyword, sort: 'rank', order: 'desc') %>
           </small>
@@ -40,7 +40,7 @@
           <%= link_to search_url(keywords: @keyword, sort: 'created_at', order: 'desc', format: :atom), class: 'rss' do %>
             <%= fa_icon "rss-square" %>
           <% end %>
-          New "<%= @keyword %>" Projects
+          New "<%= @keyword %>" Packages
           <small class='more'>
             <%= link_to 'See more &raquo;'.html_safe, search_path(keywords: @keyword, sort: 'created_at', order: 'desc') %>
           </small>
@@ -55,7 +55,7 @@
           <%= link_to search_url(keywords: @keyword, sort: 'latest_release_published_at', order: 'desc', format: :atom), class: 'rss' do %>
             <%= fa_icon "rss-square" %>
           <% end %>
-          Updated "<%= @keyword %>" Projects
+          Updated "<%= @keyword %>" Packages
           <small class='more'>
             <%= link_to 'See more &raquo;'.html_safe, search_path(keywords: @keyword, sort: 'latest_release_published_at', order: 'desc') %>
           </small>
@@ -66,21 +66,21 @@
 
       <% if @watched.any? %>
       <div class='col-sm-6 platform-column'>
-        <h4>Most Watched "<%= @keyword %>" Projects</h4>
+        <h4>Most Watched "<%= @keyword %>" Packages</h4>
         <%= render @watched, cache: true %>
       </div>
       <% end %>
 
       <% if @dependent_repos.any? %>
         <div class='col-sm-6 platform-column'>
-          <h4>Most Used "<%= @keyword %>" Projects</h4>
+          <h4>Most Used "<%= @keyword %>" Packages</h4>
           <%= render @dependent_repos, cache: true %>
         </div>
       <% end %>
 
       <% if @dependend.any? %>
         <div class='col-md-6 platform-column'>
-          <h4>Most Depended upon "<%= @keyword %>" Projects</h4>
+          <h4>Most Depended upon "<%= @keyword %>" Packages</h4>
           <%= render @dependend, cache: true %>
         </div>
       <% end %>

--- a/app/views/languages/_language.html.erb
+++ b/app/views/languages/_language.html.erb
@@ -3,7 +3,7 @@
     <div class="pictogram pictogram-<%= language['key'].downcase %>"></div>
     <div class="blurb">
       <%= link_to language['key'], language_path(language['key']) %>
-      <small><%= number_to_human language['doc_count'] %> Projects</small>
+      <small><%= number_to_human language['doc_count'] %> Packages</small>
     </div>
   </h4>
 </div>

--- a/app/views/languages/index.html.erb
+++ b/app/views/languages/index.html.erb
@@ -1,5 +1,5 @@
 <% title "Languages - Libraries.io" %>
-<% description "All the programming languages that projects have been written in." %>
+<% description "All the programming languages that packages have been written in." %>
 <h1>
   <%= fa_icon 'code' %>
   Languages

--- a/app/views/languages/show.html.erb
+++ b/app/views/languages/show.html.erb
@@ -1,7 +1,7 @@
 <% title "#{@language} - Libraries.io" %>
-<% description "A detailed listing of the most popular, recently updated and most watched #{@language} projects online" %>
-<% content_for :atom, auto_discovery_link_tag(:atom, search_url(languages: @language, sort: 'latest_release_published_at', order: 'desc', format: :atom), title: "Updated #{@language} Projects") %>
-<% content_for :atom, auto_discovery_link_tag(:atom, search_url(languages: @language, sort: 'created_at', order: 'desc', format: :atom), title: "New #{@language} Projects") %>
+<% description "A detailed listing of the most popular, recently updated and most watched #{@language} packages online" %>
+<% content_for :atom, auto_discovery_link_tag(:atom, search_url(languages: @language, sort: 'latest_release_published_at', order: 'desc', format: :atom), title: "Updated #{@language} Packages") %>
+<% content_for :atom, auto_discovery_link_tag(:atom, search_url(languages: @language, sort: 'created_at', order: 'desc', format: :atom), title: "New #{@language} Packages") %>
 
 <% cache([@language, 'languages:show', 'v1'], :expires_in => 1.hour) do %>
 <div class="row">
@@ -27,7 +27,7 @@
       <% if @popular.any? %>
       <div class='col-sm-6 platform-column'>
         <h4>
-          Popular <%= @language %> Projects
+          Popular <%= @language %> Packages
           <small class='more'>
             <%= link_to 'See more &raquo;'.html_safe, search_path(languages: @language, sort: 'rank', order: 'desc') %>
           </small>
@@ -42,7 +42,7 @@
           <%= link_to search_url(languages: @language, sort: 'created_at', order: 'desc', format: :atom), class: 'rss' do %>
             <%= fa_icon "rss-square" %>
           <% end %>
-          New <%= @language %> Projects
+          New <%= @language %> Packages
           <%= link_to 'See more &raquo;'.html_safe, search_path(languages: @language, sort: 'created_at', order: 'desc') %>
         </h4>
         <%= render @created, cache: true %>
@@ -54,7 +54,7 @@
           <%= link_to search_url(languages: @language, sort: 'latest_release_published_at', order: 'desc', format: :atom), class: 'rss' do %>
             <%= fa_icon "rss-square" %>
           <% end %>
-          Updated <%= @language %> Projects
+          Updated <%= @language %> Packages
           <small>
             <%= link_to 'See more &raquo;'.html_safe, search_path(languages: @language, sort: 'latest_release_published_at', order: 'desc') %>
           </small>
@@ -64,19 +64,19 @@
       <% end %>
       <% if @watched.any? %>
         <div class='col-sm-6 platform-column'>
-          <h4>Most Watched <%= @language %> Projects</h4>
+          <h4>Most Watched <%= @language %> Packages</h4>
           <%= render @watched, cache: true %>
         </div>
       <% end %>
       <% if @dependent_repos.any? %>
         <div class='col-sm-6 platform-column'>
-          <h4>Most Used <%= @language %> Projects</h4>
+          <h4>Most Used <%= @language %> Packages</h4>
           <%= render @dependent_repos, cache: true %>
         </div>
       <% end %>
       <% if @dependend.any? %>
         <div class='col-sm-6 platform-column'>
-          <h4>Most Depended upon <%= @language %> Projects</h4>
+          <h4>Most Depended upon <%= @language %> Packages</h4>
           <%= render @dependend, cache: true %>
         </div>
       <% end %>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -3,7 +3,7 @@
     <div class='row'>
       <div class="col-xs-12 col-sm-6 col-md-4">
           <p>
-            <%= link_to 'Libraries', root_path %> helps you find new open source libraries, modules and frameworks and keep track of ones you depend upon.
+            <%= link_to 'Libraries.io', root_path %> helps you find new open source packages, modules and frameworks and keep track of ones you depend upon.
           </p>
           <p>
             <a href="https://twitter.com/librariesio" title='Twitter'><%= fa_icon('twitter') %></a>&nbsp;
@@ -30,7 +30,7 @@
           <li><%= link_to 'Licenses', '/licenses' %></li>
           <li><%= link_to 'Help Wanted', help_wanted_path %></li>
           <li><%= link_to 'First Pull Request', first_pull_request_path %></li>
-          <li><%= link_to 'Unlicensed Libraries', unlicensed_path %></li>
+          <li><%= link_to 'Unlicensed Packages', unlicensed_path %></li>
           <li><%= link_to 'Trending Repositories', trending_path %></li>
         </ul>
         <strong><%= link_to 'Experiments', '/experiments' %></strong>
@@ -52,7 +52,7 @@
       <div class="col-xs-12 col-sm-6 col-md-4">
         <form action="//libraries.us10.list-manage.com/subscribe/post?u=15c11768c94674bc6f18d079f&amp;id=848ac04a44" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="navbar-form" novalidate>
           <p>
-            Subscribe to the Libraries newsletter:
+            Subscribe to the Libraries.io newsletter:
           </p>
           <input type="email" value="" name="EMAIL" size='20' placeholder='Your email...' class="form-control" id="mce-EMAIL">
           <div style="position: absolute; left: -5000px;"><input type="text" name="b_15c11768c94674bc6f18d079f_848ac04a44" tabindex="-1" value=""></div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true %>
   <title><%= content_for?(:title) ? content_for(:title) : "Libraries.io - The Open Source Discovery Service" %></title>
-  <meta name="description" content="<%= content_for?(:description) ? content_for(:description) : "Discover open source libraries, modules and frameworks you can use in your code." %>">
+  <meta name="description" content="<%= content_for?(:description) ? content_for(:description) : "Discover open source packages, modules and frameworks you can use in your code." %>">
   <%= csrf_meta_tags %>
   <%= content_for :atom %>
   <link rel="apple-touch-icon-precomposed" sizes="57x57" href="/apple-touch-icon-57x57.png" />
@@ -49,7 +49,7 @@
       "@type": "WebSite",
       "name": "Libraries.io",
       "url": "https://libraries.io/",
-      "description": "Discover open source libraries, modules and frameworks you can use in your code",
+      "description": "Discover open source packages, modules and frameworks you can use in your code",
       "license": "https://github.com/librariesio/libraries.io/blob/master/LICENSE.txt",
       "potentialAction": {
         "@type": "SearchAction",
@@ -63,7 +63,7 @@
       "@context": "http://schema.org",
       "@type": "Organization",
       "name": "Libraries.io",
-      "description": "Discover open source libraries, modules and frameworks you can use in your code",
+      "description": "Discover open source packages, modules and frameworks you can use in your code",
       "url": "https://libraries.io/",
       "logo": "https://libraries.io/apple-touch-icon-152x152.png",
       "email": "support@libraries.io",

--- a/app/views/licenses/_license.html.erb
+++ b/app/views/licenses/_license.html.erb
@@ -2,7 +2,7 @@
   <h4>
     <div class="blurb">
       <%= link_to format_license(license['key']), license_path(license['key']) %>
-      <small><%= number_to_human license['doc_count'] %> Projects</small>
+      <small><%= number_to_human license['doc_count'] %> Packages</small>
     </div>
   </h4>
 </div>

--- a/app/views/licenses/index.html.erb
+++ b/app/views/licenses/index.html.erb
@@ -1,5 +1,5 @@
 <% title "Licenses - Libraries.io" %>
-<% description "All the open source licenses that projects have been licensed with" %>
+<% description "All the open source licenses that packages have been licensed with" %>
 <h1>
   <%= fa_icon 'gavel' %>
   Open Source Licenses

--- a/app/views/licenses/show.html.erb
+++ b/app/views/licenses/show.html.erb
@@ -1,7 +1,7 @@
 <% title "#{@license.name} license - Libraries.io" %>
-<% description "A detailed listing of the most popular, recently updated and most watched #{@license.name} licensed projects online" %>
-<% content_for :atom, auto_discovery_link_tag(:atom, search_url(licenses: @license.id, sort: 'latest_release_published_at', order: 'desc', format: :atom), title: "Updated #{@license.id} Projects") %>
-<% content_for :atom, auto_discovery_link_tag(:atom, search_url(licenses: @license.id, sort: 'created_at', order: 'desc', format: :atom), title: "New #{@license.id} Projects") %>
+<% description "A detailed listing of the most popular, recently updated and most watched #{@license.name} licensed packages online" %>
+<% content_for :atom, auto_discovery_link_tag(:atom, search_url(licenses: @license.id, sort: 'latest_release_published_at', order: 'desc', format: :atom), title: "Updated #{@license.id} Packages") %>
+<% content_for :atom, auto_discovery_link_tag(:atom, search_url(licenses: @license.id, sort: 'created_at', order: 'desc', format: :atom), title: "New #{@license.id} Packages") %>
 
 <% cache([@license.id, 'licenses:show', 'v1'], :expires_in => 1.hour) do %>
 <div class="row">
@@ -33,7 +33,7 @@
       <% if @popular.any? %>
       <div class='col-sm-6 platform-column'>
         <h4>
-          Popular <%= @license.id %> Projects
+          Popular <%= @license.id %> Packages
           <small class='more'>
             <%= link_to 'See more &raquo;'.html_safe, search_path(licenses: @license.id, sort: 'rank', order: 'desc') %>
           </small>
@@ -48,7 +48,7 @@
           <%= link_to search_url(licenses: @license.id, sort: 'created_at', order: 'desc', format: :atom), class: 'rss' do %>
             <%= fa_icon "rss-square" %>
           <% end %>
-          New <%= @license.id %> Projects
+          New <%= @license.id %> Packages
           <small class='more'>
             <%= link_to 'See more &raquo;'.html_safe, search_path(licenses: @license.id, sort: 'created_at', order: 'desc') %>
           </small>
@@ -63,7 +63,7 @@
           <%= link_to search_url(licenses: @license.id, sort: 'latest_release_published_at', order: 'desc', format: :atom), class: 'rss' do %>
             <%= fa_icon "rss-square" %>
           <% end %>
-          Updated <%= @license.id %> Projects
+          Updated <%= @license.id %> Packages
           <small class='more'>
             <%= link_to 'See more &raquo;'.html_safe, search_path(licenses: @license.id, sort: 'latest_release_published_at', order: 'desc') %>
           </small>
@@ -73,21 +73,21 @@
       <% end %>
       <% if @watched.any? %>
       <div class='col-sm-6 platform-column'>
-        <h4>Most Watched <%= @license.id %> Projects</h4>
+        <h4>Most Watched <%= @license.id %> Packages</h4>
         <%= render @watched, cache: true %>
       </div>
       <% end %>
 
       <% if @dependent_repos.any? %>
         <div class='col-sm-6 platform-column'>
-          <h4>Most Used <%= @license.id %> Projects</h4>
+          <h4>Most Used <%= @license.id %> Packages</h4>
           <%= render @dependent_repos, cache: true %>
         </div>
       <% end %>
 
       <% if @dependend.any? %>
         <div class='col-sm-6 platform-column'>
-          <h4>Most Depended upon <%= @license.id %> Projects</h4>
+          <h4>Most Depended upon <%= @license.id %> Packages</h4>
           <%= render @dependend, cache: true %>
         </div>
       <% end %>

--- a/app/views/notice_mailer/tidelift.html.erb
+++ b/app/views/notice_mailer/tidelift.html.erb
@@ -4,7 +4,7 @@
 <p><strong>Libraries.io will be getting even better</strong></p>
 <p>We'll be continuing to work on Libraries.io. By coming together with Tidelift, we see opportunities to do even more interesting things that build on what we've done to date.</p>
 <p><strong>Libraries.io dependency monitoring for private repositories is now free</strong></p>
-<p>Libraries.io can automatically keep track of all of the libraries that your repositories depend upon across many different package managers. Once synced, Libraries.io will email you about new versions of your dependencies.</p>
+<p>Libraries.io can automatically keep track of all of the packages that your repositories depend upon across many different package managers. Once synced, Libraries.io will email you about new versions of your dependencies.</p>
 <p>Libraries.io monitoring of public repositories has always been free. Now, we are also providing unlimited free monitoring of private repositories! &nbsp;</p>
 <p>So feel free to go ahead and <a href="https://libraries.io/login">enable monitoring of your private repositories</a> to receive updates about your dependencies.</p>
 <p><strong>We're updating our terms of service and privacy policy</strong></p>

--- a/app/views/notice_mailer/tidelift.text.erb
+++ b/app/views/notice_mailer/tidelift.text.erb
@@ -10,7 +10,7 @@ We’ll be continuing to work on Libraries.io. By coming together with Tidelift,
 
 Libraries.io dependency monitoring for private repositories is now free
 
-Libraries.io can automatically keep track of all of the libraries that your repositories depend upon across many different package managers. Once synced, Libraries.io will email you about new versions of your dependencies.
+Libraries.io can automatically keep track of all of the packages that your repositories depend upon across many different package managers. Once synced, Libraries.io will email you about new versions of your dependencies.
 
 Libraries.io monitoring of public repositories has always been free. Now, we are also providing unlimited free monitoring of private repositories!
 

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -1,4 +1,4 @@
-<% title 'About - Libraries' %>
+<% title 'About - Libraries.io' %>
 <div class="row">
   <div class="col-sm-8">
    <h1>About</h1>
@@ -6,7 +6,7 @@
       Helping you make more informed decisions about the software you use.
     </h3>
     <p>
-      Libraries.io indexes data from <strong><%= number_with_delimiter(Project.total) %></strong> projects from <strong><%= PackageManager::Base.platforms.length %></strong> package managers. We monitor project releases, analyse each project's code, community, distribution and documentation, and we map the relationships between projects when they're declared as a dependency. The 'dependency tree' that emerges is the core of the services that we provide.
+      Libraries.io indexes data from <strong><%= number_with_delimiter(Project.total) %></strong> packages from <strong><%= PackageManager::Base.platforms.length %></strong> package managers. We monitor package releases, analyse each project's code, community, distribution and documentation, and we map the relationships between packages when they're declared as a dependency. The 'dependency tree' that emerges is the core of the services that we provide.
     </p>
     <h2>Use Libraries.io to</h2>
     <hr>
@@ -17,15 +17,15 @@
     <p>
       <%= link_to search_path, class: "btn btn-info" do %>
         <%= fa_icon 'search' %>
-        Search <%= number_with_delimiter(Project.total) %> libraries
+        Search <%= number_with_delimiter(Project.total) %> packages
       <% end %>
     </p>
     <p>
-      The majority of publication and distribution channels do not provide sufficient tools for developers to discover libraries that could be valuable to them. Similarly they do not provide adequate information for individuals to judge the merit of one library over another when they tackle similar issues or solve similar problems.
+      The majority of publication and distribution channels do not provide sufficient tools for developers to discover packages that could be valuable to them. Similarly they do not provide adequate information for individuals to judge the merit of one package over another when they tackle similar issues or solve similar problems.
     </p>
 
     <h3>
-      <strong>Monitor Your Projects</strong>
+      <strong>Monitor Your Packages</strong>
     </h3>
     <p>
       <strong>Keeping a watch while you work.</strong>
@@ -39,21 +39,21 @@
       <% else %>
         <%= link_to repositories_path, class: 'btn btn-primary' do %>
           <%= fa_icon 'github' %>
-          Manage your projects
+          Manage your repos
         <% end %>
       <% end %>
     <% elsif !current_user || current_user.github_enabled? %>
       <%= link_to repositories_path, class: 'btn btn-primary' do %>
         <%= fa_icon 'github' %>
-        Start monitoring your projects
+        Start monitoring your repos
       <% end %>
     <% end %>
     </p>
     <p>
-      The software we depend upon is constantly shifting and in need of continuous monitoring and management. By analysing libraries and understanding the relationships between them, we can automate much of this.
+      The software we depend upon is constantly shifting and in need of continuous monitoring and management. By analysing packages and understanding the relationships between them, we can automate much of this.
     </p>
     <p>
-      Similarly we can help you maintain your open source library by reflecting the state of the ecosystem back at you. Exposing the network of consumers who depend upon your software and the characteristics of the projects your software is deployed within.
+      Similarly we can help you maintain your open source package by reflecting the state of the ecosystem back at you. Exposing the network of consumers who depend upon your software and the characteristics of the packages your software is deployed within.
     </p>
 
     <h3>
@@ -78,7 +78,7 @@
     </p>
     <%- end %>
     <p>
-      Libraries.io tracks releases from <strong><%= number_with_delimiter(Project.total) %></strong> projects on <strong><%= PackageManager::Base.platforms.length %></strong> package managers in one place. Subscribe to a project and receive notifications of new versions or tags for platforms like Bower and Go that don't store release information centrally.
+      Libraries.io tracks releases from <strong><%= number_with_delimiter(Project.total) %></strong> packages on <strong><%= PackageManager::Base.platforms.length %></strong> package managers in one place. Subscribe to a package and receive notifications of new versions or tags for platforms like Bower and Go that don't store release information centrally.
     </p>
     <h2>Supported Package Managers</h2>
     <hr>
@@ -92,7 +92,7 @@
     </div>
     <h3><strong>What About Package Manager X?</strong></h3>
     <p>
-      Some package managers require compilation before parsing their dependencies, some we simply haven't got around to yet. Luckily Libraries.io is an open source project so if you need to add a new package manager then you can. You can find everything you need to get started in <a href='https://docs.libraries.io' target='_blank'>our documentation</a>.
+      Some package managers require compilation before parsing their dependencies, some we simply haven't got around to yet. Luckily Libraries.io is an open source package so if you need to add a new package manager then you can. You can find everything you need to get started in <a href='https://docs.libraries.io' target='_blank'>our documentation</a>.
     </p>
     <h2>Why Are You Doing This?</h2>
     <hr>

--- a/app/views/pages/compatibility.html.erb
+++ b/app/views/pages/compatibility.html.erb
@@ -1,4 +1,4 @@
-<% title 'About - Libraries' %>
+<% title 'About - Libraries.io' %>
 <div class="row">
   <div class="col-sm-8">
    <h1>Package Manager Compatibility Matrix</h1>
@@ -13,7 +13,7 @@
     </div>
     <h3><strong>What About Package Manager X?</strong></h3>
     <p>
-      Some package managers require compilation before parsing their dependencies, some we simply haven't got around to yet. Luckily Libraries.io is an open source project so if you need to add a new package manager then you can. You can find everything you need to get started in <a href='https://docs.libraries.io' target='_blank'>our documentation</a>.
+      Some package managers require compilation before parsing their dependencies, some we simply haven't got around to yet. Luckily Libraries.io is an open source package so if you need to add a new package manager then you can. You can find everything you need to get started in <a href='https://docs.libraries.io' target='_blank'>our documentation</a>.
     </p>
   </div>
   <div class="col-sm-4">

--- a/app/views/pages/data.html.erb
+++ b/app/views/pages/data.html.erb
@@ -8,14 +8,14 @@
     </h1>
     <br>
     <p>
-       Libraries.io gathers data from <strong>34</strong> package managers and <strong>3</strong> source code repositories. We track over <strong>2.7m</strong> unique open source projects, <strong>31m</strong> repositories and <strong>161m</strong> interdependencies between them. This gives Libraries.io a unique understanding of open source software. An understanding that we want to share with <strong>you</strong>.
+       Libraries.io gathers data from <strong>34</strong> package managers and <strong>3</strong> source code repositories. We track over <strong>2.7m</strong> unique open source packages, <strong>31m</strong> repositories and <strong>161m</strong> interdependencies between them. This gives Libraries.io a unique understanding of open source software. An understanding that we want to share with <strong>you</strong>.
     </p>
     <p>
       This page contains information on how to download, use and redistribute data from Libraries.io. For enquiries please contact <%= mail_to 'data@libraries.io'%>.
     </p>
     <h2>What is in this release?</h2>
     <p>
-      In this release you will find data about software distributed and/or crafted publicly on the Internet. You will find information about its development, its distribution and its dependencies. You will <strong>not</strong> find any information about the individuals who create and maintain these projects.
+      In this release you will find data about software distributed and/or crafted publicly on the Internet. You will find information about its development, its distribution and its dependencies. You will <strong>not</strong> find any information about the individuals who create and maintain these packages.
     </p>
     <hr>
     <h2>Licence</h2>

--- a/app/views/pages/experiments.html.erb
+++ b/app/views/pages/experiments.html.erb
@@ -8,7 +8,7 @@
     </h1>
     <br>
     <p>
-       Libraries.io gathers data from <strong>33</strong> package managers and <strong>3</strong> source code repositories. We track over <strong>2.4m</strong> unique open source projects, <strong>25m</strong> repositories and <strong>121m</strong> interdependencies between them. We publish this data periodically under a creative-commons license to empower and accelerate the work of those seeking to understand and create a stronger open source ecosystem. 
+       Libraries.io gathers data from <strong>33</strong> package managers and <strong>3</strong> source code repositories. We track over <strong>2.4m</strong> unique open source packages, <strong>25m</strong> repositories and <strong>121m</strong> interdependencies between them. We publish this data periodically under a creative-commons license to empower and accelerate the work of those seeking to understand and create a stronger open source ecosystem.
     </p>
     <p>
     	This page contains a number of experiments that we have created ourselves. If you would like to feature research using Libraries.io data on this page please contact <%= mail_to 'data@libraries.io'%>.
@@ -25,7 +25,7 @@
       </div>
       <div class="panel-body">
         <p>
-           The <%= link_to 'Bus factor', 'https://en.wikipedia.org/wiki/Bus_factor' %> is the number of key developers who would need to be incapacitated to make a project unable to proceed. This page shows libraries that are depended upon by many other libraries but have only ever had a handful of contributors commit to the project.
+           The <%= link_to 'Bus factor', 'https://en.wikipedia.org/wiki/Bus_factor' %> is the number of key developers who would need to be incapacitated to make a package unable to proceed. This page shows packages that are depended upon by many other packages but have only ever had a handful of contributors commit to the project.
         </p>
       </div>
     </div>
@@ -40,7 +40,7 @@
       </div>
       <div class="panel-body">
         <p>
-          Digital infrastructure is the free and open source software contributed as a public good that underpins much of today's technology. As Nadia Edghal posed in her excellent primer <a href='http://www.fordfoundation.org/library/reports-and-studies/roads-and-bridges-the-unseen-labor-behind-our-digital-infrastructure/' target='_blank'>Roads and Bridges' for the Ford Foundation:</a> 'In order to support our digital infrastructure, we must find ways to work together'. These projects are the most-commonly depended upon open source components of over 25m repositories tracked by Libraries.io. 
+          Digital infrastructure is the free and open source software contributed as a public good that underpins much of today's technology. As Nadia Edghal posed in her excellent primer <a href='http://www.fordfoundation.org/library/reports-and-studies/roads-and-bridges-the-unseen-labor-behind-our-digital-infrastructure/' target='_blank'>Roads and Bridges' for the Ford Foundation:</a> 'In order to support our digital infrastructure, we must find ways to work together'. These packages are the most-commonly depended upon open source components of over 25m repositories tracked by Libraries.io.
         </p>
       </div>
     </div>
@@ -55,7 +55,7 @@
       </div>
       <div class="panel-body">
         <p>
-          Unseen infrastructure are projects that are among some of the most depended upon (at least 1,000 dependent repos) and yet receive very little attention and recognition. These projects may become digital infrastructure, but they are unlikely to succeed without more support. 
+          Unseen infrastructure are packages that are among some of the most depended upon (at least 1,000 dependent repos) and yet receive very little attention and recognition. These packages may become digital infrastructure, but they are unlikely to succeed without more support.
         </p>
       </div>
     </div>
@@ -67,7 +67,7 @@
   		Libraries.io data is released periodically under a CC-BY-SA 4.0 license. For more information see our <%= link_to 'documentation', data_path %>.
   	</p>
   	<%= render 'releases'%>
-  
+
   	<h3>Subscribe to release notifications</h3>
     <p>
       Join the mailing list to be notified via email whenever we publish a new data set.

--- a/app/views/platforms/_platform.html.erb
+++ b/app/views/platforms/_platform.html.erb
@@ -3,7 +3,7 @@
     <div class="pictogram pictogram-<%= platform['key'].downcase %>"></div>
     <div class="blurb">
       <%= link_to platform_name(platform['key']), platform_path(platform['key'].downcase) %>
-      <small><%= number_to_human platform['doc_count'] %> Projects</small>
+      <small><%= number_to_human platform['doc_count'] %> Packages</small>
     </div>
   </h4>
 </div>

--- a/app/views/platforms/index.html.erb
+++ b/app/views/platforms/index.html.erb
@@ -1,5 +1,5 @@
 <% title "Platforms - Libraries.io" %>
-<% description "All the open source platforms that projects have been published to" %>
+<% description "All the open source platforms that packages have been published to" %>
 <h1>
   <%= fa_icon 'archive' %>
   Package Managers

--- a/app/views/platforms/show.html.erb
+++ b/app/views/platforms/show.html.erb
@@ -1,7 +1,7 @@
 <% title "#{platform_name(@platform_name)} - Libraries.io" %>
-<% description "A detailed listing of the most popular, recently updated and most watched #{platform_name(@platform_name)} projects online" %>
-<% content_for :atom, auto_discovery_link_tag(:atom, search_url(platforms: @platform_name, sort: 'latest_release_published_at', order: 'desc', format: :atom), title: "Updated #{platform_name(@platform_name)} Projects") %>
-<% content_for :atom, auto_discovery_link_tag(:atom, search_url(platforms: @platform_name, sort: 'created_at', order: 'desc', format: :atom), title: "New #{platform_name(@platform_name)} Projects") %>
+<% description "A detailed listing of the most popular, recently updated and most watched #{platform_name(@platform_name)} packages online" %>
+<% content_for :atom, auto_discovery_link_tag(:atom, search_url(platforms: @platform_name, sort: 'latest_release_published_at', order: 'desc', format: :atom), title: "Updated #{platform_name(@platform_name)} Packages") %>
+<% content_for :atom, auto_discovery_link_tag(:atom, search_url(platforms: @platform_name, sort: 'created_at', order: 'desc', format: :atom), title: "New #{platform_name(@platform_name)} Packages") %>
 
 <% cache([@platform_name, 'platforms:show', 'v1'], :expires_in => 1.hour) do %>
 <div class='row'>
@@ -28,7 +28,7 @@
       <% if @trending.any? %>
         <div class='col-sm-6 platform-column'>
           <h4>
-            Trending <%= platform_name(@platform_name) %> Projects
+            Trending <%= platform_name(@platform_name) %> Packages
             <small class='more'>
               <%= link_to 'See more &raquo;'.html_safe, trending_projects_path(platforms: @platform_name) %>
             </small>
@@ -40,7 +40,7 @@
       <% if @popular.any? %>
         <div class='col-sm-6 platform-column'>
           <h4>
-            Popular <%= platform_name(@platform_name) %> Projects
+            Popular <%= platform_name(@platform_name) %> Packages
             <small class='more'>
               <%= link_to 'See more &raquo;'.html_safe, search_path(platforms: @platform_name, sort: 'rank', order: 'desc') %>
             </small>
@@ -51,14 +51,14 @@
 
       <% if @dependent_repos.any? %>
         <div class='col-sm-6 platform-column'>
-          <h4>Most Used <%= platform_name(@platform_name) %> Projects</h4>
+          <h4>Most Used <%= platform_name(@platform_name) %> Packages</h4>
           <%= render @dependent_repos, cache: true %>
         </div>
       <% end %>
 
       <% if @dependend.any? %>
         <div class='col-sm-6 platform-column'>
-          <h4>Most Depended upon <%= platform_name(@platform_name) %> Projects</h4>
+          <h4>Most Depended upon <%= platform_name(@platform_name) %> Packages</h4>
           <%= render @dependend, cache: true %>
         </div>
       <% end %>
@@ -69,7 +69,7 @@
           <%= link_to search_url(platforms: @platform_name, sort: 'latest_release_published_at', order: 'desc', format: :atom), class: 'rss' do %>
             <%= fa_icon "rss-square" %>
           <% end %>
-          Updated <%= platform_name(@platform_name) %> Projects
+          Updated <%= platform_name(@platform_name) %> Packages
           <small class='more'>
             <%= link_to 'See more &raquo;'.html_safe, search_path(platforms: @platform_name, sort: 'latest_release_published_at', order: 'desc') %>
           </small>
@@ -83,7 +83,7 @@
             <%= link_to search_url(platforms: @platform_name, sort: 'created_at', order: 'desc', format: :atom), class: 'rss' do %>
               <%= fa_icon "rss-square" %>
             <% end %>
-            New <%= platform_name(@platform_name) %> Projects
+            New <%= platform_name(@platform_name) %> Packages
             <small class='more'>
               <%= link_to 'See more &raquo;'.html_safe, search_path(platforms: @platform_name, sort: 'created_at', order: 'desc') %>
             </small>
@@ -94,7 +94,7 @@
 
       <% if @watched.any? %>
           <div class='col-sm-6 platform-column'>
-            <h4>Most Watched <%= platform_name(@platform_name) %> Projects</h4>
+            <h4>Most Watched <%= platform_name(@platform_name) %> Packages</h4>
             <%= render @watched, cache: true %>
           </div>
           <div class="col-sm-6">

--- a/app/views/projects/_actions.html.erb
+++ b/app/views/projects/_actions.html.erb
@@ -51,12 +51,12 @@
         </li>
         <li role="separator" class="divider"></li>
         <li>
-          <%= link_to 'Unsubscribe from updates', subscription_path(current_user.subscribed_to?(@project)), method: :delete, class: 'text-danger', title: 'Stop being notified of new releases of this library' %>
+          <%= link_to 'Unsubscribe from updates', subscription_path(current_user.subscribed_to?(@project)), method: :delete, class: 'text-danger', title: 'Stop being notified of new releases of this package' %>
         </li>
       </ul>
     </div>
   <% elsif logged_in? %>
-    <%= link_to 'Subscribe to releases', subscribe_path(project_id: @project.id), class: 'tip btn btn-success pull-right-lg', rel: 'nofollow', title: 'Get notified by email of new releases of this library' %>
+    <%= link_to 'Subscribe to releases', subscribe_path(project_id: @project.id), class: 'tip btn btn-success pull-right-lg', rel: 'nofollow', title: 'Get notified by email of new releases of this package' %>
   <% else %>
     <%= link_to 'Subscribe to releases', subscribe_path(project_id: @project.id), class: 'tip btn btn-success pull-right-lg', rel: 'nofollow', title: 'Login to get notified by email of new releases' %>
   <% end %>

--- a/app/views/projects/_alerts.html.erb
+++ b/app/views/projects/_alerts.html.erb
@@ -6,15 +6,15 @@
 
 <% if @project.is_removed? %>
   <div class="alert alert-danger" role="alert">
-    <strong>This project has been removed from <%= @project.platform %></strong> and cannot be used anymore.
+    <strong>This package has been removed from <%= @project.platform %></strong> and cannot be used anymore.
   </div>
 <% elsif @project.is_deprecated? %>
   <div class="alert alert-danger" role="alert">
-    <strong>This project has been marked as deprecated</strong> you can use it but you might want to use an alternative.
+    <strong>This package has been marked as deprecated</strong> you can use it but you might want to use an alternative.
   </div>
 <% elsif @project.is_unmaintained? %>
   <div class="alert alert-danger" role="alert">
-    <strong>This project has been marked as unmaintained</strong> you can use it but it is no longer being updated.
+    <strong>This package has been marked as unmaintained</strong> you can use it but it is no longer being updated.
   </div>
 <% end %>
 

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -9,13 +9,13 @@
 
   <small>
     <% if project.is_removed? %>
-      <%= fa_icon('exclamation-triangle') %> This project is no longer available on <%= project.platform %>
+      <%= fa_icon('exclamation-triangle') %> This package is no longer available on <%= project.platform %>
     <% elsif project.is_deprecated? %>
-      <%= fa_icon('exclamation-triangle') %> This project is deprecated -
+      <%= fa_icon('exclamation-triangle') %> This package is deprecated -
       <%= project.versions_count > 1 ? 'Updated' : 'Published' %>
       <%= timeago_tag project.latest_release_published_at %>
     <% elsif project.is_unmaintained? %>
-      <%= fa_icon('exclamation-triangle') %> This project is no longer maintained -
+      <%= fa_icon('exclamation-triangle') %> This package is no longer maintained -
       <%= project.versions_count > 1 ? 'Updated' : 'Published' %>
       <%= timeago_tag project.latest_release_published_at %>
     <% else %>

--- a/app/views/projects/_search_form.html.erb
+++ b/app/views/projects/_search_form.html.erb
@@ -7,7 +7,7 @@
        <li>
          <%= link_to search_path(q: params[:q], sort: params[:sort]) do %>
            <%= fa_icon 'check' %>
-           Libraries
+           Packages
          <% end %>
        </li>
        <li>
@@ -19,7 +19,7 @@
      </ul>
    </div>
 
-    <%= text_field_tag 'q', "#{@query || '' }", placeholder: 'Search Libraries', class: 'form-control search-input', size: 40 %>
+    <%= text_field_tag 'q', "#{@query || '' }", placeholder: 'Search Packages', class: 'form-control search-input', size: 40 %>
     <% [:platforms, :licenses, :languages, :keywords, :sort].each do |field| %>
       <%= hidden_field_tag field, params[field] if params[field].present? %>
     <% end %>

--- a/app/views/projects/_statistics.html.erb
+++ b/app/views/projects/_statistics.html.erb
@@ -19,7 +19,7 @@
       <%= number_to_human(@project.latest_version.dependencies.kind('runtime').count) %>
     </dd>
     <dt class='col-xs-8'>
-      Dependent projects
+      Dependent Packages
     </dt>
     <dd class='col-xs-4'>
       <%= link_to number_to_human(@project.dependents_count), project_dependents_path(@project.to_param) %>

--- a/app/views/projects/_your_dependents.html.erb
+++ b/app/views/projects/_your_dependents.html.erb
@@ -1,7 +1,7 @@
 <% your_dependent_repos = current_user.your_dependent_repos(@project) %>
 <% if your_dependent_repos.length > 0 %>
   <hr>
-  <h4 data-ga-tracked-el='your-dependent-repositories'>Your Dependent Projects</h4>
+  <h4 data-ga-tracked-el='your-dependent-repositories'>Your Dependent Packages</h4>
   <dl class='row'>
     <% your_dependent_repos.limit(10).each do |repo| %>
       <dt class='col-sm-12'>

--- a/app/views/projects/bus_factor.html.erb
+++ b/app/views/projects/bus_factor.html.erb
@@ -53,13 +53,13 @@
       </strong>
     </h3>
     <p>
-      The <%= link_to 'Bus factor', 'https://en.wikipedia.org/wiki/Bus_factor' %> is the number of key developers who would need to be incapacitated to make a project unable to proceed.
+      The <%= link_to 'Bus factor', 'https://en.wikipedia.org/wiki/Bus_factor' %> is the number of key developers who would need to be incapacitated to make a package unable to proceed.
     </p>
     <p>
-      This page shows libraries that are depended upon by many other libraries but have only ever had a handful of contributors commit to the project.
+      This page shows packages that are depended upon by many other packages but have only ever had a handful of contributors commit to the project.
     </p>
     <p>
-      You can help out by reviewing the code for these projects, helping out with open issues and pull requests and lending the maintainers a helping hand if required.
+      You can help out by reviewing the code for these packages, helping out with open issues and pull requests and lending the maintainers a helping hand if required.
     </p>
     <p>
       <em>This is an experiment based on contributions and available dependency data from package manager repositories that make it easily available.</em>

--- a/app/views/projects/dependents.html.erb
+++ b/app/views/projects/dependents.html.erb
@@ -1,4 +1,4 @@
-<% title "Projects that depend on #{@project} on #{@project.platform_name} - Libraries.io" %>
+<% title "Packages that depend on #{@project} on #{@project.platform_name} - Libraries.io" %>
 
 <h1>
   <div class="pictogram pictogram-<%= @project.platform.downcase %>"></div>
@@ -6,7 +6,7 @@
 </h1>
 <hr>
 <% if @dependents.any? %>
-  <p class="lead"><strong><%= @dependents.total_entries %></strong> <%= 'projects'.pluralize(@dependents.total_entries) %> depend on <%= link_to @project, project_path(@project.to_param) %>:</p>
+  <p class="lead"><strong><%= @dependents.total_entries %></strong> <%= 'packages'.pluralize(@dependents.total_entries) %> depend on <%= link_to @project, project_path(@project.to_param) %>:</p>
 <% end %>
 
 <div class="row">
@@ -16,7 +16,7 @@
       <%= will_paginate @dependents, page_links: false %>
     <% else %>
       <p>
-        No projects found, go back to <%= link_to @project, project_path(@project.to_param) %>.
+        No packages found, go back to <%= link_to @project, project_path(@project.to_param) %>.
       </p>
     <% end %>
   </div>

--- a/app/views/projects/deprecated.html.erb
+++ b/app/views/projects/deprecated.html.erb
@@ -1,7 +1,7 @@
-<% title "#{@platform_name} Deprecated Libraries - Libraries.io" %>
-<% description "Projects marked as deprecated which are no longer maintained or suitable for use" %>
+<% title "#{@platform_name} Deprecated Packages - Libraries.io" %>
+<% description "Packages marked as deprecated which are no longer maintained or suitable for use" %>
 <div class="row">
-  <h1><i class="fa fa-clock-o"></i> <%= @platform_name %> Deprecated Libraries</h1>
+  <h1><i class="fa fa-clock-o"></i> <%= @platform_name %> Deprecated Packages</h1>
 </div>
 <hr>
 
@@ -10,7 +10,7 @@
     <%= render @projects, cache: true %>
     <%= will_paginate @projects, page_links: false %>
     <p>
-      <small><%= page_entries_info @projects, model: 'deprecated libraries' %></small>
+      <small><%= page_entries_info @projects, model: 'deprecated packages' %></small>
     </p>
   </div>
   <div class="col-sm-4">

--- a/app/views/projects/digital_infrastructure.html.erb
+++ b/app/views/projects/digital_infrastructure.html.erb
@@ -57,7 +57,7 @@
       "Shared, public code makes up the digital infrastructure of our society today. In the face of unprecedented demand, the costs of not supporting our digital infrastructure are numerous. No individual company or organisation is incentivised to address the public good problem alone. In order to support our digital infrastructure, we must find ways to work together."
     </p>
     <p>
-      You can support these projects by reviewing the code, helping out with open issues and thanking the maintainers for their hard work.
+      You can support these packages by reviewing the code, helping out with open issues and thanking the maintainers for their hard work.
     </p>
     <p>
       <em>This is an experiment based available dependency data from package manager repositories that make it easily available.</em>
@@ -74,7 +74,7 @@
                   <%= link_to platform_name(platform[0]), digital_infrastructure_path(platforms: nil, license: params[:license]) %>
                 <% else %>
                   <%= link_to platform_name(platform[0]), digital_infrastructure_path(platforms: platform_name(platform[0]), license: params[:license]) %>
-                  <small><%= pluralize number_to_human(platform[1]), 'projects' %></small>
+                  <small><%= pluralize number_to_human(platform[1]), 'packages' %></small>
                 <% end %>
               </li>
             <% end %>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -5,12 +5,12 @@
 
     <%= form_tag search_path, method: :get, class: 'search-form', enforce_utf8: false do |f| %>
       <div class="input-group input-group-lg">
-        <%= text_field_tag 'q', params[:q], placeholder: 'Search open source libraries, frameworks and tools...', class: 'form-control', autofocus: true %>
+        <%= text_field_tag 'q', params[:q], placeholder: 'Search open source packages, frameworks and tools...', class: 'form-control', autofocus: true %>
         <span class="input-group-btn">
           <button class="btn btn-primary" type="submit">Search</button>
         </span>
       </div>
-      <p class='hidden-xs'>Libraries.io monitors <strong><%= number_with_delimiter(Project.total) %></strong> open source libraries across <strong><%= PackageManager::Base.platforms.length %></strong> different package managers, so you don't have to. <%= link_to 'Find out more', about_path %>
+      <p class='hidden-xs'>Libraries.io monitors <strong><%= number_with_delimiter(Project.total) %></strong> open source packages across <strong><%= PackageManager::Base.platforms.length %></strong> different package managers, so you don't have to. <%= link_to 'Find out more', about_path %>
       </p>
       <hr>
     <% end %>
@@ -24,7 +24,7 @@
       </div>
       <div class="panel-body">
         <p>
-          Search <%= number_to_human(Project.total) %> projects by <%= link_to 'licence'.html_safe, licenses_path %>, <%= link_to 'language'.html_safe, languages_path %> or <%= link_to 'keyword'.html_safe, keywords_path %>, or explore new, trending or popular projects.
+          Search <%= number_to_human(Project.total) %> packages by <%= link_to 'licence'.html_safe, licenses_path %>, <%= link_to 'language'.html_safe, languages_path %> or <%= link_to 'keyword'.html_safe, keywords_path %>, or explore new, trending or popular packages.
         </p>
       </div>
       <div class="panel-footer"><%= link_to 'Explore', explore_path, class:'btn btn-primary center-block' %></div>

--- a/app/views/projects/removed.html.erb
+++ b/app/views/projects/removed.html.erb
@@ -1,7 +1,7 @@
-<% title "#{@platform_name} Removed Libraries - Libraries.io" %>
-<% description "Projects marked as removed which are no longer available for download" %>
+<% title "#{@platform_name} Removed Packages - Libraries.io" %>
+<% description "Packages marked as removed which are no longer available for download" %>
 <div class="row">
-  <h1><i class="fa fa-ban"></i> <%= @platform_name %> Removed Libraries</h1>
+  <h1><i class="fa fa-ban"></i> <%= @platform_name %> Removed Packages</h1>
 </div>
 <hr>
 
@@ -10,7 +10,7 @@
     <%= render @projects, cache: true %>
     <%= will_paginate @projects, page_links: false %>
     <p>
-      <small><%= page_entries_info @projects, model: 'removed libraries' %></small>
+      <small><%= page_entries_info @projects, model: 'removed packages' %></small>
     </p>
   </div>
   <div class="col-sm-4">

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -73,7 +73,7 @@
     </p>
     <p>
       <%= fa_icon 'download' %>
-      <%= link_to 'Export .ABOUT file for this library', @version.present? ? about_version_path(@project.to_param.merge(number: @version.number)) : about_project_path(@project.to_param) %>
+      <%= link_to 'Export .ABOUT file for this package', @version.present? ? about_version_path(@project.to_param.merge(number: @version.number)) : about_project_path(@project.to_param) %>
     </p>
     <p>
       <small class='text-muted'>Last synced: <%= @project.last_synced_at || @project.created_at %></small>

--- a/app/views/projects/sourcerank.html.erb
+++ b/app/views/projects/sourcerank.html.erb
@@ -40,10 +40,10 @@
       </strong>
     </h3>
     <p>
-      SourceRank is the score for a project based on a number of metrics, it's used across the site to boost high quality projects.
+      SourceRank is the score for a package based on a number of metrics, it's used across the site to boost high quality packages.
     </p>
     <p>
-      The factors are based on attributes of a project that make it appear like a dependable library and can be handy to compare different projects.
+      The factors are based on attributes of a package that make it appear like a dependable package and can be handy to compare different packages.
     </p>
     <p>
       Got a question or suggestion to improve SourceRank? Open an <%= link_to 'issue', 'https://github.com/librariesio/libraries.io/issues' %>, <%= link_to 'tweet us', 'https://twitter.com/librariesio' %> or email <%= mail_to 'support@libraries.io', 'support@libraries.io' %>

--- a/app/views/projects/top_dependent_projects.html.erb
+++ b/app/views/projects/top_dependent_projects.html.erb
@@ -2,7 +2,7 @@
   <% @top_dependent_projects = @project.dependent_projects.limit(10) %>
   <% if @top_dependent_projects.length > 0 %>
     <h4 data-ga-tracked-el='dependent-projects'>
-      <%= link_to "Dependent Libraries", project_dependents_path(@project.to_param) %>
+      <%= link_to "Dependent Packages", project_dependents_path(@project.to_param) %>
     </h4>
     <dl class='row'>
       <% if @top_dependent_projects.length > 0 %>

--- a/app/views/projects/trending.html.erb
+++ b/app/views/projects/trending.html.erb
@@ -1,5 +1,5 @@
-<% title "Trending Libraries - Libraries.io" %>
-<h1><i class="fa fa-line-chart"></i> Trending Libraries</h1>
+<% title "Trending Packages - Libraries.io" %>
+<h1><i class="fa fa-line-chart"></i> Trending Packages</h1>
 
 <div class="row">
   <div class="col-sm-8">
@@ -18,7 +18,7 @@
                   <%= link_to platform_name(platform[0]), trending_projects_path(platforms: nil, license: params[:license]) %>
                 <% else %>
                   <%= link_to platform_name(platform[0]), trending_projects_path(platforms: platform_name(platform[0]), license: params[:license]) %>
-                  <small><%= pluralize number_to_human(platform[1]), 'projects' %></small>
+                  <small><%= pluralize number_to_human(platform[1]), 'packages' %></small>
                 <% end %>
               </li>
             <% end %>

--- a/app/views/projects/unlicensed.html.erb
+++ b/app/views/projects/unlicensed.html.erb
@@ -1,7 +1,7 @@
-<% title "#{@platform_name} Libraries without licenses - Libraries.io" %>
-<% description "Help the community by encouraging the authors to add a LICENSE file to their #{@platform_name} libraries." %>
+<% title "#{@platform_name} Packages without licenses - Libraries.io" %>
+<% description "Help the community by encouraging the authors to add a LICENSE file to their #{@platform_name} packages." %>
 <div class="row">
-  <h1><i class="fa fa-copyright"></i> <%= @platform_name %> Libraries without licenses</h1>
+  <h1><i class="fa fa-copyright"></i> <%= @platform_name %> Packages without licenses</h1>
 </div>
 <hr>
 
@@ -27,7 +27,7 @@
     <% end %>
     <%= will_paginate @search, page_links: false %>
     <p>
-      <small><%= page_entries_info @search, model: 'libraries without licenses' %></small>
+      <small><%= page_entries_info @search, model: 'packages without licenses' %></small>
     </p>
   </div>
   <div class="col-sm-4 facets">
@@ -37,7 +37,7 @@
       </strong>
     </h3>
     <p>
-      Over <strong>30%</strong> of all open source libraries published aren't licensed correctly, by using a library in your code that doesn't have a license you could be in breach of copyright.
+      Over <strong>30%</strong> of all open source packages published aren't licensed correctly, by using a package in your code that doesn't have a license you could be in breach of copyright.
     </p>
     <p>
       Theoretically the author could assert copyright at any time and demand that you stop using their code.
@@ -46,7 +46,7 @@
       Code without an explicit license is protected by copyright and is by default All Rights Reserved. The person or people who wrote the code are protected as such. Any time you're using software you didn't write, licensing should be considered and abided.
     </p>
     <p>
-      This is a list of the most popular/important libraries that we couldn't find a license for, you can help the community by encouraging the authors to add a <code>LICENSE</code> file to their repositories.
+      This is a list of the most popular/important packages that we couldn't find a license for, you can help the community by encouraging the authors to add a <code>LICENSE</code> file to their repositories.
     </p>
     <p>
       Find out more about open source licensing at <%= link_to 'ChooseALicense.com','http://choosealicense.com/' %>

--- a/app/views/projects/unmaintained.html.erb
+++ b/app/views/projects/unmaintained.html.erb
@@ -1,7 +1,7 @@
-<% title "#{@platform_name} Unmaintained Libraries - Libraries.io" %>
-<% description "Projects marked as unmaintained which are no longer updated" %>
+<% title "#{@platform_name} Unmaintained Packages - Libraries.io" %>
+<% description "Packages marked as unmaintained which are no longer updated" %>
 <div class="row">
-  <h1><i class="fa fa-archive"></i> <%= @platform_name %> Unmaintained Libraries</h1>
+  <h1><i class="fa fa-archive"></i> <%= @platform_name %> Unmaintained Packages</h1>
 </div>
 <hr>
 
@@ -10,7 +10,7 @@
     <%= render @projects, cache: true %>
     <%= will_paginate @projects, page_links: false %>
     <p>
-      <small><%= page_entries_info @projects, model: 'unmaintained libraries' %></small>
+      <small><%= page_entries_info @projects, model: 'unmaintained packages' %></small>
     </p>
   </div>
   <div class="col-sm-4">

--- a/app/views/projects/unseen_infrastructure.html.erb
+++ b/app/views/projects/unseen_infrastructure.html.erb
@@ -51,13 +51,13 @@
       </strong>
     </h3>
     <p>
-      Unseen infrastructure are open source libraries that are heavily depended upon by the community but don't receive much recognition or attention.
+      Unseen infrastructure are open source packages that are heavily depended upon by the community but don't receive much recognition or attention.
     </p>
     <p>
-      This page shows projects that are depended upon by at least 1,000 other open source repositories but have less than 100 stars.
+      This page shows packages that are depended upon by at least 1,000 other open source repositories but have less than 100 stars.
     </p>
     <p>
-      You can help out by reviewing the code for these libraries, helping out with open issues and thanking the maintainers for their hard work.
+      You can help out by reviewing the code for these packages, helping out with open issues and thanking the maintainers for their hard work.
     </p>
     <p>
       <em>This is an experiment based on contributions and available dependency data from package manager repositories that make it easily available.</em>
@@ -74,7 +74,7 @@
                   <%= link_to platform_name(platform[0]), unseen_infrastructure_path(platforms: nil, license: params[:license]) %>
                 <% else %>
                   <%= link_to platform_name(platform[0]), unseen_infrastructure_path(platforms: platform_name(platform[0]), license: params[:license]) %>
-                  <small><%= pluralize number_to_human(platform[1]), 'projects' %></small>
+                  <small><%= pluralize number_to_human(platform[1]), 'packages' %></small>
                 <% end %>
               </li>
             <% end %>

--- a/app/views/projects/unsubscribe.html.erb
+++ b/app/views/projects/unsubscribe.html.erb
@@ -10,7 +10,7 @@
         You're currently subscribed to updates for any new versions of <%= @project %>:
       </p>
       <p>
-        <%= link_to subscription_path(current_user.subscribed_to?(@project)), method: :delete, class: 'btn btn-success', title: 'Stop being notified of new releases of this library' do %>
+        <%= link_to subscription_path(current_user.subscribed_to?(@project)), method: :delete, class: 'btn btn-success', title: 'Stop being notified of new releases of this package' do %>
           <%= fa_icon('times') %>
           Unsubscribe from updates to <strong><%= @project %></strong>
         <% end %>

--- a/app/views/recommendations/index.html.erb
+++ b/app/views/recommendations/index.html.erb
@@ -1,4 +1,4 @@
-<h1>Recommended Libraries</h1>
+<h1>Recommended Packages</h1>
 
 <div class="row">
   <div class="col-md-8">
@@ -17,10 +17,10 @@
         data from your
         <%= link_to 'Profile', user_path(current_user.to_param) %> and
       <% end %>
-      Libraries data.
+      Libraries.io data.
     </p>
     <p>
-      That includes libraries your repositories depend on, projects you watch and popular libraries written in languages you use.
+      That includes packages your repositories depend on, packages you watch and popular packages written in languages you use.
     </p>
     <p>
       Not seeing anything interesting to you? <%= link_to 'Let us know.', 'mailto:support@libraries.io' %>

--- a/app/views/repositories/_search_form.html.erb
+++ b/app/views/repositories/_search_form.html.erb
@@ -7,7 +7,7 @@
        <li>
          <%= link_to search_path(q: params[:q], sort: params[:sort]) do %>
            <span class='fa-blank'></span>
-           Libraries
+           Packages
          <% end %>
        </li>
        <li>

--- a/app/views/repositories/show.html.erb
+++ b/app/views/repositories/show.html.erb
@@ -139,7 +139,7 @@
       <% if @projects.length > 0 %>
         <div class="row"></div>
         <hr>
-        <h4>Projects Referencing this Repo</h4>
+        <h4>Packages Referencing this Repo</h4>
         <%= render @projects, cache: true %>
       <% end %>
 

--- a/app/views/repositories/sourcerank.html.erb
+++ b/app/views/repositories/sourcerank.html.erb
@@ -40,10 +40,10 @@
       </strong>
     </h3>
     <p>
-      SourceRank is the score for a project based on a number of metrics, it's used across the site to boost high quality projects.
+      SourceRank is the score for a package based on a number of metrics, it's used across the site to boost high quality repositories.
     </p>
     <p>
-      The factors are based on attributes of a project that make it appear like a dependable library and can be handy to compare different projects.
+      The factors are based on attributes of a package that make it appear like a dependable package and can be handy to compare different repositories.
     </p>
     <p>
       Got a question or suggestion to improve SourceRank? Open an <%= link_to 'issue', 'https://github.com/librariesio/libraries.io/issues' %>, <%= link_to 'tweet us', 'https://twitter.com/librariesio' %> or email <%= mail_to 'support@libraries.io', 'support@libraries.io' %>

--- a/app/views/repository_users/contributions.html.erb
+++ b/app/views/repository_users/contributions.html.erb
@@ -13,7 +13,7 @@
       <%= will_paginate @contributions, page_links: false %>
     <% else %>
       <p>
-        No projects found, go back to <%= link_to @user, user_path(@user.to_param) %>.
+        No packages found, go back to <%= link_to @user, user_path(@user.to_param) %>.
       </p>
     <% end %>
   </div>

--- a/app/views/repository_users/dependencies.html.erb
+++ b/app/views/repository_users/dependencies.html.erb
@@ -1,8 +1,8 @@
-<% title "Libraries that #{@user} depends on the most - Libraries.io" %>
+<% title "Packages that #{@user} depends on the most - Libraries.io" %>
 
 <h1>
   <%= image_tag @user.avatar_url(120), width: 60, height: 60, alt: @user %>
-  Libraries that <%= link_to @user, user_path(@user.to_param) %> depends on the most
+  Packages that <%= link_to @user, user_path(@user.to_param) %> depends on the most
 </h1>
 <hr>
 <div class="row">
@@ -12,7 +12,7 @@
       <%= will_paginate @projects, page_links: false %>
     <% else %>
       <p>
-        No projects found, go back to <%= link_to @user, user_path(@user.to_param) %>.
+        No packages found, go back to <%= link_to @user, user_path(@user.to_param) %>.
       </p>
     <% end %>
   </div>
@@ -23,7 +23,7 @@
       </strong>
     </h3>
     <p>
-      This is a list of every library that <%= link_to @user, user_path(@user.to_param) %>'s
+      This is a list of every package that <%= link_to @user, user_path(@user.to_param) %>'s
       open source repositories list as a dependency, ordered by most used.
     </p>
   </div>

--- a/app/views/repository_users/projects.html.erb
+++ b/app/views/repository_users/projects.html.erb
@@ -1,8 +1,8 @@
-<% title "Projects referencing #{@user}'s Repositories - Libraries.io" %>
+<% title "Packages referencing #{@user}'s Repositories - Libraries.io" %>
 
 <h1>
   <%= image_tag @user.avatar_url(120), width: 60, height: 60, alt: @user %>
-  Projects referencing <%= link_to @user, user_path(@user.to_param) %>'s Repositories
+  Packages referencing <%= link_to @user, user_path(@user.to_param) %>'s Repositories
 </h1>
 <hr>
 <div class="row">
@@ -12,7 +12,7 @@
       <%= will_paginate @projects, page_links: false %>
     <% else %>
       <p>
-        No projects found, go back to <%= link_to @user, user_path(@user.to_param) %>.
+        No packages found, go back to <%= link_to @user, user_path(@user.to_param) %>.
       </p>
     <% end %>
   </div>
@@ -23,7 +23,7 @@
       </strong>
     </h3>
     <p>
-      This is a list of every project published to a package manager that references one of <%= link_to @user, user_path(@user.to_param) %>'s repositories as it's source.
+      This is a list of every package published to a package manager that references one of <%= link_to @user, user_path(@user.to_param) %>'s repositories as it's source.
     </p>
   </div>
 </div>

--- a/app/views/repository_users/repositories.html.erb
+++ b/app/views/repository_users/repositories.html.erb
@@ -13,7 +13,7 @@
       <%= will_paginate @repositories, page_links: false %>
     <% else %>
       <p>
-        No projects found, go back to <%= link_to @user, user_path(@user.to_param) %>.
+        No packages found, go back to <%= link_to @user, user_path(@user.to_param) %>.
       </p>
     <% end %>
   </div>

--- a/app/views/repository_users/show.html.erb
+++ b/app/views/repository_users/show.html.erb
@@ -14,7 +14,7 @@
       <% if count > 0 %>
         <p>
           <%= fa_icon 'code' %>
-          Tracking <%= number_to_human @user.open_source_contributions.sum(:count) %> commits to <%= number_to_human count %> open source projects
+          Tracking <%= number_to_human @user.open_source_contributions.sum(:count) %> commits to <%= number_to_human count %> open source packages
         </p>
       <% end %>
     <% end %>
@@ -67,14 +67,14 @@
     <div class="row">
       <% if @projects.length > 0 %>
         <div class="col-sm-6 user-column">
-          <h4>Published Projects</h4>
+          <h4>Published Packages</h4>
           <%= render @projects, cache: true %>
           <%= link_to "See all #{@user}'s projects", user_projects_path(@user.to_param) %>
         </div>
       <% end %>
       <% if @favourite_projects.length > 0 %>
         <div class="col-sm-6 user-column">
-          <h4>Most Used Projects</h4>
+          <h4>Most Used Packages</h4>
           <%= render @favourite_projects, cache: true %>
           <%= link_to "See all #{@user}'s most used projects", user_dependencies_path(@user.to_param) %>
         </div>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -9,7 +9,7 @@
     </div>
       <div class="row">
         <div class="col-xs-6">
-          <h5><%= search_page_entries_info @search, model: 'library' %></h5>
+          <h5><%= search_page_entries_info @search, model: 'package' %></h5>
         </div>
         <div class="col-xs-6">
           <div class="btn-group pull-right">
@@ -47,7 +47,7 @@
       <%= will_paginate @search, page_links: false %>
     <% else %>
       <p>
-        <b>No projects found. </b>
+        <b>No packages found. </b>
       </p>
       <% if params[:platforms].present? || params[:licenses].present? ||  params[:languages].present? ||  params[:keywords].present? %>
         <p>
@@ -56,7 +56,7 @@
       <% else %>
         <h3>Something Missing?</h3>
         <p>
-          If a project from one of these package managers is missing please <%= link_to 'report it as a bug', "https://github.com/librariesio/libraries.io/issues/new?title=No results for search '#{params[:q]}'" %>.
+          If a package from one of these package managers is missing please <%= link_to 'report it as a bug', "https://github.com/librariesio/libraries.io/issues/new?title=No results for search '#{params[:q]}'" %>.
         </p>
         <div class='row'>
           <%= render partial: 'platforms/platform', collection: @platforms %>

--- a/app/views/subscriptions/index.html.erb
+++ b/app/views/subscriptions/index.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-md-8">
-    <h2>Projects you're watching</h2>
+    <h2>Packages you're watching</h2>
     <% if @subscriptions.any? %>
       <table id='subscriptions' class='table table-striped table-hover'>
         <%= render @subscriptions %>
@@ -8,10 +8,10 @@
       <%= will_paginate @subscriptions, page_links: false %>
     <% else %>
       <p>
-        Libraries lets you watch libraries that you depend on and notifies you by email when there's a new release.
+        Libraries.io lets you watch packages that you depend on and notifies you by email when there's a new release.
       </p>
       <p>
-        Below are some recommended projects for you to watch:
+        Below are some recommended packages for you to watch:
       </p>
       <%= render collection: @projects, partial: 'subscriptions/project' %>
       <p>

--- a/app/views/web_hooks/index.html.erb
+++ b/app/views/web_hooks/index.html.erb
@@ -37,7 +37,7 @@
   <div class="col-md-4">
     <h4>How's this work?</h4>
     <p>
-      Libraries will post JSON to your web hook url whenever a new version of a library that your repository depends on is released.
+      Libraries.io will post JSON to your web hook url whenever a new version of a package that your repository depends on is released.
     </p>
     <p class='text-center'>
       <%= link_to 'Add a web hook', new_repository_web_hook_path(@repository.to_param), class: 'btn btn-primary' %>

--- a/spec/requests/admin/projects_spec.rb
+++ b/spec/requests/admin/projects_spec.rb
@@ -18,7 +18,7 @@ describe "Admin::ProjectController" do
       mock_is_admin
       login(user)
       visit admin_projects_path
-      expect(page).to have_content 'Popular projects without repo links'
+      expect(page).to have_content 'Popular packages without repo links'
     end
   end
 
@@ -37,7 +37,7 @@ describe "Admin::ProjectController" do
       mock_is_admin
       login(user)
       visit deprecated_admin_projects_path
-      expect(page).to have_content 'Deprecated projects'
+      expect(page).to have_content 'Deprecated packages'
     end
   end
 
@@ -56,7 +56,7 @@ describe "Admin::ProjectController" do
       mock_is_admin
       login(user)
       visit unmaintained_admin_projects_path
-      expect(page).to have_content 'Unmaintained projects'
+      expect(page).to have_content 'Unmaintained packages'
     end
   end
 end

--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -14,7 +14,7 @@ describe "CollectionController", elasticsearch: true do
     it "renders successfully when logged out" do
       Project.__elasticsearch__.refresh_index!
       visit collection_path(project.language, project.keywords.first)
-      expect(page).to have_content 'libraries written in'
+      expect(page).to have_content 'packages written in'
     end
   end
 end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -14,7 +14,7 @@ describe "DashboardController" do
     it "renders successfully when logged in" do
       login(user)
       visit muted_path
-      expect(page).to have_content 'Muted Projects'
+      expect(page).to have_content 'Muted Packages'
     end
   end
 

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -29,13 +29,13 @@ RSpec.describe ProjectsController do
   describe "GET #unlicensed" do
     it "responds successfully", type: :request do
       visit unlicensed_path
-      expect(page).to have_content 'Unlicensed Libraries'
+      expect(page).to have_content 'Unlicensed Packages'
     end
 
     context "filtered by platform" do
       it "responds successfully" do
         visit unlicensed_path(platform: 'Rubygems')
-        expect(page).to have_content 'Unlicensed Libraries'
+        expect(page).to have_content 'Unlicensed Packages'
       end
     end
   end

--- a/spec/requests/recommendations_spec.rb
+++ b/spec/requests/recommendations_spec.rb
@@ -12,7 +12,7 @@ describe "RecommendationsController" do
     it "renders successfully when logged in" do
       login(user)
       visit recommendations_path
-      expect(page).to have_content 'Recommended Libraries'
+      expect(page).to have_content 'Recommended Packages'
     end
   end
 end


### PR DESCRIPTION
Package is what we're using for Tidelift and slightly less confusing that Project or Library.

This only changes the web UI, not changing the Project class, any database columns or API fields at this time.

Also changed a few "Libraries" for "Libraries.io" where the site was referenced