### PR TITLE
Use fast jasonapi for version_serializer.rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,7 @@ gem 'concurrent-ruby-ext'
 gem 'charlock_holmes', '>= 0.7.5'
 gem 'octicons_helper'
 gem 'ffi'
+gem 'fast_jsonapi'
 
 group :development do
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,6 +189,11 @@ GEM
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
     fast_blank (1.0.0)
+    fast_jsonapi (1.0.17)
+      activerecord (~> 5.0)
+      activesupport (~> 5.0)
+      multi_json (~> 1.12)
+      oj (~> 3.3)
     fast_xor (1.1.3)
       rake
       rake-compiler
@@ -582,6 +587,7 @@ DEPENDENCIES
   faraday-http-cache
   faraday_middleware
   fast_blank
+  fast_jsonapi
   fast_xor
   fast_xs
   ffi

--- a/app/serializers/version_serializer.rb
+++ b/app/serializers/version_serializer.rb
@@ -1,4 +1,5 @@
-class VersionSerializer < ActiveModel::Serializer
+class VersionSerializer
+  include FastJsonapi::ObjectSerializer
   attributes :number, :published_at
 
   belongs_to :project

--- a/spec/serializers/version_serializer_spec.rb
+++ b/spec/serializers/version_serializer_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 describe VersionSerializer do
-  subject { described_class.new(build(:version)) }
+  subject { described_class.new(build(:version)).serializable_hash[:data][:attributes].keys }
 
   it 'should have expected attribute names' do
-    expect(subject.attributes.keys).to eql([:number, :published_at])
+    is_expected.to eql([:number, :published_at])
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines for [contributors](http://docs.libraries.io/contributorshandbook)?
- [x] Have you checked to ensure there aren't other open pull requests on the repository for a similar change?
- [x] Is there a corresponding ticket for your pull request?
- [x] Have you written new tests for your changes?
- [x] Have you successfully run the project with your changes locally?

This PR is related to https://github.com/librariesio/libraries.io/issues/1959.
I replaced `version_serializer.rb`'s ActiveModel::Serializer with FastJsonapi::ObjectSerializer. I will do the same thing to the other serializers, but this is a good start  I guess! Thank you! 
