### PR TITLE
Preparing for open data release 1.2

### DIFF
--- a/app/helpers/open_data_helper.rb
+++ b/app/helpers/open_data_helper.rb
@@ -28,7 +28,7 @@ module OpenDataHelper
       '1.2.0' => {
         date: 'March 13, 2018',
         filename: 'Libraries.io-open-data-1.2.0.tar.gz',
-        md5: 'TODO',
+        md5: '5ada269fa799265b5ffc32902ccfbce1',
         size: '8.7GB',
         rows: '397 million',
         download: 'https://zenodo.org/record/1196312/files/Libraries.io-open-data-1.2.0.tar.gz'

--- a/app/helpers/open_data_helper.rb
+++ b/app/helpers/open_data_helper.rb
@@ -30,7 +30,7 @@ module OpenDataHelper
         filename: 'Libraries.io-open-data-1.2.0.tar.gz',
         md5: 'TODO',
         size: 'TODO',
-        rows: 'TODO',
+        rows: '397 million',
         download: 'https://zenodo.org/record/1196312/files/Libraries.io-open-data-1.2.0.tar.gz'
       }
     }

--- a/app/helpers/open_data_helper.rb
+++ b/app/helpers/open_data_helper.rb
@@ -29,7 +29,7 @@ module OpenDataHelper
         date: 'March 13, 2018',
         filename: 'Libraries.io-open-data-1.2.0.tar.gz',
         md5: 'TODO',
-        size: 'TODO',
+        size: '8.7GB',
         rows: '397 million',
         download: 'https://zenodo.org/record/1196312/files/Libraries.io-open-data-1.2.0.tar.gz'
       }

--- a/app/helpers/open_data_helper.rb
+++ b/app/helpers/open_data_helper.rb
@@ -24,6 +24,14 @@ module OpenDataHelper
         size: '7.1GB',
         rows: '311 million',
         download: 'https://zenodo.org/record/1068916/files/Libraries.io-open-data-1.1.1.tar.gz'
+      },
+      '1.2.0' => {
+        date: 'March 13, 2018',
+        filename: 'Libraries.io-open-data-1.2.0.tar.gz',
+        md5: 'TODO',
+        size: 'TODO',
+        rows: 'TODO',
+        download: 'TODO'
       }
     }
   end

--- a/app/helpers/open_data_helper.rb
+++ b/app/helpers/open_data_helper.rb
@@ -31,7 +31,7 @@ module OpenDataHelper
         md5: 'TODO',
         size: 'TODO',
         rows: 'TODO',
-        download: 'TODO'
+        download: 'https://zenodo.org/record/1196312/files/Libraries.io-open-data-1.2.0.tar.gz'
       }
     }
   end

--- a/app/views/pages/_releases.html.erb
+++ b/app/views/pages/_releases.html.erb
@@ -1,12 +1,12 @@
 <dl class='row'>
     <dt class='col-xs-6'>Next</dt>
-    <dd class='col-xs-6'>March 2018</dd>
+    <dd class='col-xs-6'>June 2018</dd>
     <dt class='col-xs-6'>Latest</dt>
     <dd class='col-xs-6'>
-      <a href="https://zenodo.org/record/1068916">1.1.1</a> - 30 Nov, 2017
+      <a href="https://zenodo.org/record/TODO">1.1.1</a> - 13 Mar, 2018
     </dd>
     <dt class='col-xs-6'>Previous</dt>
     <dd class='col-xs-6'>
-      <a href="https://zenodo.org/record/833207">1.0.1</a> - 21 July, 2017
+      <a href="https://zenodo.org/record/1068916">1.1.1</a> - 30 Nov, 2017
     </dd>
 </dl>

--- a/app/views/pages/_releases.html.erb
+++ b/app/views/pages/_releases.html.erb
@@ -3,7 +3,7 @@
     <dd class='col-xs-6'>June 2018</dd>
     <dt class='col-xs-6'>Latest</dt>
     <dd class='col-xs-6'>
-      <a href="https://zenodo.org/record/TODO">1.1.1</a> - 13 Mar, 2018
+      <a href="https://zenodo.org/record/1196312">1.2.0</a> - 13 Mar, 2018
     </dd>
     <dt class='col-xs-6'>Previous</dt>
     <dd class='col-xs-6'>

--- a/app/views/pages/data.html.erb
+++ b/app/views/pages/data.html.erb
@@ -8,7 +8,7 @@
     </h1>
     <br>
     <p>
-       Libraries.io gathers data from <strong>34</strong> package managers and <strong>3</strong> source code repositories. We track over <strong>2.7m</strong> unique open source packages, <strong>31m</strong> repositories and <strong>161m</strong> interdependencies between them. This gives Libraries.io a unique understanding of open source software. An understanding that we want to share with <strong>you</strong>.
+       Libraries.io gathers data from <strong>35</strong> package managers and <strong>3</strong> source code repositories. We track over <strong>2.7m</strong> unique open source packages, <strong>33m</strong> repositories and <strong>235m</strong> interdependencies between them. This gives Libraries.io a unique understanding of open source software. An understanding that we want to share with <strong>you</strong>.
     </p>
     <p>
       This page contains information on how to download, use and redistribute data from Libraries.io. For enquiries please contact <%= mail_to 'data@libraries.io'%>.


### PR DESCRIPTION
Aiming to get the release out on 13th March, bits still to calculate:

- [x] md5
- [x] size
- [x] rows
- [x] zenodo download link
- [x] zenodo version ID

Fixes https://github.com/librariesio/libraries.io/issues/2011