### PR TITLE
Improve syncing repos where permissions are required

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -106,7 +106,7 @@ class RepositoriesController < ApplicationController
     if @repository.recently_synced?
       flash[:error] = "Repository has already been synced recently"
     else
-      @repository.manual_sync
+      @repository.manual_sync(current_user.token)
       flash[:notice] = "Repository has been queued to be resynced"
     end
     redirect_back fallback_location: repository_path(@repository.to_param)

--- a/app/models/concerns/github_identity.rb
+++ b/app/models/concerns/github_identity.rb
@@ -52,6 +52,7 @@ module GithubIdentity
       end
       next if github_repo.nil?
       current_repo_ids << github_repo.id
+      github_repo.update_all_info_async(token)
 
       unless rp = existing_permissions.find{|p| p.repository_id == github_repo.id}
         rp = repository_permissions.build(repository_id: github_repo.id)


### PR DESCRIPTION
Also forces syncing of all active user repos on a more regular basis

As reported by @splashinn 