### PR TITLE
Update pypi links from pypi.python.org to pypi.org

### DIFF
--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -4,11 +4,11 @@ module PackageManager
     HAS_DEPENDENCIES = true
     BIBLIOTHECARY_SUPPORT = true
     SECURITY_PLANNED = true
-    URL = 'https://pypi.python.org'
+    URL = 'https://pypi.org/'
     COLOR = '#3572A5'
 
     def self.package_link(project, version = nil)
-      "https://pypi.python.org/pypi/#{project.name}/#{version}"
+      "https://pypi.org/project/#{project.name}/#{version}"
     end
 
     def self.install_instructions(project, version = nil)
@@ -20,19 +20,19 @@ module PackageManager
     end
 
     def self.project_names
-      get_raw("https://pypi.python.org/simple/").scan(/href='(\w+)'/).flatten
+      get_raw("https://pypi.org/simple/").scan(/href='(\w+)'/).flatten
     end
 
     def self.recent_names
-      u = 'https://pypi.python.org/pypi?%3Aaction=rss'
+      u = 'https://pypi.org/rss/updates.xml'
       updated = SimpleRSS.parse(get_raw(u)).items.map(&:title)
-      u = 'https://pypi.python.org/pypi?%3Aaction=packages_rss'
+      u = 'https://pypi.org/rss/packages.xml'
       new_packages = SimpleRSS.parse(get_raw(u)).items.map(&:title)
       (updated.map { |t| t.split(' ').first } + new_packages.map { |t| t.split(' ').first }).uniq
     end
 
     def self.project(name)
-      get("https://pypi.python.org/pypi/#{name}/json")
+      get("https://pypi.org/pypi/#{name}/json")
     rescue
       {}
     end

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -9,11 +9,11 @@ describe PackageManager::Pypi do
 
   describe '#package_link' do
     it 'returns a link to project website' do
-      expect(described_class.package_link(project)).to eq("https://pypi.python.org/pypi/foo/")
+      expect(described_class.package_link(project)).to eq("https://pypi.org/project/foo/")
     end
 
     it 'handles version' do
-      expect(described_class.package_link(project, '2.0.0')).to eq("https://pypi.python.org/pypi/foo/2.0.0")
+      expect(described_class.package_link(project, '2.0.0')).to eq("https://pypi.org/project/foo/2.0.0")
     end
   end
 


### PR DESCRIPTION
Fixes #2024

Only thing that doesn't appear to work correctly on the new pypi.org is the rss feeds which are aren't matching with the ones on pypi.python.org at the moment, will wait for that to be fixed before merging.