### PR TITLE
Speed up application start-up with bootsnap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,7 @@ gem 'concurrent-ruby-ext'
 gem 'charlock_holmes', '>= 0.7.5'
 gem 'octicons_helper'
 gem 'ffi'
+gem 'bootsnap', require: false
 
 group :development do
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,8 @@ GEM
       sdl4r
       toml-rb (~> 1.0)
       typhoeus
+    bootsnap (1.2.1)
+      msgpack (~> 1.0)
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
@@ -279,6 +281,7 @@ GEM
       protocol
     modware (0.1.3)
       key_struct (~> 0.4)
+    msgpack (1.2.4)
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -556,6 +559,7 @@ DEPENDENCIES
   asciidoctor
   bibliothecary
   bitbucket_rest_api!
+  bootsnap
   bootstrap-sass
   brakeman
   bugsnag

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+require 'bootsnap/setup'


### PR DESCRIPTION
Uses https://github.com/Shopify/bootsnap to shave a few seconds off the startup time