### PR TITLE
Record API usage by month

### DIFF
--- a/app/controllers/admin/stats_controller.rb
+++ b/app/controllers/admin/stats_controller.rb
@@ -28,6 +28,12 @@ class Admin::StatsController < Admin::ApplicationController
     @versions = Version.joins(:project).where('lower(projects.platform) = ?', @platform.downcase).where('versions.created_at > ?', 3.months.ago).group_by_day('versions.created_at').count
   end
 
+  def api
+    current_month_key = "api-usage-#{Date.today.strftime("%Y-%m")}"
+    @api_key_usage = REDIS.hgetall(current_month_key)
+    @api_keys = ApiKey.includes(:user).find(@api_key_usage.keys.map(&:to_i))
+  end
+
   private
 
   def stats_for(klass)

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -25,6 +25,7 @@ class Api::ApplicationController < ApplicationController
   def check_api_key
     return true if params[:api_key].nil?
     require_api_key
+    record_api_usage
   end
 
   def require_api_key
@@ -38,6 +39,11 @@ class Api::ApplicationController < ApplicationController
   def current_api_key
     return nil if params[:api_key].blank?
     @current_api_key ||= ApiKey.active.find_by_access_token(params[:api_key])
+  end
+
+  def record_api_usage
+    return unless @current_api_key.present?
+    REDIS.hincrby "api-usage-#{Date.today.strftime("%Y-%m")}", @current_api_key.id, 1
   end
 
   def current_user

--- a/app/views/admin/_nav.html.erb
+++ b/app/views/admin/_nav.html.erb
@@ -3,6 +3,7 @@
   <ul class="nav nav-tabs">
     <li role="presentation" class="<%= cp('/admin') %>"><a href="/admin">Overview</a></li>
     <li role="presentation" class="<%= cp('/admin/stats') %>"><a href="/admin/stats">Stats</a></li>
+    <li role="presentation" class="<%= cp('/admin/stats/api') %>"><a href="/admin/stats/api">API</a></li>
     <li role="presentation" class="<%= cp('/admin/stats/repositories') %>"><a href="/admin/stats/repositories">Repo Stats</a></li>
     <li role="presentation" class="<%= cp('/admin/project_suggestions') %>">
       <a href="/admin/project_suggestions">

--- a/app/views/admin/stats/api.html.erb
+++ b/app/views/admin/stats/api.html.erb
@@ -1,4 +1,9 @@
-<h1>API Usage for <%= Date.today.strftime("%B %Y") %></h1>
+<%= render 'admin/nav' %>
+<% title 'API Usage - Libraries.io' %>
+<h1>
+  API Usage for <%= Date.today.strftime("%B %Y") %>
+</h1>
+
 
 <table class='table'>
   <thead>

--- a/app/views/admin/stats/api.html.erb
+++ b/app/views/admin/stats/api.html.erb
@@ -1,0 +1,34 @@
+<h1>API Usage for <%= Date.today.strftime("%B %Y") %></h1>
+
+<table class='table'>
+  <thead>
+    <th>Email</th>
+    <th>Signed up</th>
+    <th>Last login</th>
+    <th>Optin?</th>
+    <th>Requests</th>
+  </thead>
+  <tbody>
+    <% @api_key_usage.each do |api_key_id, usage| %>
+      <% api_key = @api_keys.first{|key| key.id == api_key_id.to_i } %>
+      <% next unless api_key.present? %>
+      <tr>
+        <td>
+          <%= api_key.user.email %>
+        </td>
+        <td>
+          <%= api_key.user.created_at.to_s(:short) %>
+        </td>
+        <td>
+          <%= api_key.user.last_login_at.try(:to_s, :short) %>
+        </td>
+        <td>
+          <%= fa_icon(api_key.user.optin? ? 'check-circle' : 'times-circle') %>
+        </td>
+        <td>
+          <%= number_to_human usage %>
+        </td>
+      </li>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/shared/_notice.html.erb
+++ b/app/views/shared/_notice.html.erb
@@ -2,8 +2,8 @@
   <div class='alert alert-danger'>
     We have updated our <a href='/terms'>terms of service</a> and <a href='/privacy'>privacy policy</a>. If you do not accept these changes <b>your account will be removed</b> at some point in the future. <%= link_to 'Accept', optin_account_path, method: 'put', class: 'btn btn-success btn-sm', rel: 'nofollow', title: 'Accept the new terms of service and privacy policy' %>
   </div>
+<% elsif !(logged_in? && current_user.admin?) %>
+  <div class="alert alert-info" role="alert">
+    <strong>Introducing <a href="https://tidelift.com" target="_blank" style="text-decoration:underline">the Tidelift Subscription</a>.</strong> Professional-quality security updates and maintenance for the open source projects you depend on.
+  </div>
 <% end %>
-
-<div class="alert alert-info" role="alert">
-  <strong>Introducing <a href="https://tidelift.com" target="_blank" style="text-decoration:underline">the Tidelift Subscription</a>.</strong> Professional-quality security updates and maintenance for the open source projects you depend on.
-</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,6 +84,7 @@ Rails.application.routes.draw do
     end
 
     get '/stats', to: 'stats#index', as: :stats
+    get '/stats/api', to: 'stats#api', as: :api_stats
     get '/stats/repositories', to: 'stats#repositories', as: :repositories_stats
     get '/graphs', to: 'stats#graphs', as: :graphs
     get '/:host_type/:login/dependencies', to: 'repository_organisations#dependencies', as: :organisation_dependencies


### PR DESCRIPTION
We need to get a bit more visibility on which API keys are using the API so we can advise active/heavy users about upcoming changes, requirements to optin to new terms of service etc

This pr adds recording of active api keys broken down by month, stored in redis, and an admin dashboard to see a breakdown:

![screen shot 2018-04-12 at 11 35 48](https://user-images.githubusercontent.com/1060/38672416-02ad1e5a-3e46-11e8-8a07-3e4f1621dd90.png)
