### PR TITLE
Add version range usage breakdown api

### DIFF
--- a/app/controllers/api/docs_controller.rb
+++ b/app/controllers/api/docs_controller.rb
@@ -22,5 +22,7 @@ class Api::DocsController < ApplicationController
     @search = Project.search('grunt', api: true).records
 
     @repository_user = RepositoryUser.host('GitHub').login('andrew').first || RepositoryUser.first
+
+    @all_counts = @project.repository_dependencies.where('repositories.fork = ?', false).joins(manifest: :repository).distinct('manifests.repository_id').group('repository_dependencies.requirements').count.select{|k,v| k.present? }
   end
 end

--- a/app/controllers/api/project_usage_controller.rb
+++ b/app/controllers/api/project_usage_controller.rb
@@ -1,0 +1,8 @@
+class Api::ProjectUsageController < ApplicationController
+  before_action :find_project
+  def show
+    @all_counts = @project.repository_dependencies.where('repositories.fork = ?', false).joins(manifest: :repository).distinct('manifests.repository_id').group('repository_dependencies.requirements').count.select{|k,v| k.present? }
+
+    render json: @all_counts
+  end
+end

--- a/app/views/api/docs/index.html.erb
+++ b/app/views/api/docs/index.html.erb
@@ -161,6 +161,24 @@
 <%= JSON.pretty_generate @project.source_rank.as_json %></pre>
     <% end %>
 
+    <h3 id="project-usage">Project Usage</h3>
+
+    <p>
+      Get breakdown of version usage for a given project.
+    </p>
+
+    <p>
+      <code>GET https://libraries.io/api/:platform/:name/usage?api_key=<%= @api_key %></code>
+    </p>
+    <hr>
+    <p>
+      Example: <strong> <%= link_to "https://libraries.io/api/npm/base62/usage?api_key=#{@api_key}", "https://libraries.io/api/npm/base62/sourcerank?api_key=#{@api_key}" %> </strong>
+    </p>
+    <% cache "api-docs-#{@cache_version}usage", :expires_in => 1.day do %>
+      <pre class='well well-small'>
+<%= JSON.pretty_generate @all_counts.as_json %></pre>
+    <% end %>
+
     <h3 id="project-search">Project Search</h3>
 
     <p>
@@ -477,6 +495,7 @@
       <li><a href="#project-dependent-repositories">Project Dependent Repositories</a></li>
       <li><a href="#project-contributors">Project Contributors</a></li>
       <li><a href="#project-sourcerank">Project SourceRank</a></li>
+      <li><a href="#project-usage">Project Usage</a></li>
       <li><a href="#project-search">Project Search</a></li>
     </ul>
     <ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
     PROJECT_CONSTRAINT = /[^\/]+/
     VERSION_CONSTRAINT = /[\w\.\-]+/
 
+    get '/:platform/:name/usage', to: 'project_usage#show', as: :project_usage, constraints: { :platform => PLATFORM_CONSTRAINT, :name => PROJECT_CONSTRAINT }
     get '/:platform/:name/sourcerank', to: 'projects#sourcerank', constraints: { :platform => PLATFORM_CONSTRAINT, :name => PROJECT_CONSTRAINT }
     get '/:platform/:name/contributors', to: 'projects#contributors', constraints: { :platform => PLATFORM_CONSTRAINT, :name => PROJECT_CONSTRAINT }
     get '/:platform/:name/:version/tree', to: 'tree#show', constraints: { :platform => /[\w\-]+/, :name => PROJECT_CONSTRAINT, :version => VERSION_CONSTRAINT }, as: :version_tree


### PR DESCRIPTION
Simple counts of version number/range usage on all open source, non-forked repos.

Fixes #999 

Example URL: https://libraries.io/api/npm/base62/usage

Example output:

```json
{
  "*": 4,
  "= 0.1.0": 1,
  "0.1.0": 1,
  "^0.1.1": 3,
  "~0.1.1": 3,
  "0.1.1": 6953,
  "^0.1.2": 2,
  "0.1.x": 1,
  "^1.0.0": 3,
  "^1.1.0": 62,
  "~1.1.0": 1,
  "1.1.0": 19,
  "^1.1.1": 6,
  "1.1.1": 109,
  "^1.1.2": 13,
  "1.1.2": 180,
  "^1.2.0": 4,
  "1.2.0": 1312,
  "^1.2.1": 3,
  "1.2.1": 1078,
  "1.2.4": 1,
  "1.2.5": 62,
  "^1.2.7": 1,
  "1.2.7": 648,
  "1.2.8": 115,
  "http://npm.tescloud.com/base62/-/base62-1.1.1.tgz": 1,
  "http://registry.npmjs.org/base62/-/base62-0.1.1.tgz": 6,
  "http://registry.npmjs.org/base62/-/base62-1.1.2.tgz": 1,
  "http://registry.npmjs.org/base62/-/base62-1.2.0.tgz": 2,
  "http://registry.npm.taobao.org/base62/download/base62-0.1.1.tgz": 1,
  "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz": 125,
  "https://registry.npmjs.org/base62/-/base62-1.1.1.tgz": 5,
  "https://registry.npmjs.org/base62/-/base62-1.1.2.tgz": 19,
  "https://registry.npmjs.org/base62/-/base62-1.2.0.tgz": 54,
  "https://registry.npmjs.org/base62/-/base62-1.2.1.tgz": 4,
  "https://registry.npmjs.org/base62/-/base62-1.2.7.tgz": 2,
  "https://registry.npm.taobao.org/base62/download/base62-0.1.1.tgz": 1,
  "https://registry.npm.taobao.org/base62/download/base62-1.1.2.tgz": 2,
  "https://registry.npm.taobao.org/base62/download/base62-1.2.0.tgz": 6,
  "latest": 1
}
```