### PR TITLE
Ignore ActionController:UnknownFormat errors

### DIFF
--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -12,6 +12,7 @@ default: &defaults
     - ActiveRecord::RecordNotFound
     - ActionController::RoutingError
     - ActiveRecord::RecordInvalid
+    - ActionController::UnknownFormat
 
   # Enable Garbage Collection instrumentation
   enable_gc_instrumentation: true


### PR DESCRIPTION
We get occasional requests for things in random formats; don't report to appsignal
