### PR TITLE
repo_search doesn't need facets on ES search

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -151,7 +151,7 @@ class RepositoriesController < ApplicationController
         language: current_language,
         keywords: current_keywords,
         host_type: formatted_host
-      }, sort: sort, order: 'desc').paginate(per_page: 6, page: 1)
+      }, sort: sort, order: 'desc', no_facet: true).paginate(per_page: 6, page: 1)
       search.results.map{|result| RepositorySearchResult.new(result) }
     end
   end

--- a/app/models/concerns/repo_search.rb
+++ b/app/models/concerns/repo_search.rb
@@ -113,12 +113,14 @@ module RepoSearch
       }
 
       unless options[:api]
-        search_definition[:aggs] = {
-          language: Project.facet_filter(:language, facet_limit, options),
-          license: Project.facet_filter(:license, facet_limit, options),
-          keywords: Project.facet_filter(:keywords, facet_limit, options),
-          host_type: Project.facet_filter(:host_type, facet_limit, options)
-        }
+        unless options[:no_facet]
+          search_definition[:aggs] = {
+            language: Project.facet_filter(:language, facet_limit, options),
+            license: Project.facet_filter(:license, facet_limit, options),
+            keywords: Project.facet_filter(:keywords, facet_limit, options),
+            host_type: Project.facet_filter(:host_type, facet_limit, options)
+          }
+        end
         if query.present?
           search_definition[:suggest] = {
             did_you_mean: {


### PR DESCRIPTION
Stop getting back faceted aggregations to speed up queries on pages
like /github so that we don't timeout. We're not using the aggregations
and they're expensive for ES to compute