### PR TITLE
Add a latest_download_url field to the projects API

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -13,7 +13,7 @@ class Project < ApplicationRecord
   API_FIELDS = [:name, :platform, :description, :language, :homepage,
                 :repository_url, :normalized_licenses, :rank, :status,
                 :latest_release_number, :latest_release_published_at,
-                :dependents_count, :dependent_repos_count]
+                :dependents_count, :dependent_repos_count, :latest_download_url]
 
   validates_presence_of :name, :platform
   validates_uniqueness_of :name, scope: :platform, case_sensitive: true
@@ -183,6 +183,10 @@ class Project < ApplicationRecord
 
   def download_url(version = nil)
     platform_class.download_url(name, version)
+  end
+
+  def latest_download_url
+    download_url(latest_release_number)
   end
 
   def documentation_url(version = nil)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -182,7 +182,7 @@ class Project < ApplicationRecord
   end
 
   def download_url(version = nil)
-    platform_class.download_url(name, version)
+    platform_class.download_url(name, version) if version
   end
 
   def latest_download_url

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -2,7 +2,7 @@ class ProjectSerializer < ActiveModel::Serializer
   attributes :name, :platform, :description, :homepage, :repository_url,
              :normalized_licenses, :rank, :latest_release_published_at,
              :latest_release_number, :language, :status, :package_manager_url,
-             :stars, :forks, :keywords, :latest_stable_release,
+             :stars, :forks, :keywords, :latest_stable_release, :latest_download_url,
              :dependents_count, :dependent_repos_count
 
   has_many :versions

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -25,7 +25,7 @@ RSpec.configure do |config|
 end
 
 def project_json_response(projects)
-  projects.as_json(only: Project::API_FIELDS, methods: [:package_manager_url, :stars, :forks, :keywords, :latest_stable_release], include: {versions: {only: [:number, :published_at]} })
+  projects.as_json(only: Project::API_FIELDS, methods: [:package_manager_url, :stars, :forks, :keywords, :latest_stable_release, :latest_download_url], include: {versions: {only: [:number, :published_at]} })
 end
 
 RSpec::Sidekiq.configure do |config|

--- a/spec/requests/api/bower_search_spec.rb
+++ b/spec/requests/api/bower_search_spec.rb
@@ -26,6 +26,7 @@ describe "Api::BowerSearchController", elasticsearch: true do
         "forks": project.forks,
         "keywords": project.keywords,
         "latest_stable_release": project.latest_stable_release,
+        "latest_download_url": nil,
         "dependents_count": project.dependents_count,
         "dependent_repos_count": project.dependent_repos_count,
         "versions": project.versions

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -70,6 +70,7 @@ describe "Api::ProjectsController" do
         "forks": project.forks,
         "keywords": project.keywords,
         "latest_stable_release": project.latest_stable_release,
+        "latest_download_url": project.latest_download_url,
         "dependents_count": project.dependents_count,
         "dependent_repos_count": project.dependent_repos_count,
         "versions": project.versions.as_json(only: [:number, :published_at]),

--- a/spec/requests/api/subscriptions_spec.rb
+++ b/spec/requests/api/subscriptions_spec.rb
@@ -10,7 +10,7 @@ describe "Api::SubscriptionsController" do
       get "/api/subscriptions?api_key=#{user.api_key}"
       expect(response).to have_http_status(:success)
       expect(response.content_type).to eq('application/json')
-      expect(response.body).to be_json_eql [subscription.as_json(only: [:include_prerelease, :created_at, :updated_at], include: {project: {only: Project::API_FIELDS, methods: [:package_manager_url, :stars, :forks, :keywords, :latest_stable_release], include: {versions: {only: [:number, :published_at]} }}})].to_json
+      expect(response.body).to be_json_eql [subscription.as_json(only: [:include_prerelease, :created_at, :updated_at], include: {project: {only: Project::API_FIELDS, methods: [:package_manager_url, :stars, :forks, :keywords, :latest_stable_release, :latest_download_url], include: {versions: {only: [:number, :published_at]} }}})].to_json
     end
   end
 
@@ -19,7 +19,7 @@ describe "Api::SubscriptionsController" do
       get "/api/subscriptions/#{subscription.project.platform}/#{subscription.project.name}?api_key=#{user.api_key}"
       expect(response).to have_http_status(:success)
       expect(response.content_type).to eq('application/json')
-      expect(response.body).to be_json_eql subscription.to_json(only: [:include_prerelease, :created_at, :updated_at], include: {project: {only: Project::API_FIELDS, methods: [:package_manager_url, :stars, :forks, :keywords, :latest_stable_release], include: {versions: {only: [:number, :published_at]} }}})
+      expect(response.body).to be_json_eql subscription.to_json(only: [:include_prerelease, :created_at, :updated_at], include: {project: {only: Project::API_FIELDS, methods: [:package_manager_url, :stars, :forks, :keywords, :latest_stable_release, :latest_download_url], include: {versions: {only: [:number, :published_at]} }}})
     end
   end
 
@@ -44,7 +44,7 @@ describe "Api::SubscriptionsController" do
       put "/api/subscriptions/#{subscription.project.platform}/#{subscription.project.name}?api_key=#{user.api_key}", params: { subscription: { include_prerelease: true } }
       expect(response).to have_http_status(:success)
       expect(response.content_type).to eq('application/json')
-      expect(response.body).to be_json_eql subscription.reload.to_json(only: [:include_prerelease, :created_at, :updated_at], include: {project: {only: Project::API_FIELDS, methods: [:package_manager_url, :stars, :forks, :keywords, :latest_stable_release], include: {versions: {only: [:number, :published_at]} }}})
+      expect(response.body).to be_json_eql subscription.reload.to_json(only: [:include_prerelease, :created_at, :updated_at], include: {project: {only: Project::API_FIELDS, methods: [:package_manager_url, :stars, :forks, :keywords, :latest_stable_release, :latest_download_url], include: {versions: {only: [:number, :published_at]} }}})
     end
   end
 

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -8,7 +8,7 @@ describe ProjectSerializer do
       :name, :platform, :description, :homepage, :repository_url,
       :normalized_licenses, :rank, :latest_release_published_at,
       :latest_release_number, :language, :status, :package_manager_url,
-      :stars, :forks, :keywords, :latest_stable_release,
+      :stars, :forks, :keywords, :latest_stable_release, :latest_download_url,
       :dependents_count, :dependent_repos_count
     ])
   end


### PR DESCRIPTION
This is a small step toward https://github.com/librariesio/libraries.io/issues/2169 , making available at least the latest download url.
