### PR TITLE
Fix parsing various things out of pom.xml

### DIFF
--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -69,17 +69,22 @@ module PackageManager
       base_url = "http://repo1.maven.org/maven2/#{project[:groupId]}/#{project[:artifactId]}"
       latest_version = project[:versions].last[:number]
       version_xml = get_xml(base_url + "/#{latest_version}/#{project[:artifactId]}-#{latest_version}.pom")
+      self.mapping_from_pom_xml(version_xml)
+    end
+
+    def self.mapping_from_pom_xml(version_xml)
       if version_xml.respond_to?('project')
         xml = version_xml.project
       else
         xml = version_xml
       end
       {
-        name: project[:name],
-        description: xml.locate('description').try(:nodes).try(:first),
-        homepage: xml.locate('url').try(:nodes).try(:first),
-        repository_url: repo_fallback(xml.locate('scm').try(:locate, 'url').try(:nodes).try(:first), xml.locate('url').try(:nodes).try(:first)),
-        licenses: (xml.locate('licenses').try(:locate, 'license') || []).map{|l| l.locate('name').map(&:nodes)}.flatten
+        name:  xml.locate('name').first.try(:nodes).try(:first),
+        description: xml.locate('description').first.try(:nodes).try(:first),
+        homepage: xml.locate('url').first.try(:nodes).try(:first),
+        repository_url: repo_fallback(xml.locate('scm/url').first.try(:nodes).try(:first),
+                                      xml.locate('url').first.try(:nodes).try(:first)),
+        licenses: xml.locate('licenses/license/name').map{|l| l.nodes}.flatten
       }
     end
 

--- a/spec/fixtures/proto-google-common-protos-0.1.9.pom
+++ b/spec/fixtures/proto-google-common-protos-0.1.9.pom
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.api.grpc</groupId>
+  <artifactId>proto-google-common-protos</artifactId>
+  <version>0.1.9</version>
+  <name>com.google.api.grpc:proto-google-common-protos</name>
+  <description>PROTO library for proto-google-common-protos</description>
+  <url>https://github.com/googleapis/googleapis</url>
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <id>Google Inc</id>
+      <name>Google Inc</name>
+      <email>googleapis-packages@google.com</email>
+      <url>https://github.com/googleapis/googleapis</url>
+      <organization>org.apache.maven.model.Organization@4749d95b</organization>
+      <organizationUrl>https://www.google.com</organizationUrl>
+    </developer>
+  </developers>
+  <scm>
+    <connection>scm:git:https://github.com/googleapis/googleapis</connection>
+    <url>https://github.com/googleapis/googleapis-dummy</url>
+  </scm>
+  <dependencies>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>3.2.0</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>api-common</artifactId>
+      <version>1.0.0-rc1</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/spec/models/package_manager/maven_spec.rb
+++ b/spec/models/package_manager/maven_spec.rb
@@ -16,4 +16,29 @@ describe PackageManager::Maven do
       expect(described_class.package_link(project, '2.0.0')).to eq("http://search.maven.org/#artifactdetails%7Ccom.github.jparkie%7Cpdd%7C2.0.0%7Cjar")
     end
   end
+
+  describe 'mapping_from_pom_xml' do
+    let(:pom) { Ox.parse(File.open("spec/fixtures/proto-google-common-protos-0.1.9.pom").read) }
+    let(:parsed) { described_class.mapping_from_pom_xml(pom) }
+
+    it 'to find license' do
+      expect(parsed[:licenses]).to eq(["Apache-2.0"])
+    end
+
+    it 'to find name' do
+      expect(parsed[:name]).to eq("com.google.api.grpc:proto-google-common-protos")
+    end
+
+    it 'to find description' do
+      expect(parsed[:description]).to eq("PROTO library for proto-google-common-protos")
+    end
+
+    it 'to find homepage' do
+      expect(parsed[:homepage]).to eq("https://github.com/googleapis/googleapis")
+    end
+
+    it 'to find repository url' do
+      expect(parsed[:repository_url]).to eq("https://github.com/googleapis/googleapis-dummy")
+    end
+  end
 end


### PR DESCRIPTION
Ox.locate returns an array so we need to look at the first element
of the array for a lot of things. Also take advantage of the fact
that Ox.locate can take a path in the xml instead of constructing
that logic.

Add tests with a sample pom file to show things are working
