### PR TITLE
Add link to Ruby wrapper

### DIFF
--- a/app/views/api/docs/index.html.erb
+++ b/app/views/api/docs/index.html.erb
@@ -479,6 +479,12 @@
     <ul>
       <li><a href="https://github.com/ropenscilabs/rbraries">rbraries</a></li>
     </ul>
+    <p>
+      Ruby
+    </p>
+    <ul>
+      <li><a href="https://github.com/marcandre/libraries_io">libraries_io</a></li>
+    </ul>
 
   </div>
   <div class="col-sm-4">


### PR DESCRIPTION
I created an API wrapper for Ruby: https://github.com/marcandre/libraries_io

This PR adds a link to the relevant docs page.