### PR TITLE
Fix doc on limit error code [doc only]

### DIFF
--- a/app/views/api/docs/index.html.erb
+++ b/app/views/api/docs/index.html.erb
@@ -20,7 +20,7 @@
     <h3 id='rate-limit'>Rate limit</h3>
 
     <p>
-      All requests are subject to a 60/request/minute rate limit based on your api_key, any further requests within that timeframe will result in a <code>403</code> response.
+      All requests are subject to a 60/request/minute rate limit based on your api_key, any further requests within that timeframe will result in a <code>429</code> response.
     </p>
 
     <h3 id='pagination'>Pagination</h3>


### PR DESCRIPTION
Very minor, but the error code generated by rack is (correctly) code 429 ("Too Many Requests") and not 403 ("Forbidden").

I noticed this when [running my spec suite on travis](https://travis-ci.org/marcandre/libraries_io/jobs/428830643#0-611). I now use VCR to avoid network calls at all...