### PR TITLE
Switch to the (non-deprecated) registration3 endpoint for nuget

### DIFF
--- a/app/models/package_manager/nu_get.rb
+++ b/app/models/package_manager/nu_get.rb
@@ -55,7 +55,7 @@ module PackageManager
     end
 
     def self.get_releases(name)
-      latest_version = get_json("https://api.nuget.org/v3/registration1/#{name.downcase}/index.json")
+      latest_version = get_json("https://api.nuget.org/v3/registration3/#{name.downcase}/index.json")
       if latest_version['items'][0]['items']
         releases = []
         latest_version['items'].each do |items|


### PR DESCRIPTION
nuget stopped updating registration1 a few months ago, we should
use registration3. It looks like everything we read out of the json
works just fine and it was already handling following the pages
