### PR TITLE
Add information about latest stable releases to the project table

### DIFF
--- a/app/models/concerns/releases.rb
+++ b/app/models/concerns/releases.rb
@@ -62,6 +62,12 @@ module Releases
     self.latest_release_number = latest_release.try(:number)
   end
 
+  def set_latest_stable_release_info
+    latest_stable = latest_stable_release
+    self.latest_stable_release_number = latest_stable.try(:number)
+    self.latest_stable_release_published_at = (latest_stable.try(:published_at).presence || latest_stable.try([:updated_at]))
+  end
+
   def set_runtime_dependencies_count
     self.runtime_dependencies_count = latest_release.try(:runtime_dependencies_count)
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -169,6 +169,7 @@ class Project < ApplicationRecord
     normalize_licenses
     set_latest_release_published_at
     set_latest_release_number
+    set_latest_stable_release_info
     set_runtime_dependencies_count
     set_language
   end

--- a/db/migrate/20181010192042_add_stable_release_to_projects.rb
+++ b/db/migrate/20181010192042_add_stable_release_to_projects.rb
@@ -1,0 +1,6 @@
+class AddStableReleaseToProjects < ActiveRecord::Migration[5.1]
+  def change
+    add_column :projects, :latest_stable_release_number, :string
+    add_column :projects, :latest_stable_release_published_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180404110322) do
+ActiveRecord::Schema.define(version: 20181010192042) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -116,30 +116,32 @@ ActiveRecord::Schema.define(version: 20180404110322) do
 
   create_table "projects", id: :serial, default: %q{nextval('projects_id_seq'::regclass)}, force: :cascade do |t|
     t.string   "name"
-    t.string   "platform",                    :index=>{:name=>"index_projects_on_platform_and_name", :with=>["name"], :unique=>true, :order=>{:platform=>:asc, :name=>:asc}}
-    t.datetime "created_at",                  :null=>false, :index=>{:name=>"index_projects_on_created_at", :order=>{:created_at=>:asc}}
-    t.datetime "updated_at",                  :null=>false, :index=>{:name=>"index_projects_on_updated_at", :order=>{:updated_at=>:asc}}
+    t.string   "platform",                           :index=>{:name=>"index_projects_on_platform_and_name", :with=>["name"], :unique=>true, :order=>{:platform=>:asc, :name=>:asc}}
+    t.datetime "created_at",                         :index=>{:name=>"index_projects_on_created_at", :order=>{:created_at=>:asc}}
+    t.datetime "updated_at",                         :index=>{:name=>"index_projects_on_updated_at", :order=>{:updated_at=>:asc}}
     t.text     "description"
     t.text     "keywords"
     t.string   "homepage"
     t.string   "licenses"
     t.string   "repository_url"
-    t.integer  "repository_id",               :index=>{:name=>"index_projects_on_repository_id", :order=>{:repository_id=>:asc}}
-    t.string   "normalized_licenses",         :default=>[], :array=>true
-    t.integer  "versions_count",              :default=>0, :null=>false, :index=>{:name=>"index_projects_on_versions_count", :order=>{:versions_count=>:asc}}
-    t.integer  "rank",                        :default=>0
+    t.integer  "repository_id",                      :index=>{:name=>"index_projects_on_repository_id", :order=>{:repository_id=>:asc}}
+    t.string   "normalized_licenses",                :default=>[], :array=>true
+    t.integer  "versions_count",                     :default=>0, :null=>false, :index=>{:name=>"index_projects_on_versions_count", :order=>{:versions_count=>:asc}}
+    t.integer  "rank",                               :default=>0
     t.datetime "latest_release_published_at"
     t.string   "latest_release_number"
     t.integer  "pm_id"
-    t.string   "keywords_array",              :default=>[], :array=>true, :index=>{:name=>"index_projects_on_keywords_array", :using=>:gin}
-    t.integer  "dependents_count",            :default=>0, :null=>false, :index=>{:name=>"index_projects_on_dependents_count", :order=>{:dependents_count=>:asc}}
+    t.string   "keywords_array",                     :default=>[], :array=>true, :index=>{:name=>"index_projects_on_keywords_array", :using=>:gin}
+    t.integer  "dependents_count",                   :default=>0, :null=>false, :index=>{:name=>"index_projects_on_dependents_count", :order=>{:dependents_count=>:asc}}
     t.string   "language"
     t.string   "status"
     t.datetime "last_synced_at"
     t.integer  "dependent_repos_count"
     t.integer  "runtime_dependencies_count"
-    t.integer  "score",                       :default=>0, :null=>false
+    t.integer  "score",                              :default=>0, :null=>false
     t.datetime "score_last_calculated"
+    t.string   "latest_stable_release_number"
+    t.datetime "latest_stable_release_published_at"
 
     t.index ["platform", "name"], :name=>"index_projects_on_platform_and_name_lower", :case_sensitive=>false
   end


### PR DESCRIPTION
This pulls the latest stable release and saves it along with the project much like is done with latest release. This way, we can get the information without having to do extra queries