### PR TITLE
Fix how we fetch the full list of package names from pypi

### DIFF
--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -20,7 +20,8 @@ module PackageManager
     end
 
     def self.project_names
-      get_raw("https://pypi.org/simple/").scan(/href='(\w+)'/).flatten
+      index = Nokogiri::HTML(get_raw("https://pypi.org/simple/"))
+      index.css("a").map(&:text)
     end
 
     def self.recent_names


### PR DESCRIPTION
This fixes up how we get the full list of packages from pypi per [PEP-503](https://www.python.org/dev/peps/pep-0503/)