### PR TITLE
Allow runtime dependencies to include 'normal'

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -7,7 +7,7 @@ class Version < ApplicationRecord
   belongs_to :project
   counter_culture :project
   has_many :dependencies, dependent: :delete_all
-  has_many :runtime_dependencies, -> { where kind: 'runtime' }, class_name: 'Dependency'
+  has_many :runtime_dependencies, -> { where kind: ['runtime', 'normal'] }, class_name: 'Dependency'
 
   after_commit :send_notifications_async, on: :create
   after_commit :update_repository_async, on: :create
@@ -90,7 +90,7 @@ class Version < ApplicationRecord
   end
 
   def any_outdated_dependencies?
-    @any_outdated_dependencies ||= dependencies.kind('runtime').any?(&:outdated?)
+    @any_outdated_dependencies ||= runtime_dependencies.any?(&:outdated?)
   end
 
   def to_param

--- a/app/views/projects/_statistics.html.erb
+++ b/app/views/projects/_statistics.html.erb
@@ -16,7 +16,7 @@
       Dependencies
     </dt>
     <dd class='col-xs-4'>
-      <%= number_to_human(@project.latest_version.dependencies.kind('runtime').count) %>
+      <%= number_to_human(@project.latest_version.runtime_dependencies.count) %>
     </dd>
     <dt class='col-xs-8'>
       Dependent Packages

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Version, type: :model do
   it { should belong_to(:project) }
   it { should have_many(:dependencies) }
-  it { should have_many(:runtime_dependencies).conditions(kind: 'runtime') }
+  it { should have_many(:runtime_dependencies).conditions(kind: ['runtime', 'normal']) }
 
   it { should validate_presence_of(:project_id) }
   it { should validate_presence_of(:number) }


### PR DESCRIPTION
Some package managers (notably cargo) use 'normal' for 'runtime'
deps so put that in the allowed kinds for runtime
