### PR TITLE
Update normalize_licenses to handle basic SPDX style license expressions

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -346,7 +346,25 @@ class Project < ApplicationRecord
     elsif licenses.length > 150
       normalized = ['Other']
     else
-      normalized = licenses.split(/[,\/]/).map do |license|
+      downcased = licenses.downcase
+      # chomp off leading/trailing () to make Spdx.find happier
+      if downcased.start_with?('(')
+        downcased[0] = ''
+      end
+      if downcased.start_with?(')')
+        downcased[-1] = ''
+      end
+      # splits are OR, AND, COMMA (,), and SLASH (/)
+      # technically OR and AND are different in meaning
+      # but our model doesn't allow the distinction
+      if downcased.include?("or")
+        split = downcased.split(/or/)
+      elsif downcased.include?("and")
+        split = downcased.split(/and/)
+      else
+        split = licenses.split(/[,\/]/)
+      end
+      normalized = split.map do |license|
         Spdx.find(license).try(:id)
       end.compact
       normalized = ['Other'] if normalized.empty?

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -16,4 +16,50 @@ describe Project, type: :model do
 
   it { should validate_presence_of(:name) }
   it { should validate_presence_of(:platform) }
+
+  describe 'license normalization' do
+    let(:project) { create(:project, name: 'foo', platform: PackageManager::Rubygems) }
+
+    it 'handles a single license' do
+      project.licenses = "mit"
+      project.normalize_licenses
+      expect(project.normalized_licenses).to eq(["MIT"])
+    end
+
+    it 'handles comma separated license' do
+      project.licenses = "mit,isc"
+      project.normalize_licenses
+      expect(project.normalized_licenses).to eq(["MIT", "ISC"])
+    end
+
+    it 'handles OR separated licenses' do
+      project.licenses = "mit OR isc"
+      project.normalize_licenses
+      expect(project.normalized_licenses).to eq(["MIT", "ISC"])
+    end
+
+    it 'handles or separated licenses' do
+      project.licenses = "mit or ISC"
+      project.normalize_licenses
+      expect(project.normalized_licenses).to eq(["MIT", "ISC"])
+    end
+
+    it 'handles (OR) separated licenses' do
+      project.licenses = "(mit OR isc)"
+      project.normalize_licenses
+      expect(project.normalized_licenses).to eq(["MIT", "ISC"])
+    end
+
+    it 'handles AND separated licenses' do
+      project.licenses = "mit AND ISC"
+      project.normalize_licenses
+      expect(project.normalized_licenses).to eq(["MIT", "ISC"])
+    end
+
+    it 'handles and separated licenses' do
+      project.licenses = "mit and ISC"
+      project.normalize_licenses
+      expect(project.normalized_licenses).to eq(["MIT", "ISC"])
+    end
+  end
 end


### PR DESCRIPTION
Allow basic spdx license mappings with OR and AND. Note that libraries
doesn't distinguish between the two with the current model so just
reporting both
