### PR TITLE
Moved listen gem to production list for PUma daemon mode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,7 @@ gem 'charlock_holmes', '>= 0.7.5'
 gem 'octicons_helper'
 gem 'ffi'
 gem 'bootsnap', require: false
+gem 'listen'
 
 group :development do
   gem 'spring'
@@ -99,7 +100,6 @@ group :development do
   gem 'capistrano-env'
   gem 'capistrano-linked-files'
   gem 'capistrano-sidekiq'
-  gem 'listen'
   gem 'pry'
   gem 'spring-watcher-listen'
 end


### PR DESCRIPTION
It appears that in order for Puma to run in daemon mode it requires the `listen` gem. Moved that dependency to the production list so that it is available at deploy time.
