### PR TITLE
Fix grammar: possessive its

### DIFF
--- a/app/views/api/docs/index.html.erb
+++ b/app/views/api/docs/index.html.erb
@@ -57,7 +57,7 @@
     <h3 id='project'>Project</h3>
 
     <p>
-      Get information about a package and it's versions.
+      Get information about a package and its versions.
     </p>
 
     <p>

--- a/app/views/pages/_open_data_documentation.html.erb
+++ b/app/views/pages/_open_data_documentation.html.erb
@@ -80,7 +80,7 @@
     </li>
     <li class='list-group-item'>
         <h5>Last synced Timestamp <em class='text-muted'>datetime</em></h5>
-        <p>Timestamp of when Libraries.io last synced the project from it's package manager API</p>
+        <p>Timestamp of when Libraries.io last synced the project from its package manager API</p>
       </p>
     </li>
     <li class='list-group-item'>
@@ -194,7 +194,7 @@
       Libraries.io dependencies belong to versions of a project, each version can have different sets of dependencies with different versions. Dependencies point at a specific version or range of versions of other projects, the resolution of that project version change over time as new versions are published and dependent on the specifics of the platform.
     </p>
     <p>
-      Almost all package managers dependencies will be from the same package manager, the only exception is Atom, which pulls it's
+      Almost all package managers dependencies will be from the same package manager, the only exception is Atom, which pulls its
       dependencies from the NPM package manager, hence the extra `Dependency Platform` field.
     </p>
   </div>
@@ -565,7 +565,7 @@
     </li>
     <li class='list-group-item'>
         <h5>Last synced Timestamp <em class='text-muted'>datetime</em></h5>
-        <p>Timestamp of when Libraries.io last synced the project from it's package manager API</p>
+        <p>Timestamp of when Libraries.io last synced the project from its package manager API</p>
       </p>
     </li>
     <li class='list-group-item'>

--- a/app/views/repository_users/projects.html.erb
+++ b/app/views/repository_users/projects.html.erb
@@ -23,7 +23,7 @@
       </strong>
     </h3>
     <p>
-      This is a list of every package published to a package manager that references one of <%= link_to @user, user_path(@user.to_param) %>'s repositories as it's source.
+      This is a list of every package published to a package manager that references one of <%= link_to @user, user_path(@user.to_param) %>'s repositories as its source.
     </p>
   </div>
 </div>

--- a/docs/add-a-package-manager.md
+++ b/docs/add-a-package-manager.md
@@ -3,7 +3,7 @@
 Libraries.io already has support for most of the largest package managers but there are many more
 that we've not added yet. This guide will take you through the steps for adding support for another.
 
-Adding support for a new package manager is fairly easy assuming that the package manager repository has an API for extracting data about it's packages over the internet. Follow these steps:
+Adding support for a new package manager is fairly easy assuming that the package manager repository has an API for extracting data about its packages over the internet. Follow these steps:
 
 ## Add the `PackageManager` class file
 
@@ -54,7 +54,7 @@ end
 
 ### `#project`
 
-Once we have a list of package names, we need to be able to get the information for each package by it's name from the registry. This is also used for syncing/updating a package we already know about when a new version is published.
+Once we have a list of package names, we need to be able to get the information for each package by its name from the registry. This is also used for syncing/updating a package we already know about when a new version is published.
 
 This method takes a string of the name as an argument and usually makes a http request to the registry for the given name and returns a ruby hash of information, often parsed from json or xml.
 
@@ -202,7 +202,7 @@ end
 
 ### `#formatted_name`
 
-If the package manager's official name doesn't fit with Ruby's class name rules you can add it's official name in this method, for example [`npm`](../app/models/package_manager/npm.rb) is always lower case, the class name is `NPM` so we have added the following:
+If the package manager's official name doesn't fit with Ruby's class name rules you can add its official name in this method, for example [`npm`](../app/models/package_manager/npm.rb) is always lower case, the class name is `NPM` so we have added the following:
 
 ```ruby
 def self.formatted_name


### PR DESCRIPTION
Its = belonging to it.

It's = it has, or it is.

It sort of makes sense when one considers one's yours, theirs, and hers,
which works so long as one's prepared to overlook one's one's. : )

https://en.oxforddictionaries.com/definition/its

- [x] Have you followed the guidelines for [contributors](http://docs.libraries.io/contributorshandbook)?
- [x] Have you checked to ensure there aren't other open pull requests on the repository for a similar change?
- [ ] Is there a corresponding ticket for your pull request?
- [ ] Have you written new tests for your changes?
    - It would be pretty cool to run all your prose through a grammar checker but I think it's out of scope for this PR ;)
- [ ] Have you successfully run the project with your changes locally?
    - No, I was too lazy to do this, but the change is so minor that I probably haven't broken anything.
