### PR TITLE
Optimize how we get the watched dependent projects

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,8 +20,6 @@ class User < ApplicationRecord
   has_many :public_repositories, -> { where private: false }, anonymous_class: Repository, through: :repository_users
 
   has_many :watched_repositories, source: :repository, through: :repository_subscriptions
-  has_many :watched_dependencies, through: :watched_repositories, source: :dependencies
-  has_many :watched_dependent_projects, -> { group('projects.id') }, through: :watched_dependencies, source: :project
 
   has_many :dependencies, through: :source_repositories
   has_many :really_all_dependencies, through: :all_repositories, source: :dependencies
@@ -70,6 +68,11 @@ class User < ApplicationRecord
 
   def to_s
     nickname
+  end
+
+  def watched_dependent_projects
+    repo_subs = repository_subscriptions.pluck(:repository_id)
+    Project.where(id: RepositoryDependency.where(repository_id: repo_subs).pluck(:project_id).uniq)
   end
 
   def all_subscribed_project_ids

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,8 +12,6 @@ describe User, type: :model do
   it { should have_many(:adminable_repository_organisations) }
   it { should have_many(:source_repositories) }
   it { should have_many(:watched_repositories) }
-  it { should have_many(:watched_dependencies) }
-  it { should have_many(:watched_dependent_projects) }
   it { should have_many(:dependencies) }
   it { should have_many(:really_all_dependencies) }
   it { should have_many(:all_dependent_projects) }


### PR DESCRIPTION
User.watched_dependent_projects is used on the homepage for User.all_subscribed_versions
and ends up being a pretty slow query

```sql
SELECT "projects"."*" FROM "projects" INNER JOIN "repository_dependencies" ON "projects"."id" = "repository_dependencies"."project_id" INNER JOIN "manifests" ON "repository_dependencies"."manifest_id" = "manifests"."id" INNER JOIN "repositories" ON "manifests"."repository_id" = "repositories"."id" INNER JOIN "repository_subscriptions" ON "repositories"."id" = "repository_subscriptions"."repository_id" WHERE "repository_subscriptions"."user_id" = ? GROUP BY projects.id
```

We can speed this up by making explicit queries that just return ids as necessary
and then querying by id (primary key) rather than ending up doing large table scans
