### PR TITLE
Add Maintenance Stats to the project status response 

### DIFF
--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -41,6 +41,10 @@ class Api::ApplicationController < ApplicationController
     @current_api_key ||= ApiKey.active.find_by_access_token(params[:api_key])
   end
 
+  def internal_api_key?
+    current_api_key.is_internal?
+  end
+
   def record_api_usage
     return unless @current_api_key.present?
     REDIS.hincrby "api-usage-#{Date.today.strftime("%Y-%m")}", @current_api_key.id, 1

--- a/app/controllers/api/status_controller.rb
+++ b/app/controllers/api/status_controller.rb
@@ -6,7 +6,7 @@ class Api::StatusController < Api::ApplicationController
       # Try to get all the projects passed in.
       @projects = params[:projects].group_by{|project| project[:platform] }.map do |platform, projects|
         projects.each_slice(1000).map do |slice|
-          Project.platform(platform).where(name: slice.map{|project| project[:name] }.uniq).includes(:repository, :versions)
+          Project.platform(platform).where(name: slice.map{|project| project[:name] }.uniq).includes(:repository, :versions, :repository_maintenance_stats)
         end
       end.flatten.compact
 
@@ -22,7 +22,7 @@ class Api::StatusController < Api::ApplicationController
           projects.each_slice(1000).map do |slice|
             downcased_names = slice.map {|project| project[:name].downcase }
             # lowercase compare the downcased_names... use lower(platform) to improve index usage
-            Project.where('lower(platform)=? AND lower(name) in (?)', platform.downcase, downcased_names).includes(:repository, :versions)
+            Project.where('lower(platform)=? AND lower(name) in (?)', platform.downcase, downcased_names).includes(:repository, :versions, :repository_maintenance_stats)
           end
         end.flatten.compact
         # Concatanate any new items found.

--- a/app/controllers/api/status_controller.rb
+++ b/app/controllers/api/status_controller.rb
@@ -31,10 +31,6 @@ class Api::StatusController < Api::ApplicationController
     else
       @projects = []
     end
-    fields = Project::API_FIELDS
-    if params[:score]
-      fields.push :score
-    end
     render json: @projects, each_serializer: ProjectStatusSerializer, show_score: params[:score], show_stats: internal_api_key?
   end
 end

--- a/app/controllers/api/status_controller.rb
+++ b/app/controllers/api/status_controller.rb
@@ -1,5 +1,6 @@
 class Api::StatusController < Api::ApplicationController
   before_action :require_api_key
+  before_action :require_internal_api_key
 
   def check
     if params[:projects].any?
@@ -41,6 +42,9 @@ class Api::StatusController < Api::ApplicationController
       include: {
         versions: {
           only: [:number, :published_at]
+        },
+        repository_maintenance_stats: {
+          only: [:category, :value, :updated_at]
         }
       }
     })

--- a/app/controllers/api/status_controller.rb
+++ b/app/controllers/api/status_controller.rb
@@ -1,6 +1,5 @@
 class Api::StatusController < Api::ApplicationController
   before_action :require_api_key
-  before_action :require_internal_api_key
 
   def check
     if params[:projects].any?
@@ -36,17 +35,6 @@ class Api::StatusController < Api::ApplicationController
     if params[:score]
       fields.push :score
     end
-    render json: @projects.to_json({
-      only: fields,
-      methods: [:package_manager_url, :stars, :forks, :keywords, :latest_download_url],
-      include: {
-        versions: {
-          only: [:number, :published_at]
-        },
-        repository_maintenance_stats: {
-          only: [:category, :value, :updated_at]
-        }
-      }
-    })
+    render json: @projects, each_serializer: ProjectStatusSerializer, show_score: params[:score], show_stats: internal_api_key?
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -36,6 +36,7 @@ class Project < ApplicationRecord
   has_many :registry_permissions, dependent: :delete_all
   has_many :registry_users, through: :registry_permissions
   has_one :readme, through: :repository
+  has_many :repository_maintenance_stats, through: :repository
 
   scope :platform, ->(platform) { where(platform: PackageManager::Base.format_name(platform)) }
   scope :lower_platform, ->(platform) { where('lower(projects.platform) = ?', platform.try(:downcase)) }

--- a/app/serializers/project_status_serializer.rb
+++ b/app/serializers/project_status_serializer.rb
@@ -1,0 +1,16 @@
+class ProjectStatusSerializer < ActiveModel::Serializer
+  attributes Project::API_FIELDS
+  attributes :package_manager_url, :stars, :forks, :keywords, :latest_download_url
+  attribute :score, if: :score?
+
+  has_many :versions
+  has_many :repository_maintenance_stats, if: :show_stats?
+
+  def score?
+    instance_options[:show_score]
+  end
+
+  def show_stats?
+    instance_options[:show_stats]
+  end
+end

--- a/app/serializers/repository_maintenance_stat_serializer.rb
+++ b/app/serializers/repository_maintenance_stat_serializer.rb
@@ -1,0 +1,3 @@
+class RepositoryMaintenanceStatSerializer < ActiveModel::Serializer
+  attributes :category, :value, :updated_at
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -151,6 +151,12 @@ FactoryBot.define do
     forks_count 1
   end
 
+  factory :repository_maintenance_stat do
+    category { "test_category" }
+    value { "test value" }
+    repository
+  end
+
   factory :user do
     email
     after(:create) do |user, _evaluator|
@@ -183,6 +189,7 @@ FactoryBot.define do
   factory :api_key do
     user
     access_token { SecureRandom.hex }
+    is_internal { false }
   end
 
   factory :auth_token do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -26,6 +26,7 @@ FactoryBot.define do
     licenses        'MIT'
     keywords_array  ['web']
     repository_url
+    repository { nil }
   end
 
   factory :platform do

--- a/spec/requests/api/status_spec.rb
+++ b/spec/requests/api/status_spec.rb
@@ -52,6 +52,27 @@ describe "API::StatusController" do
       expect(json_response.first["repository_maintenance_stats"].length).to be 0
     end
 
+    it "contains all expected fields" do
+      # all the fields we expect to come back in the response for a project
+      expected_fields = [
+        "name", "platform", "description", "homepage", "repository_url", "normalized_licenses",
+        "rank", "latest_release_published_at", "latest_release_number", "dependents_count",
+        "language", "status", "dependent_repos_count", "score", "latest_stable_release_number",
+        "latest_stable_release_published_at", "package_manager_url", "stars", "forks",
+        "keywords", "latest_download_url", "versions", "repository_maintenance_stats"
+      ]
+
+      post "/api/check", params: {api_key: internal_user.api_key, projects: [{name: project_django.name, platform: project_django.platform}], score: true }
+      expect(response).to have_http_status(:success)
+      expect(response.content_type).to eq('application/json')
+
+      json_response = JSON.parse(response.body)
+      project = json_response.first
+      expected_fields.each do |field|
+        expect(project.key? field).to be true
+      end
+    end
+
     context "with normal API key" do
 
       it "returns no maintenance stats" do

--- a/spec/requests/api/status_spec.rb
+++ b/spec/requests/api/status_spec.rb
@@ -4,13 +4,29 @@ describe "API::StatusController" do
   let(:user) { create(:user) }
   let!(:project) { create(:project) }
   let!(:project_django) { create(:project, name: 'Django', platform: 'Pypi') }
+  let!(:repository) { create(:repository) }
+  let!(:maintenance_stat) { create(:repository_maintenance_stat, repository: repository)}
+
+  before do
+    user.current_api_key.update_attribute(:is_internal, true)
+
+    project.repository = repository
+    project.save!
+  end
 
   describe "GET /api/check", type: :request do
     it "renders successfully with one" do
-      post "/api/check", params: {api_key: user.api_key, projects: [{name: project.name, platform: 'rubygems'}] }
+      post "/api/check", params: {api_key: user.api_key, projects: [{name: project.name, platform: project.platform}] }
       expect(response).to have_http_status(:success)
       expect(response.content_type).to eq('application/json')
       expect(response.body.include?(project.name)).to be == true
+      
+      # check for maintenance stats being returned
+      json_response = JSON.parse(response.body)
+      maintenance_stats = json_response.first["repository_maintenance_stats"]
+      expect(maintenance_stats.length).to be 1
+      expect(maintenance_stats.first["category"]).to eql maintenance_stat.category
+      expect(maintenance_stats.first["value"]).to eql maintenance_stat.value
     end
 
     it "renders empty json list if cannot find Project" do
@@ -26,6 +42,27 @@ describe "API::StatusController" do
       expect(response.content_type).to eq('application/json')
       expect(response.body.include?(project.name)).to be == true
       expect(response.body.include?('Django')).to be == true
+    end
+
+    it "renders empty maintenance stats if they don't exist" do
+      post "/api/check", params: {api_key: user.api_key, projects: [{name: project_django.name, platform: project_django.platform}] }
+      expect(response).to have_http_status(:success)
+      expect(response.content_type).to eq('application/json')
+      expect(response.body.include?(project_django.name)).to be == true
+
+      json_response = JSON.parse(response.body)
+      expect(json_response.first["repository_maintenance_stats"].length).to be 0
+    end
+
+    context "with normal API key" do
+      before do
+        user.current_api_key.update_attribute(:is_internal, false)
+      end
+
+      it "returns a 403 response code" do
+        post "/api/check", params: {api_key: user.api_key, projects: [{name: project_django.name, platform: project_django.platform}] }
+        expect(response).to have_http_status(:forbidden)
+      end
     end
   end
 end

--- a/spec/requests/api/status_spec.rb
+++ b/spec/requests/api/status_spec.rb
@@ -59,9 +59,14 @@ describe "API::StatusController" do
         user.current_api_key.update_attribute(:is_internal, false)
       end
 
-      it "returns a 403 response code" do
+      it "returns no maintenance stats" do
         post "/api/check", params: {api_key: user.api_key, projects: [{name: project_django.name, platform: project_django.platform}] }
-        expect(response).to have_http_status(:forbidden)
+        expect(response).to have_http_status(:success)
+        expect(response.content_type).to eq('application/json')
+        expect(response.body.include?(project_django.name)).to be == true
+
+        json_response = JSON.parse(response.body)
+        expect(json_response.first.key? "repository_maintenance_stats").to be false
       end
     end
   end


### PR DESCRIPTION
Added the repository stats to the project response in the status controller and added some tests to verify the response is correct. I also added the requirement for an internal API key to hit this URL.