### PR TITLE
Queries are not being sent directly to elasticsearch so the sanitizin…

### DIFF
--- a/app/models/concerns/project_search.rb
+++ b/app/models/concerns/project_search.rb
@@ -228,27 +228,6 @@ module ProjectSearch
       end
     end
 
-    def self.sanitize_query(str)
-      return '' if str.blank?
-      # Escape special characters
-      # http://lucene.apache.org/core/old_versioned_docs/versions/2_9_1/queryparsersyntax.html#Escaping Special Characters
-      escaped_characters = Regexp.escape('\\+-&|/!(){}[]^~?:')
-      str = str.gsub(/([#{escaped_characters}])/, '\\\\\1')
-
-      # AND, OR and NOT are used by lucene as logical operators. We need
-      # to escape them
-      ['AND', 'OR', 'NOT'].each do |word|
-        escaped_word = word.split('').map {|char| "\\#{char}" }.join('')
-        str = str.gsub(/\s*\b(#{word.upcase})\b\s*/, " #{escaped_word} ")
-      end
-
-      # Escape odd quotes
-      quote_count = str.count '"'
-      str = str.gsub(/(.*)"(.*)/, '\1\"\3') if quote_count % 2 == 1
-
-      str
-    end
-
     def self.facet_filter(name, limit, options)
       {
         aggs: {

--- a/app/models/concerns/project_search.rb
+++ b/app/models/concerns/project_search.rb
@@ -141,9 +141,8 @@ module ProjectSearch
       }
     end
 
-    def self.search(original_query, options = {})
+    def self.search(query, options = {})
       facet_limit = options.fetch(:facet_limit, 36)
-      query = sanitize_query(original_query)
       options[:filters] ||= []
       search_definition = {
         query: {

--- a/app/models/concerns/repo_search.rb
+++ b/app/models/concerns/repo_search.rb
@@ -61,7 +61,6 @@ module RepoSearch
 
     def self.search(query, options = {})
       facet_limit = options.fetch(:facet_limit, 35)
-      query = Project.sanitize_query(query)
       options[:filters] ||= []
       options[:must_not] ||= []
       search_definition = {


### PR DESCRIPTION
For example,

```
2.5.1 :003 > Project.search("org.apache.struts\\:struts2\\-core OR split").size
Cache read: 3268014704ba11472f4dcc63aa31912b2ec213b1
ETHON: performed EASY effective_url=http://localhost:9200/projects-development/project/_search response_code=200 return_code=ok total_time=0.03334
HTTP Cache: [GET /projects-development/project/_search] miss, uncacheable
 => 0 
```

```
2.5.1 :006 > Project.__elasticsearch__.search("org.apache.struts\\:struts2\\-core OR split").size
Cache read: 68b24659c7d3ddeba1ec38cb087e70376bf94982
ETHON: performed EASY effective_url=http://localhost:9200/projects-development/project/_search?q=org.apache.struts%5C%3Astruts2%5C-core+OR+split response_code=200 return_code=ok total_time=0.007655
HTTP Cache: [GET /projects-development/project/_search?q=org.apache.struts%5C%3Astruts2%5C-core+OR+split] miss, uncacheable
 => 2 
```