### PR TITLE
Revert "Remove link to dependent repos page, as when there are a lot …

### DIFF
--- a/app/views/projects/_statistics.html.erb
+++ b/app/views/projects/_statistics.html.erb
@@ -29,7 +29,7 @@
       Dependent repositories
     </dt>
     <dd class='col-xs-4'>
-      <%= number_to_human(@project.dependent_repos_count) %>
+      <%= link_to number_to_human(@project.dependent_repos_count), project_usage_path(@project.to_param) %>
     </dd>
     <dt class='col-xs-8'>
       Total <%= @project.release_or_tag %>


### PR DESCRIPTION
This page should be faster now with the materialized view so we shouldn't need to remove this link. I don't think this actually did much anyway.