### PR TITLE
Rake Task to Process Repository Maintenance Stats

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -38,7 +38,7 @@ class Project < ApplicationRecord
   has_one :readme, through: :repository
   has_many :repository_maintenance_stats, through: :repository
 
-  scope :least_recently_updated_stats, -> { joins(:repository_maintenance_stats).group('projects.id').where.not(repository: nil).order('max(repository_maintenance_stats.updated_at) ASC') }
+  scope :least_recently_updated_stats, -> { joins(:repository_maintenance_stats).group('projects.id').where.not(repository: nil).order(Arel.sql('max(repository_maintenance_stats.updated_at) ASC')) }
   scope :no_existing_stats, -> { includes(:repository_maintenance_stats).where(repository_maintenance_stats: {id: nil}).where.not(repository: nil) }
 
   scope :platform, ->(platform) { where(platform: PackageManager::Base.format_name(platform)) }
@@ -274,7 +274,7 @@ class Project < ApplicationRecord
 
   def set_dependents_count
     return if destroyed?
-    new_dependents_count = dependents.joins(:version).pluck('DISTINCT versions.project_id').count
+    new_dependents_count = dependents.joins(:version).pluck(Arel.sql('DISTINCT versions.project_id')).count
     new_dependent_repos_count = dependent_repos_fast_count
 
     updates = {}

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -119,4 +119,18 @@ namespace :projects do
     exit if ENV['READ_ONLY'].present?
     ProjectDependentRepository.refresh
   end
+
+  supported_platforms = ['Maven', 'npm', 'Bower', 'PyPI', 'Rubygems', 'Packagist']
+
+  desc 'Create maintenance stats for projects'
+  task create_maintenance_stats: :environment do
+    exit if ENV['READ_ONLY'].present?
+    Project.no_existing_stats.where(platform: supported_platforms).limit(500).each(&:update_maintenance_stats_async)
+  end
+
+  desc 'Update maintenance stats for projects'
+  task update_maintenance_stats: :environment do
+    exit if ENV['READ_ONLY'].present?
+    Project.least_recently_updated_stats.where(platform: supported_platforms).limit(500).each{|project| project.update_maintenance_stats_async(priority: :low)}
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -13,6 +13,7 @@ describe Project, type: :model do
   it { should have_many(:project_suggestions) }
   it { should have_one(:readme) }
   it { should belong_to(:repository) }
+  it { should have_many(:repository_maintenance_stats)}
 
   it { should validate_presence_of(:name) }
   it { should validate_presence_of(:platform) }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -64,7 +64,7 @@ describe Project, type: :model do
     end
   end
 
-  describe 'maintenance stats', focus: true do
+  describe 'maintenance stats' do
     let!(:repository) { create(:repository) }
     let!(:project) { create(:project, repository: repository) }
 


### PR DESCRIPTION
Added rake tasks to update a project's maintenance stats and to fill in those stats for project's without any. 