### PR TITLE
Remove rack-timeout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,6 @@ gem 'premailer-rails', '1.9.7'
 gem 'gemoji'
 gem 'foreman', require: false
 gem 'puma'
-gem 'rack-timeout', '0.4.2'
 gem 'semantic_range'
 gem 'license-compatibility'
 gem 'escape_utils'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -462,7 +462,6 @@ GEM
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rack-timeout (0.4.2)
     rails (5.2.2)
       actioncable (= 5.2.2)
       actionmailer (= 5.2.2)
@@ -744,7 +743,6 @@ DEPENDENCIES
   rack-attack-rate-limit
   rack-canonical-host
   rack-cors
-  rack-timeout (= 0.4.2)
   rails (= 5.2.2)
   rails-timeago!
   rails_safe_tasks

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,2 +1,0 @@
-Rack::Timeout.timeout = ENV.fetch("TIMEOUT", 10).to_i  # seconds
-Rack::Timeout::Logger.disable


### PR DESCRIPTION
Rack::Timeout leads to leaking of database connections as requests
timeout and that then takes things down. Let's instead let requests
run a little longer
