### PR TITLE
Pass in # of Projects to Sync in Rake Tasks

### DIFF
--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -123,14 +123,16 @@ namespace :projects do
   supported_platforms = ['Maven', 'npm', 'Bower', 'PyPI', 'Rubygems', 'Packagist']
 
   desc 'Create maintenance stats for projects'
-  task create_maintenance_stats: :environment do
+  task :create_maintenance_stats, [:number_to_sync] => :environment do |_task, args|
     exit if ENV['READ_ONLY'].present?
-    Project.no_existing_stats.where(platform: supported_platforms).limit(500).each(&:update_maintenance_stats_async)
+    number_to_sync = args.number_to_sync || 2000
+    Project.no_existing_stats.where(platform: supported_platforms).limit(number_to_sync).each(&:update_maintenance_stats_async)
   end
 
   desc 'Update maintenance stats for projects'
-  task update_maintenance_stats: :environment do
+  task :update_maintenance_stats, [:number_to_sync] => :environment do |_task, args|
     exit if ENV['READ_ONLY'].present?
-    Project.least_recently_updated_stats.where(platform: supported_platforms).limit(500).each{|project| project.update_maintenance_stats_async(priority: :low)}
+    number_to_sync = args.number_to_sync || 2000
+    Project.least_recently_updated_stats.where(platform: supported_platforms).limit(number_to_sync).each{|project| project.update_maintenance_stats_async(priority: :low)}
   end
 end


### PR DESCRIPTION
Should let us change the amount of projects we want to dump in the queues in the cron jobs without having to deploy a new version of libraries.io