### PR TITLE
Parse nuget licenses

### DIFF
--- a/app/models/package_manager/nu_get.rb
+++ b/app/models/package_manager/nu_get.rb
@@ -84,7 +84,8 @@ module PackageManager
         homepage: item['projectUrl'],
         keywords_array: Array(item['tags']),
         repository_url: repo_fallback('', item['projectUrl']),
-        releases: project[:releases]
+        releases: project[:releases],
+        licenses: item['licenseExpression']
       }
     end
 


### PR DESCRIPTION
This parses nuget licenseExpressions which are the current way
to give a license for a nuget package (see
https://github.com/NuGet/Home/wiki/Packaging-License-within-the-nupkg).

To support older packages, we'd also need/want to look at licenseUrl
but that then would require downloading and evaluating the contents
of that file. Given nuget is deprecating and not allowing it for new
versions, this feels like it'll cover things as they're released
and is the current best practice for the ecosystem
