### PR TITLE
Reformat Project repository_url On Save

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -87,6 +87,7 @@ module PackageManager
         dbproject.assign_attributes(mapped_project.except(:name, :releases, :versions, :version, :dependencies))
         dbproject.save
       else
+        dbproject.reformat_repository_url
         dbproject.update_attributes(mapped_project.except(:name, :releases, :versions, :version, :dependencies))
       end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,4 +1,3 @@
-require "pry"
 class Project < ApplicationRecord
   include ProjectSearch
   include SourceRank

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,3 +1,4 @@
+require "pry"
 class Project < ApplicationRecord
   include ProjectSearch
   include SourceRank
@@ -544,6 +545,11 @@ class Project < ApplicationRecord
 
   def update_maintenance_stats_async(priority: :medium)
     RepositoryMaintenanceStatWorker.enqueue(repository.id, priority: priority) unless repository.nil?
+  end
+
+  def reformat_repository_url
+    repository_url = URLParser.try_all(self.repository_url)
+    update_attributes(repository_url: repository_url)
   end
 
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -119,4 +119,16 @@ describe Project, type: :model do
       end
     end
   end
+
+  describe 'reformat_urls' do
+    let!(:project) { create(:project) }
+
+    it "should save the updated format URL" do
+      project.update_attributes!(homepage: 'https://libraries.io', repository_url: 'scm:git:git://github.com/librariesio/libraries.io/libaries.io.git')
+      project.reformat_repository_url
+      
+      expect(project.homepage).to eql 'https://libraries.io'
+      expect(project.repository_url).to eql 'https://github.com/librariesio/libraries.io'
+    end
+  end
 end


### PR DESCRIPTION
This might help with a few repositories that have an old poorly formatted repository url and do not find a new one to reformat on sync.