### PR TITLE
Add Log Message to Trace Sync Errors

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -125,7 +125,6 @@ class Project < ApplicationRecord
   def manual_sync
     async_sync
     update_repository_async
-    self.last_synced_at = Time.zone.now
     forced_save
   end
 

--- a/app/workers/package_manager_download_worker.rb
+++ b/app/workers/package_manager_download_worker.rb
@@ -4,6 +4,7 @@ class PackageManagerDownloadWorker
 
   def perform(class_name, name)
     return unless class_name.present?
+    Rails.logger.info("Beginning update for #{class_name}/#{name}")
     "PackageManager::#{class_name}".constantize.update(name)
   end
 end

--- a/app/workers/package_manager_download_worker.rb
+++ b/app/workers/package_manager_download_worker.rb
@@ -4,7 +4,7 @@ class PackageManagerDownloadWorker
 
   def perform(class_name, name)
     return unless class_name.present?
-    Rails.logger.info("Beginning update for #{class_name}/#{name}")
+    logger.info("Beginning update for #{class_name}/#{name}")
     "PackageManager::#{class_name}".constantize.update(name)
   end
 end


### PR DESCRIPTION
Add a log message when starting a sync so we can search for it in the logs to figure out what is going on with packages that are not syncing correctly. Also changed when `last_synced_at` is set so that it is set during the update and not when the request is made.