### PR TITLE
Order Contributors by the Number of Contributions in API

### DIFF
--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -59,7 +59,7 @@ class Api::ProjectsController < Api::ApplicationController
   end
 
   def contributors
-    paginate json: @project.contributors
+    paginate json: @project.contributors.order('count DESC')
   end
 
   private


### PR DESCRIPTION
They are already ordered by this on the main Project page.