### PR TITLE
Remove Unique Digests

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -331,6 +331,6 @@ class Repository < ApplicationRecord
   end
 
   def gather_maintenance_stats
-    CriticalRepositoryMaintenanceStatWorker.perform_async(id)
+    RepositoryMaintenanceStatWorker.enqueue(id, priority: :medium)
   end
 end

--- a/app/workers/repository_maintenance_stat_worker.rb
+++ b/app/workers/repository_maintenance_stat_worker.rb
@@ -1,13 +1,6 @@
 class RepositoryMaintenanceStatWorker
     include Sidekiq::Worker
-    ##
-    # These settings will create a lock using a combination of the worker class and arguments passed.
-    # This will prevent a second request for the same repository to be added to the Sidekiq queue and
-    # will keep the existing request. There are three queues in use which are set with different priority levels.
-    # This lock will exist across the different priority queues to prevent
-    # duplication at different priorities for the same repository. By default this worker will use the
-    # medium priority queue. If a request is rejected because of an existing lock, then a message will be sent to the logs.
-    sidekiq_options queue: :repo_maintenance_stat, lock: :until_and_while_executing, unique_across_queues: true, retry: 3, on_conflict: :log
+    sidekiq_options queue: :repo_maintenance_stat, retry: 3
 
     def perform(repo_id)
         GatherRepositoryMaintenanceStats.gather_stats(Repository.find_by_id(repo_id))


### PR DESCRIPTION
This will remove the unique requirements when adding a repository to the maintenance stat queue. The digests are not being reliably removed from Redis which results in a repository being locked out from getting refreshed, potentially permanently. It appears to be a known issue in the unique jobs gem: https://github.com/mhenrixon/sidekiq-unique-jobs/issues/379

Keeping the repository requests unique is potentially useful, but more care needs to be taken on creating/removing the locks. Perhaps the gem will provide a fix that could be used again later?