### PR TITLE
Define ProjectSearch#marshal_load to match marshal_dump

### DIFF
--- a/app/models/concerns/project_search.rb
+++ b/app/models/concerns/project_search.rb
@@ -67,6 +67,12 @@ module ProjectSearch
       end
     end
 
+    def marshal_load(hash)
+      hash.each do |attr, value|
+        instance_variable_set(attr, value)
+      end
+    end
+
     def self.facets(options = {})
       Rails.cache.fetch "facet:#{options.to_s.gsub(/\W/, '')}", :expires_in => 1.hour, race_condition_ttl: 2.minutes do
         search('', options).response.aggregations

--- a/spec/models/concerns/project_search_spec.rb
+++ b/spec/models/concerns/project_search_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe ProjectSearch do
+  subject { build(:project) }
+
+  it "Marshals properly" do
+    original = subject.to_json
+    result = Marshal.load(Marshal.dump(subject)).to_json
+
+    expect(result).to eq(original)
+  end
+end


### PR DESCRIPTION
Looks like this may have been broken in #2269

You must define `marshal_load` if you define `marshal_dump` (https://ruby-doc.org/core-2.6/Marshal.html)