### PR TITLE
We need to always update source rank instead of deciding based on updated_at

### DIFF
--- a/app/models/concerns/source_rank.rb
+++ b/app/models/concerns/source_rank.rb
@@ -7,7 +7,7 @@ module SourceRank
   end
 
   def update_source_rank_async
-    UpdateSourceRankWorker.perform_async(self.id) if updated_at.present? && updated_at < 1.day.ago
+    UpdateSourceRankWorker.perform_async(self.id)
 
     ProjectScoreCalculationBatch.enqueue(platform, [id])
   end


### PR DESCRIPTION
We call the async worker when we're updating a record. So updated_at
is always going to be recent. This means we're not actually updating
source ranks regularly

Fixes #2324
