### PR TITLE
Add normalized_licenses to dependencies view

### DIFF
--- a/app/controllers/api/docs_controller.rb
+++ b/app/controllers/api/docs_controller.rb
@@ -17,7 +17,7 @@ class Api::DocsController < ApplicationController
 
     @repo_dependencies = @repository.as_json
 
-    @repo_dependencies[:dependencies] = map_dependencies(@repository.repository_dependencies || [])
+    @repo_dependencies[:dependencies] = map_dependencies(@repository.repository_dependencies.includes(:project) || [])
 
     @search = Project.search('grunt', api: true).records
 

--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -79,7 +79,7 @@ class Api::ProjectsController < Api::ApplicationController
 
     project_json = serializer.new(project).as_json
     project_json[:dependencies_for_version] = version.number
-    project_json[:dependencies] = map_dependencies(version.dependencies || [])
+    project_json[:dependencies] = map_dependencies(version.dependencies.includes(:project) || [])
 
     project_json
   end

--- a/app/controllers/api/repositories_controller.rb
+++ b/app/controllers/api/repositories_controller.rb
@@ -11,7 +11,7 @@ class Api::RepositoriesController < Api::ApplicationController
 
   def dependencies
     repo_json = RepositorySerializer.new(@repository).as_json
-    repo_json[:dependencies] = map_dependencies(@repository.repository_dependencies || [])
+    repo_json[:dependencies] = map_dependencies(@repository.repository_dependencies.includes(:projects) || [])
 
     render json: repo_json
   end

--- a/app/serializers/dependency_serializer.rb
+++ b/app/serializers/dependency_serializer.rb
@@ -1,4 +1,8 @@
 class DependencySerializer < ActiveModel::Serializer
   attributes :project_name, :name, :platform, :requirements, :latest_stable,
-             :latest, :deprecated, :outdated, :filepath, :kind
+             :latest, :deprecated, :outdated, :filepath, :kind, :normalized_licenses
+
+  def normalized_licenses
+    object.project.try(:normalized_licenses)
+  end
 end

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -89,7 +89,8 @@ describe "Api::ProjectsController" do
           "deprecated": dependency.deprecated,
           "outdated": dependency.outdated,
           "filepath": dependency.filepath,
-          "kind": dependency.kind
+          "kind": dependency.kind,
+          "normalized_licenses": dependency.project.normalized_licenses,
           }
         end
         }.to_json)
@@ -116,7 +117,8 @@ describe "Api::ProjectsController" do
           "deprecated": dependency.deprecated,
           "outdated": dependency.outdated,
           "filepath": dependency.filepath,
-          "kind": dependency.kind
+          "kind": dependency.kind,
+          "normalized_licenses": dependency.project.normalized_licenses,
           }
         end
         }.to_json)
@@ -162,7 +164,8 @@ describe "Api::ProjectsController" do
               "deprecated": dependency.deprecated,
               "outdated": dependency.outdated,
               "filepath": dependency.filepath,
-              "kind": dependency.kind
+              "kind": dependency.kind,
+              "normalized_licenses": dependency.project.normalized_licenses,
             }
             end
           }
@@ -183,7 +186,8 @@ describe "Api::ProjectsController" do
               "deprecated": dependency.deprecated,
               "outdated": dependency.outdated,
               "filepath": dependency.filepath,
-              "kind": dependency.kind
+              "kind": dependency.kind,
+              "normalized_licenses": dependency.project.normalized_licenses,
             }
             end
           }

--- a/spec/serializers/dependency_serializer_spec.rb
+++ b/spec/serializers/dependency_serializer_spec.rb
@@ -7,6 +7,6 @@ describe DependencySerializer do
     expect(subject.attributes.keys).to eql([:project_name, :name, :platform,
                                             :requirements, :latest_stable,
                                             :latest, :deprecated, :outdated,
-                                            :filepath, :kind])
+                                            :filepath, :kind, :normalized_licenses])
   end
 end


### PR DESCRIPTION
I'd like to have `normalized_licenses` in the dependencies API schema

I opted to modify all uses of `map_dependencies` to avoid n+1 queries rather than introduce another serializer.