### PR TITLE
Maven: Look up Parent POM for Information

### DIFF
--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -87,19 +87,19 @@ module PackageManager
       keys = %i[description homepage repository_url licenses]
       parent = Hash[keys.product([nil])]
       if xml.locate('parent').first
-        group_id = xml.locate('parent/groupId').first.try(:nodes).try(:first)
-        artifact_id = xml.locate('parent/artifactId').first.try(:nodes).try(:first)
-        unless [group_id, artifact_id].any?(nil)
+        group_id = xml.locate('parent/groupId').first&.nodes&.first
+        artifact_id = xml.locate('parent/artifactId').first&.nodes&.first
+        if group_id && artifact_id
           parent = mapping(project([group_id, artifact_id].join(":")))
         end
       end
 
       # merge with parent data if available and take child values on overlap
       child = {
-        description: xml.locate('description').first.try(:nodes).try(:first),
-        homepage: xml.locate('url').first.try(:nodes).try(:first),
-        repository_url: repo_fallback(xml.locate('scm/url').first.try(:nodes).try(:first),
-                                      xml.locate('url').first.try(:nodes).try(:first)),
+        description: xml.locate('description').first&.nodes&.first,
+        homepage: xml.locate('url').first&.nodes&.first,
+        repository_url: repo_fallback(xml.locate('scm/url').first&.nodes&.first,
+                                      xml.locate('url').first&.nodes&.first),
         licenses: xml.locate('licenses/license/name').map{|l| l.nodes}.flatten.join(",")
       }.reject{|k,v| v.nil?}
       parent.merge(child)

--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -101,7 +101,7 @@ module PackageManager
         repository_url: repo_fallback(xml.locate('scm/url').first.try(:nodes).try(:first),
                                       xml.locate('url').first.try(:nodes).try(:first)),
         licenses: xml.locate('licenses/license/name').map{|l| l.nodes}.flatten.join(",")
-      }.reject!{|k,v| v.nil?}
+      }.reject{|k,v| v.nil?}
       parent.merge(child)
     end
 

--- a/spec/fixtures/proto-google-common-protos-0.1.9.pom
+++ b/spec/fixtures/proto-google-common-protos-0.1.9.pom
@@ -9,10 +9,10 @@
   <description>PROTO library for proto-google-common-protos</description>
 
   <parent>
-		<groupId>com.google.api.grpc</groupId>
-		<artifactId>proto-google-common-parent</artifactId>
-		<version>0.1.9</version>
-	</parent>
+    <groupId>com.google.api.grpc</groupId>
+    <artifactId>proto-google-common-parent</artifactId>
+    <version>0.1.9</version>
+  </parent>
 
   <licenses>
     <license>

--- a/spec/fixtures/proto-google-common-protos-0.1.9.pom
+++ b/spec/fixtures/proto-google-common-protos-0.1.9.pom
@@ -7,7 +7,13 @@
   <version>0.1.9</version>
   <name>com.google.api.grpc:proto-google-common-protos</name>
   <description>PROTO library for proto-google-common-protos</description>
-  <url>https://github.com/googleapis/googleapis</url>
+
+  <parent>
+		<groupId>com.google.api.grpc</groupId>
+		<artifactId>proto-google-common-parent</artifactId>
+		<version>0.1.9</version>
+	</parent>
+
   <licenses>
     <license>
       <name>Apache-2.0</name>

--- a/spec/models/package_manager/maven_spec.rb
+++ b/spec/models/package_manager/maven_spec.rb
@@ -20,30 +20,41 @@ describe PackageManager::Maven do
   describe 'mapping_from_pom_xml' do
     let(:pom) { Ox.parse(File.open("spec/fixtures/proto-google-common-protos-0.1.9.pom").read) }
     let(:parent_pom) { {homepage: 'https://github.com/googleapis/googleapis', licenses: 'unknown'} }
-    let(:parent_project) { {name: 'com.google.api.grpc:proto-google-common-parent', groupId: 'com.google.api.grpc', artifactId: 'proto-google-common-parent', versions: []} }
+    let(:parent_project) { {name: 'com.google.api.grpc:proto-google-common-parent', groupId: 'com.google.api.grpc', artifactId: 'proto-google-common-parent', versions: [{number: "1.0", published_at: Time.now.to_s}]} }
     let(:parsed) { described_class.mapping_from_pom_xml(pom) }
 
-    before do 
-      expect(described_class).to receive(:project).and_return(parent_project)
-      expect(described_class).to receive(:mapping).with(parent_project).and_return(parent_pom)
+    context "with parsed pom" do
+      before do 
+        expect(described_class).to receive(:project).and_return(parent_project)
+        expect(described_class).to receive(:mapping).with(parent_project, 1).and_return(parent_pom)
+      end
+  
+      it 'to find license' do
+        # parent license should be overwritten by direct pom
+        expect(parsed[:licenses]).to eq("Apache-2.0")
+      end
+  
+      it 'to find description' do
+        expect(parsed[:description]).to eq("PROTO library for proto-google-common-protos")
+      end
+  
+      it 'to find homepage' do
+        # homepage value should come from parent pom
+        expect(parsed[:homepage]).to eq("https://github.com/googleapis/googleapis")
+      end
+  
+      it 'to find repository url' do
+        expect(parsed[:repository_url]).to eq("https://github.com/googleapis/googleapis-dummy")
+      end
     end
-
-    it 'to find license' do
-      # parent license should be overwritten by direct pom
-      expect(parsed[:licenses]).to eq("Apache-2.0")
-    end
-
-    it 'to find description' do
-      expect(parsed[:description]).to eq("PROTO library for proto-google-common-protos")
-    end
-
-    it 'to find homepage' do
-      # homepage value should come from parent pom
-      expect(parsed[:homepage]).to eq("https://github.com/googleapis/googleapis")
-    end
-
-    it 'to find repository url' do
-      expect(parsed[:repository_url]).to eq("https://github.com/googleapis/googleapis-dummy")
+  
+    it 'to stop calling parent poms at maximum depth' do
+      # parent lookup methods should be called 5 times
+      # each call to get the parent will return a pom file also with a parent, which would be an endless loop
+      expect(described_class).to receive(:project).exactly(5).times.and_return(parent_project)
+      expect(described_class).to receive(:get_xml).exactly(5).times.and_return(pom)
+      expect(described_class).to receive(:mapping).exactly(5).times.and_call_original
+      described_class.mapping_from_pom_xml(pom)
     end
   end
 end

--- a/spec/models/package_manager/maven_spec.rb
+++ b/spec/models/package_manager/maven_spec.rb
@@ -19,9 +19,17 @@ describe PackageManager::Maven do
 
   describe 'mapping_from_pom_xml' do
     let(:pom) { Ox.parse(File.open("spec/fixtures/proto-google-common-protos-0.1.9.pom").read) }
+    let(:parent_pom) { {homepage: 'https://github.com/googleapis/googleapis', licenses: 'unknown'} }
+    let(:parent_project) { {name: 'com.google.api.grpc:proto-google-common-parent', groupId: 'com.google.api.grpc', artifactId: 'proto-google-common-parent', versions: []} }
     let(:parsed) { described_class.mapping_from_pom_xml(pom) }
 
+    before do 
+      expect(described_class).to receive(:project).and_return(parent_project)
+      expect(described_class).to receive(:mapping).with(parent_project).and_return(parent_pom)
+    end
+
     it 'to find license' do
+      # parent license should be overwritten by direct pom
       expect(parsed[:licenses]).to eq("Apache-2.0")
     end
 
@@ -30,6 +38,7 @@ describe PackageManager::Maven do
     end
 
     it 'to find homepage' do
+      # homepage value should come from parent pom
       expect(parsed[:homepage]).to eq("https://github.com/googleapis/googleapis")
     end
 


### PR DESCRIPTION
This will look into the POM xml for an artifact and if there is a parent specified it will also look up the parent POM file recursively. Values are overwritten by the child POM file and missing values are carried down from the parent. This should hopefully help with some of the Maven data being missing or incorrect.