### PR TITLE
Expand Maven Properties

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ gem 'asciidoctor'
 gem 'org-ruby'
 gem 'creole'
 gem 'bundler'
-gem 'bibliothecary', :path => '/Users/mike/Developer/libraries/bibliothecary'
+gem 'bibliothecary', git: 'https://github.com/librariesio/bibliothecary', tag: "v6.7.2"
 gem 'github-linguist'
 gem 'rack-cors', :require => 'rack/cors'
 gem 'active_model_serializers'

--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ gem 'asciidoctor'
 gem 'org-ruby'
 gem 'creole'
 gem 'bundler'
-gem 'bibliothecary', git: 'https://github.com/librariesio/bibliothecary', tag: "v6.7.0"
+gem 'bibliothecary', :path => '/Users/mike/Developer/libraries/bibliothecary'
 gem 'github-linguist'
 gem 'rack-cors', :require => 'rack/cors'
 gem 'active_model_serializers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -745,4 +745,4 @@ RUBY VERSION
    ruby 2.6.2p47
 
 BUNDLED WITH
-   1.17.3
+   1.17.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,18 @@
 GIT
+  remote: https://github.com/librariesio/bibliothecary
+  revision: 010fb70818125f9a9814b1f233f6428edffaf446
+  tag: v6.7.2
+  specs:
+    bibliothecary (6.7.2)
+      commander
+      deb_control
+      librariesio-gem-parser
+      ox (>= 2.8.1)
+      sdl4r
+      toml-rb (~> 1.0)
+      typhoeus
+
+GIT
   remote: https://github.com/librariesio/bitbucket
   revision: 43f8f97be403091debab480235413b20059337bd
   specs:
@@ -23,18 +37,6 @@ GIT
   revision: ed94eaa7107bdc60e8fd98e1904d4c065a9a576d
   specs:
     semantic (1.6.1)
-
-PATH
-  remote: /Users/mike/Developer/libraries/bibliothecary
-  specs:
-    bibliothecary (6.7.2)
-      commander
-      deb_control
-      librariesio-gem-parser
-      ox (>= 2.8.1)
-      sdl4r
-      toml-rb (~> 1.0)
-      typhoeus
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,4 @@
 GIT
-  remote: https://github.com/librariesio/bibliothecary
-  revision: 22e47f979ee9c1189ae528aa41c092d64b335fe6
-  tag: v6.7.0
-  specs:
-    bibliothecary (6.7.0)
-      commander
-      deb_control
-      librariesio-gem-parser
-      ox (>= 2.8.1)
-      sdl4r
-      toml-rb (~> 1.0)
-      typhoeus
-
-GIT
   remote: https://github.com/librariesio/bitbucket
   revision: 43f8f97be403091debab480235413b20059337bd
   specs:
@@ -37,6 +23,18 @@ GIT
   revision: ed94eaa7107bdc60e8fd98e1904d4c065a9a576d
   specs:
     semantic (1.6.1)
+
+PATH
+  remote: /Users/mike/Developer/libraries/bibliothecary
+  specs:
+    bibliothecary (6.7.2)
+      commander
+      deb_control
+      librariesio-gem-parser
+      ox (>= 2.8.1)
+      sdl4r
+      toml-rb (~> 1.0)
+      typhoeus
 
 GEM
   remote: https://rubygems.org/
@@ -745,4 +743,4 @@ RUBY VERSION
    ruby 2.6.2p47
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -84,11 +84,11 @@ module PackageManager
       return false unless mapped_project.present?
       dbproject = Project.find_or_initialize_by({:name => mapped_project[:name], :platform => self.name.demodulize})
       if dbproject.new_record?
-        dbproject.assign_attributes(mapped_project.except(:name, :releases, :versions, :version, :dependencies))
+        dbproject.assign_attributes(mapped_project.except(:name, :releases, :versions, :version, :dependencies, :properties))
         dbproject.save
       else
         dbproject.reformat_repository_url
-        dbproject.update_attributes(mapped_project.except(:name, :releases, :versions, :version, :dependencies))
+        dbproject.update_attributes(mapped_project.except(:name, :releases, :versions, :version, :dependencies, :properties))
       end
 
       if self::HAS_VERSIONS

--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -126,13 +126,9 @@ module PackageManager
     end
 
     def self.extract_pom_properties(xml)
-      props = {}
-      if xml.respond_to? 'properties'
-        xml.properties.each do |prop_node|
-          props[prop_node.value] = prop_node.nodes.first
-        end
+      xml.locate("properties/*").each_with_object({}) do |prop_node, all|
+        all[prop_node.value] = prop_node.nodes.first
       end
-      props
     end
 
     def self.dependencies(name, version, project)

--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -1,5 +1,3 @@
-require 'pry'
-
 module PackageManager
   class Maven < Base
     HAS_VERSIONS = true

--- a/spec/fixtures/proto-google-common-protos-0.1.9.pom
+++ b/spec/fixtures/proto-google-common-protos-0.1.9.pom
@@ -8,6 +8,10 @@
   <name>com.google.api.grpc:proto-google-common-protos</name>
   <description>PROTO library for proto-google-common-protos</description>
 
+  <properties>
+    <api.version>1.0.0-rc1</api.version>
+  </properties>
+
   <parent>
     <groupId>com.google.api.grpc</groupId>
     <artifactId>proto-google-common-parent</artifactId>
@@ -44,7 +48,7 @@
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>api-common</artifactId>
-      <version>1.0.0-rc1</version>
+      <version>${api.version}</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,4 @@ RSpec.configure do |config|
       model.__elasticsearch__.client.indices.delete index: model.index_name
     end
   end
-
-  config.filter_run :focus
-  config.run_all_when_everything_filtered = true
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,4 +24,7 @@ RSpec.configure do |config|
       model.__elasticsearch__.client.indices.delete index: model.index_name
     end
   end
+
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
 end


### PR DESCRIPTION
Use Bibliothecary to expand properties in POM files. Gather properties from parent projects and send those in alongside child pom files.