### PR TITLE
Create New Route to Refresh a Projects Maintenance Stats

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -4,7 +4,7 @@ class ProjectsController < ApplicationController
   before_action :find_project, only: [:show, :sourcerank, :about, :dependents,
                                       :dependent_repos, :your_dependent_repos,
                                       :versions, :tags, :mute, :unmute, :unsubscribe,
-                                      :sync, :score]
+                                      :sync, :score, :refresh_stats]
   before_action :find_project_lite, only: [:top_dependent_repos, :top_dependent_projects]
 
   def index
@@ -166,6 +166,12 @@ class ProjectsController < ApplicationController
 
   def score
     @calculator = ProjectScoreCalculator.new(@project)
+  end
+
+  def refresh_stats
+    @project.update_maintenance_stats_async
+    flash[:notice] = "Project has been queued to refresh maintenance stats"
+    redirect_back fallback_location: project_path(@project.to_param)
   end
 
   private

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -94,7 +94,7 @@
     <% end %>
     <% if logged_in? && current_user.admin? && current_user.current_api_key.is_internal? %>
       <p>
-        <%= link_to api_maintenance_stat_enqueue_path(@project.platform_name, @project.name, api_key: current_user.api_key), method: :put, class: 'btn btn-primary btn-xs' do %>
+        <%= link_to project_refresh_stats_path(@project.to_param), method: :post, class: 'btn btn-primary btn-xs' do %>
           <%= fa_icon 'refresh' %>
           Resync Stats
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -251,6 +251,7 @@ Rails.application.routes.draw do
   get '/:platform/:name/:number/dependencies', to: 'projects#dependencies', constraints: { :number => /.*/, :name => /.*/ }, as: :version_dependencies
 
   post '/:platform/:name/sync', to: 'projects#sync', constraints: { :name => /.*/ }, as: :sync_project
+  post '/:platform/:name/refresh-stats', to: 'projects#refresh_stats', constraints: { :name => /.*/ }, as: :project_refresh_stats
   get '/:platform/:name/unsubscribe', to: 'projects#unsubscribe', constraints: { :name => /.*/ }, as: :unsubscribe_project
   get '/:platform/:name/usage', to: 'project_usage#show', as: :project_usage, constraints: { :name => /.*/ }, :defaults => { :format => 'html' }
   get '/:platform/:name/timeline', to: 'timeline#show', as: :project_timeline, constraints: { :name => /.*/ }, :defaults => { :format => 'html' }


### PR DESCRIPTION
Use this route to refresh a project's maintenance stats from project page instead of the page calling the API.