### PR TITLE
Handle Hyphens and Underscores for Pypi Projects

### DIFF
--- a/app/controllers/api/status_controller.rb
+++ b/app/controllers/api/status_controller.rb
@@ -16,8 +16,8 @@ class Api::StatusController < Api::ApplicationController
   private
 
   def find_projects(projects, platform)
-    project_find_names = projects.map{|project| project_names(project, platform)}
-    Project.platform(platform).where(name: project_find_names).includes(:repository, :versions, :repository_maintenance_stats)
+    project_find_names = projects.flat_map{|project| project_names(project, platform)}.map(&:downcase)
+    Project.platform(platform).where('lower(platform)=? AND lower(name) in (?)', platform.downcase, project_find_names).includes(:repository, :versions, :repository_maintenance_stats)
   end
 
   def project_names(project, platform)

--- a/app/controllers/api/status_controller.rb
+++ b/app/controllers/api/status_controller.rb
@@ -6,7 +6,7 @@ class Api::StatusController < Api::ApplicationController
       # Try to get all the projects passed in.
       @projects = params[:projects]
         .group_by { |project| project[:platform] }
-        .flat_map { |platform, projects| find_projects(projects, platform) }
+        .flat_map(&method(:find_projects))
         .compact
     else
       @projects = []
@@ -16,7 +16,7 @@ class Api::StatusController < Api::ApplicationController
 
   private
 
-  def find_projects(projects, platform)
+  def find_projects((platform, projects))
     projects.each_slice(1000).flat_map do |slice|
       project_find_names = slice.flat_map { |project| project_names(project, platform) }.map(&:downcase)
       Project.platform(platform).where('lower(platform)=? AND lower(name) in (?)', platform.downcase, project_find_names).includes(:repository, :versions, :repository_maintenance_stats)

--- a/app/controllers/api/status_controller.rb
+++ b/app/controllers/api/status_controller.rb
@@ -24,10 +24,8 @@ class Api::StatusController < Api::ApplicationController
   end
 
   def project_names(project, platform)
-    begin
       "PackageManager::#{platform.capitalize}".constantize.project_find_names(project[:name])
-    rescue => exception
-      PackageManager::Base.project_find_names(project[:name])
-    end
+  rescue NameError
+    PackageManager::Base.project_find_names(project[:name])
   end
 end

--- a/app/controllers/api/status_controller.rb
+++ b/app/controllers/api/status_controller.rb
@@ -5,32 +5,26 @@ class Api::StatusController < Api::ApplicationController
     if params[:projects].any?
       # Try to get all the projects passed in.
       @projects = params[:projects].group_by{|project| project[:platform] }.map do |platform, projects|
-        projects.each_slice(1000).map do |slice|
-          Project.platform(platform).where(name: slice.map{|project| project[:name] }.uniq).includes(:repository, :versions, :repository_maintenance_stats)
-        end
+        projects.each_slice(1000).map{|slice| find_projects(slice, platform)}
       end.flatten.compact
-
-      # If there are any that don't get found, downcase them and try again
-      if params[:projects].length != @projects.length
-
-        # downcase all platform/name pairs we've found so we can match against them later
-        found = @projects.map { |project| [project[:platform]&.downcase, project[:name].downcase] }
-        # Find any projects that were passed that we didn't find, to try them again but case insensitive
-        missing = params[:projects].select { |project| !found.include?([project[:platform]&.downcase, project[:name].downcase]) }
-
-        lowercase_project_named = missing.group_by{|project| project[:platform] }.map do |platform, projects|
-          projects.each_slice(1000).map do |slice|
-            downcased_names = slice.map {|project| project[:name].downcase }
-            # lowercase compare the downcased_names... use lower(platform) to improve index usage
-            Project.where('lower(platform)=? AND lower(name) in (?)', platform.downcase, downcased_names).includes(:repository, :versions, :repository_maintenance_stats)
-          end
-        end.flatten.compact
-        # Concatanate any new items found.
-        @projects.concat(lowercase_project_named)
-      end
     else
       @projects = []
     end
     render json: @projects, each_serializer: ProjectStatusSerializer, show_score: params[:score], show_stats: internal_api_key?
+  end
+
+  private
+
+  def find_projects(projects, platform)
+    project_find_names = projects.map{|project| project_names(project, platform)}
+    Project.platform(platform).where(name: project_find_names).includes(:repository, :versions, :repository_maintenance_stats)
+  end
+
+  def project_names(project, platform)
+    begin
+      "PackageManager::#{platform.capitalize}".constantize.project_find_names(project[:name])
+    rescue => exception
+      PackageManager::Base.project_find_names(project[:name])
+    end
   end
 end

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -219,6 +219,10 @@ module PackageManager
       end
     end
 
+    def self.search_names(project_name)
+      [project_name, project_name.downcase]
+    end
+
     private
 
     def self.get(url, options = {})

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -219,7 +219,7 @@ module PackageManager
       end
     end
 
-    def self.search_names(project_name)
+    def self.project_find_names(project_name)
       [project_name, project_name.downcase]
     end
 

--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -82,7 +82,7 @@ module PackageManager
       return license_classifiers.map { |l| l.split(':: ').last }.join(',')
     end
 
-    def self.search_names(project_name)
+    def self.project_find_names(project_name)
       [project_name, project_name.downcase].flat_map {|name| [name, name.gsub('-', '_'), name.gsub('_', '-')]}.uniq
     end
   end

--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -81,5 +81,9 @@ module PackageManager
       license_classifiers = project['info']['classifiers'].select { |c| c.start_with?('License :: ')}
       return license_classifiers.map { |l| l.split(':: ').last }.join(',')
     end
+
+    def self.search_names(project_name)
+      [project_name, project_name.downcase].flat_map {|name| [name, name.gsub('-', '_'), name.gsub('_', '-')]}.uniq
+    end
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -516,13 +516,13 @@ class Project < ApplicationRecord
   def self.find_with_includes!(platform, name, includes)
     # this clunkiness is because .includes() doesn't allow zero args and we want
     # to allow that.
-    search_names = begin
-       "PackageManager::#{platform.capitalize}".constantize.search_names(name)
+    project_find_names = begin
+       "PackageManager::#{platform.capitalize}".constantize.project_find_names(name)
     rescue => exception
       raise ActiveRecord::RecordNotFound
     end
     
-    query = self.visible.platform(platform).where(name: search_names)
+    query = self.visible.platform(platform).where(name: project_find_names)
     query = query.includes(*includes) unless includes.empty?
     project = query.first
     if project.nil?

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -516,7 +516,13 @@ class Project < ApplicationRecord
   def self.find_with_includes!(platform, name, includes)
     # this clunkiness is because .includes() doesn't allow zero args and we want
     # to allow that.
-    query = self.visible.platform(platform).where(name: name)
+    search_names = begin
+       "PackageManager::#{platform.capitalize}".constantize.search_names(name)
+    rescue => exception
+      raise ActiveRecord::RecordNotFound
+    end
+    
+    query = self.visible.platform(platform).where(name: search_names)
     query = query.includes(*includes) unless includes.empty?
     project = query.first
     if project.nil?

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -518,7 +518,7 @@ class Project < ApplicationRecord
     # to allow that.
     project_find_names = begin
        "PackageManager::#{platform.capitalize}".constantize.project_find_names(name)
-    rescue => exception
+    rescue NameError
       raise ActiveRecord::RecordNotFound
     end
     

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -49,14 +49,12 @@ describe PackageManager::Pypi do
   describe 'project_find_names' do
     it 'suggests underscore version of name' do
       suggested_find_names = described_class.project_find_names('test-hyphen')
-      expect(suggested_find_names.include?('test_hyphen')).to be true
-      expect(suggested_find_names.include?('test-hyphen')).to be true
+      expect(suggested_find_names).to include('test_hyphen', 'test-hyphen')
     end
 
     it 'suggests hyphen version of name' do
       suggested_find_names = described_class.project_find_names('test_underscore')
-      expect(suggested_find_names.include?('test-underscore')).to be true
-      expect(suggested_find_names.include?('test_underscore')).to be true
+      expect(suggested_find_names).to include('test-underscore', 'test_underscore')
     end
   end
 end

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -45,4 +45,18 @@ describe PackageManager::Pypi do
       expect(described_class.mapping(bandit)[:licenses]).to eq("Apache Software License")
     end
   end
+
+  describe 'project_find_names' do
+    it 'suggests underscore version of name' do
+      suggested_find_names = described_class.project_find_names('test-hyphen')
+      expect(suggested_find_names.include?('test_hyphen')).to be true
+      expect(suggested_find_names.include?('test-hyphen')).to be true
+    end
+
+    it 'suggests hyphen version of name' do
+      suggested_find_names = described_class.project_find_names('test_underscore')
+      expect(suggested_find_names.include?('test-underscore')).to be true
+      expect(suggested_find_names.include?('test_underscore')).to be true
+    end
+  end
 end


### PR DESCRIPTION
Still need to do some more testing locally to make sure nothing is screwed up with this, but wanted opinions. This creates a method in package managers to have a suggested list of names to use to find projects. For all the cases except Pypi, this is just the project name. For Pypi this includes replacing hyphens with underscores and vice versa. This is to help mimic the same mechanic that Pypi supports and would help find projects when reading Python dependency manifests.