### PR TITLE
Basic support for metadata redirects

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -534,6 +534,11 @@ class Project < ApplicationRecord
     project
   end
 
+  def self.known?(platform, name)
+    self.visible.platform(platform).where(name: name).exists? ||
+      self.visible.lower_platform(platform&.downcase).lower_name(name&.downcase).exists?
+  end
+
   def find_version!(version_name)
     version = if version_name == 'latest'
                 versions.sort.first
@@ -554,5 +559,4 @@ class Project < ApplicationRecord
     repository_url = URLParser.try_all(self.repository_url)
     update_attributes(repository_url: repository_url)
   end
-
 end

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -248,4 +248,44 @@ describe "Api::ProjectsController" do
        "versions_present": 0}.to_json)
     end
   end
+
+  context "for a Go project that is not in the DB" do
+    let!(:project) { create(:project, platform: "Go", name: "known/project") }
+
+    context "that redirects to a known project" do
+      it "redirects" do
+        allow(PackageManager::Go)
+          .to receive(:resolved_name)
+          .with("unknown/project")
+          .and_return(project.name)
+
+        get "/api/go/unknown%2Fproject/contributors"
+        expect(response).to redirect_to("/api/go/known%2Fproject/contributors")
+      end
+    end
+
+    context "that redirects to an unknown project" do
+      it "redirects" do
+        allow(PackageManager::Go)
+          .to receive(:resolved_name)
+          .with("unknown/project")
+          .and_return("other/unknown/project")
+
+        expect { get "/api/go/unknown%2Fproject/contributors" }
+          .to raise_exception(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "that does not redirect" do
+      it "returns not found" do
+        allow(PackageManager::Go)
+          .to receive(:resolved_name)
+          .with("unknown/project")
+          .and_return("unknown/project")
+
+        expect { get "/api/go/unknown%2Fproject/contributors" }
+          .to raise_exception(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
 end


### PR DESCRIPTION
There's a balance to be struck here - at what point do we just start using `go get`?

This only handles metadata redirects to github.com urls - we may want to expand that, but I wanted some discussion.