### PR TITLE
default to nil values for MavenUrl to allow bad data through

### DIFF
--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -223,7 +223,7 @@ module PackageManager
         new(*name.split(':', 2))
       end
 
-      def initialize(group_id, artifact_id)
+      def initialize(group_id = nil, artifact_id = nil)
         @group_id = group_id
         @artifact_id = artifact_id
       end


### PR DESCRIPTION
I'm not sure how to test this locally to check if the search still blows up.