### PR TITLE
Fix Package Manager Name Lookup

### DIFF
--- a/app/controllers/api/status_controller.rb
+++ b/app/controllers/api/status_controller.rb
@@ -24,8 +24,7 @@ class Api::StatusController < Api::ApplicationController
   end
 
   def project_names(project, platform)
-      "PackageManager::#{platform.capitalize}".constantize.project_find_names(project[:name])
-  rescue NameError
-    PackageManager::Base.project_find_names(project[:name])
-  end
+    platform_class = PackageManager::Base.find(platform)
+    PackageManager::Base.project_find_names(project[:name]) if platform_class.nil?
+    project_find_names = platform_class.project_find_names(project[:name])
 end

--- a/app/controllers/api/status_controller.rb
+++ b/app/controllers/api/status_controller.rb
@@ -25,6 +25,7 @@ class Api::StatusController < Api::ApplicationController
 
   def project_names(project, platform)
     platform_class = PackageManager::Base.find(platform)
-    PackageManager::Base.project_find_names(project[:name]) if platform_class.nil?
-    project_find_names = platform_class.project_find_names(project[:name])
+    return PackageManager::Base.project_find_names(project[:name]) if platform_class.nil?
+    platform_class.project_find_names(project[:name])
+  end
 end

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -220,7 +220,7 @@ module PackageManager
     end
 
     def self.project_find_names(project_name)
-      [project_name, project_name.downcase]
+      [project_name, project_name.downcase].uniq
     end
 
     private

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -520,7 +520,6 @@ class Project < ApplicationRecord
     platform_class = PackageManager::Base.find(platform)
     raise ActiveRecord::RecordNotFound if platform_class.nil?
     project_find_names = platform_class.project_find_names(name)
-      
     
     query = self.visible.platform(platform).where(name: project_find_names)
     query = query.includes(*includes) unless includes.empty?

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -516,11 +516,11 @@ class Project < ApplicationRecord
   def self.find_with_includes!(platform, name, includes)
     # this clunkiness is because .includes() doesn't allow zero args and we want
     # to allow that.
-    project_find_names = begin
-       "PackageManager::#{platform.capitalize}".constantize.project_find_names(name)
-    rescue NameError
-      raise ActiveRecord::RecordNotFound
-    end
+    
+    platform_class = PackageManager::Base.find(platform)
+    raise ActiveRecord::RecordNotFound if platform_class.nil?
+    project_find_names = platform_class.project_find_names(name)
+      
     
     query = self.visible.platform(platform).where(name: project_find_names)
     query = query.includes(*includes) unless includes.empty?


### PR DESCRIPTION
Catching errors was not catching everything it needed to and this seems like a better way to get the correct package manager class to call.