### PR TITLE
Don't error if a property node has no `nodes`

### DIFF
--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -131,7 +131,7 @@ module PackageManager
 
     def self.extract_pom_properties(xml)
       xml.locate("properties/*").each_with_object({}) do |prop_node, all|
-        all[prop_node.value] = prop_node.nodes.first
+        all[prop_node.value] = prop_node.nodes.first if prop_node&.nodes.present?
       end
     end
 


### PR DESCRIPTION
Could also have gone with `respond_to?(:nodes)` if that feels better?