### PR TITLE
Only consider nodes for prop_nodes that have them

### DIFF
--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -131,7 +131,7 @@ module PackageManager
 
     def self.extract_pom_properties(xml)
       xml.locate("properties/*").each_with_object({}) do |prop_node, all|
-        all[prop_node.value] = prop_node.nodes.first if prop_node&.nodes.present?
+        all[prop_node.value] = prop_node.nodes.first if prop_node.respond_to?(:nodes)
       end
     end
 


### PR DESCRIPTION
Fixes #2392 - the problem here is not that `prop_node` is missing, but that it doesn't have `nodes`