### PR TITLE
Support Go redirects in bulk API

### DIFF
--- a/app/queries/project_status_query.rb
+++ b/app/queries/project_status_query.rb
@@ -1,0 +1,55 @@
+class ProjectStatusQuery
+  def initialize(platform, requested_project_names)
+    @platform = platform
+    @requested_project_names = requested_project_names
+  end
+
+  def projects_by_name
+    projects.merge(missing_projects)
+  end
+
+  private
+
+  def projects
+    @projects ||= fetch_projects(
+      @requested_project_names,
+      &platform_class.method(:project_find_names)
+    )
+  end
+
+  def missing_projects
+    return {} unless @platform.downcase == "go"
+
+    fetch_projects(
+      @requested_project_names.reject(&projects.method(:key?)),
+      &PackageManager::Go.method(:resolved_name)
+    )
+  end
+
+  def fetch_projects(requested_project_names, &resolver)
+    resolved_project_names = requested_project_names
+      .map { |requested_name| resolve_project_names(requested_name, &resolver) }
+      .reduce({}, :merge)
+
+    Project
+      .visible
+      .where(
+        "lower(platform)=? AND lower(name) in (?)",
+        @platform.downcase,
+        resolved_project_names.keys
+      )
+      .includes(:repository, :versions, :repository_maintenance_stats)
+      .find_each
+      .index_by { |project| resolved_project_names[project.name.downcase] }
+  end
+
+  def resolve_project_names(requested_name)
+    Array(yield(requested_name))
+      .map { |resolved_name| [resolved_name.downcase, requested_name] }
+      .to_h
+  end
+
+  def platform_class
+    @platform_class ||= PackageManager::Base.find(@platform) || PackageManager::Base
+  end
+end

--- a/app/serializers/project_status_serializer.rb
+++ b/app/serializers/project_status_serializer.rb
@@ -13,4 +13,8 @@ class ProjectStatusSerializer < ActiveModel::Serializer
   def show_stats?
     instance_options[:show_stats]
   end
+
+  def name
+    instance_options[:project_names][object.name]
+  end
 end

--- a/spec/queries/project_status_query_spec.rb
+++ b/spec/queries/project_status_query_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+describe ProjectStatusQuery do
+  describe "#projects_by_name" do
+    it "returns a list of projects by their requested names" do
+      project = create(:project, platform: "Go", name: "known/project")
+
+      instance = described_class.new("go", ["known/project"])
+
+      expect(instance.projects_by_name).to eq({ "known/project" => project })
+    end
+
+    it "handles go project redirects" do
+      project = create(:project, platform: "Go", name: "known/project")
+
+      allow(PackageManager::Go)
+        .to receive(:resolved_name)
+        .with("unknown/project")
+        .and_return("known/project")
+      allow(PackageManager::Go)
+        .to receive(:resolved_name)
+        .with("second/unknown/project")
+        .and_return("other/unknown/project")
+
+      instance = described_class.new("Go", ["unknown/project", "second/unknown/project"])
+
+      expect(instance.projects_by_name).to eq({ "unknown/project" => project })
+    end
+  end
+end


### PR DESCRIPTION
Two changes here:
1. Serve project data with the name that was used to request it
2. Handle Go redirects in the bulk status API

Think I should centralize some of this Go handling somehow?