### PR TITLE
Fix spacing on account settings page

### DIFF
--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -38,7 +38,7 @@
       <div class="panel-heading">API Key</div>
       <div class="panel-body">
         <p>
-          Your private token is used to access application resources without authentication.<strong>Keep it secret!</strong>
+          Your private token is used to access application resources without authentication. <strong>Keep it secret!</strong>
         </p>
         <p>
           View API documentation here: <%= link_to 'libraries.io/api', api_path %>


### PR DESCRIPTION
Add space after period in "API Key" section of account settings page.

- [x] Have you followed the guidelines for [contributors](http://docs.libraries.io/contributorshandbook)?
- [x] Have you checked to ensure there aren't other open pull requests on the repository for a similar change?

Other questions: no; this is formatting of a user-visible string, should not affect functionality.
