### PR TITLE
Increase tree depth

### DIFF
--- a/app/models/repository_tree_resolver.rb
+++ b/app/models/repository_tree_resolver.rb
@@ -18,7 +18,7 @@ class RepositoryTreeResolver
 
   def platforms
     @platforms ||= @manifests.pluck(:platform).map(&:downcase).uniq.select do |platform|
-      package_manager = PackageManager::Base.PackageManager::Base.find(platform)
+      package_manager = PackageManager::Base.find(platform)
       package_manager && package_manager::HAS_VERSIONS # can only resolve trees for platforms with versions
     end
   end

--- a/app/models/tree_resolver.rb
+++ b/app/models/tree_resolver.rb
@@ -1,5 +1,5 @@
 class TreeResolver
-  MAX_TREE_DEPTH = 10
+  MAX_TREE_DEPTH = 15
 
   def initialize(version, kind, date = nil)
     @version = version
@@ -57,7 +57,7 @@ class TreeResolver
     append_license_names(version)
     should_fetch = append_project_name(dependency)
 
-    return ["MORE"] if index > MAX_TREE_DEPTH
+    return if index > MAX_TREE_DEPTH
 
     dependencies = should_fetch ? fetch_dependencies(version, kind) : []
 
@@ -66,14 +66,9 @@ class TreeResolver
       requirements: dependency&.requirements,
       dependency: dependency,
       normalized_licenses: version.project.normalized_licenses,
-      dependencies: dependencies.map do |dep|
-        load_dependencies_for(
-          dep.latest_resolvable_version(@date),
-          dep,
-          "runtime",
-          index + 1
-        )
-      end
+      dependencies: dependencies
+        .map { |dep| load_dependencies_for(dep.latest_resolvable_version(@date), dep, "runtime", index + 1) }
+        .compact,
     }
   end
 

--- a/app/models/tree_resolver.rb
+++ b/app/models/tree_resolver.rb
@@ -57,7 +57,11 @@ class TreeResolver
     append_license_names(version)
     should_fetch = append_project_name(dependency)
 
-    return if index > MAX_TREE_DEPTH
+    if index > MAX_TREE_DEPTH
+      Rails.logger.info("Max tree depth #{MAX_TREE_DEPTH} reached when loading dependencies for #{version.project.platform}/#{version.project.name} for parent #{@version.project.platform}/#{@version.project.name}")
+
+      return
+    end
 
     dependencies = should_fetch ? fetch_dependencies(version, kind) : []
 

--- a/app/models/tree_resolver.rb
+++ b/app/models/tree_resolver.rb
@@ -1,15 +1,12 @@
 class TreeResolver
-  attr_accessor :project_names
-  attr_accessor :license_names
-  attr_accessor :tree
+  MAX_TREE_DEPTH = 10
 
   def initialize(version, kind, date = nil)
     @version = version
     @kind = kind
-    @project_names = []
-    @license_names = []
-    @tree = nil
     @date = date
+    @project_names = Set.new
+    @license_names = Set.new
   end
 
   def cached?
@@ -25,53 +22,83 @@ class TreeResolver
   end
 
   def load_dependencies_tree
-    tree_data = Rails.cache.fetch cache_key, :expires_in => 1.day, race_condition_ttl: 2.minutes do
-      generate_dependency_tree
-    end
+    tree_data = Rails.cache.fetch(
+      cache_key,
+      expires_in: 1.day,
+      race_condition_ttl: 2.minutes,
+      &method(:generate_dependency_tree)
+    )
     @project_names = tree_data[:project_names]
     @license_names = tree_data[:license_names]
     @tree = tree_data[:tree]
   end
 
+  def project_names
+    @project_names.to_a
+  end
+
+  def license_names
+    @license_names.to_a
+  end
+
   private
 
-  def generate_dependency_tree
+  def generate_dependency_tree(_key)
     {
       tree: load_dependencies_for(@version, nil, @kind, 0),
-      project_names: project_names,
-      license_names: license_names
+      project_names: @project_names,
+      license_names: @license_names,
     }
   end
 
   def load_dependencies_for(version, dependency, kind, index)
-    if version
-      @license_names << version.project.try(:normalized_licenses)
-      kind = index.zero? ? kind : 'runtime'
-      dependencies = version.dependencies.kind(kind).includes(project: :versions).limit(100).order(:project_name)
-      {
-        version: version,
-        dependency: dependency,
-        requirements: dependency.try(:requirements),
-        normalized_licenses: version.project.try(:normalized_licenses),
-        dependencies: dependencies.map do |dep|
-          if dep.project && !@project_names.include?(dep.project_name)
-            @project_names << dep.project_name
-            index < 10 ? load_dependencies_for(dep.latest_resolvable_version(@date), dep, kind, index + 1) : ['MORE']
-          else
-            {
-              version: dep.latest_resolvable_version(@date),
-              requirements: dep.try(:requirements),
-              dependency: dep,
-              normalized_licenses: dep.project.try(:normalized_licenses),
-              dependencies: []
-            }
-          end
-        end
-      }
-    end
+    return unless version
+
+    append_license_names(version)
+    should_fetch = append_project_name(dependency)
+
+    return ["MORE"] if index > MAX_TREE_DEPTH
+
+    dependencies = should_fetch ? fetch_dependencies(version, kind) : []
+
+    {
+      version: version,
+      requirements: dependency&.requirements,
+      dependency: dependency,
+      normalized_licenses: version.project.normalized_licenses,
+      dependencies: dependencies.map do |dep|
+        load_dependencies_for(
+          dep.latest_resolvable_version(@date),
+          dep,
+          "runtime",
+          index + 1
+        )
+      end
+    }
   end
 
   def cache_key
-    ['tree', @version, @kind, @date].compact
+    ["tree", @version, @kind, @date].compact
+  end
+
+  def append_project_name(dependency)
+    return true unless dependency
+    @project_names.add?(dependency.project_name).present?
+  end
+
+  def append_license_names(version)
+    version
+      .project
+      .normalized_licenses
+      .each(&@license_names.method(:add))
+  end
+
+  def fetch_dependencies(version, kind)
+    version
+      .dependencies
+      .kind(kind)
+      .includes(project: :versions)
+      .limit(100)
+      .order(:project_name)
   end
 end

--- a/spec/models/tree_resolver_spec.rb
+++ b/spec/models/tree_resolver_spec.rb
@@ -97,9 +97,6 @@ RSpec.describe TreeResolver do
 
   context "with a max-depth tree" do
     it "produces the truncated tree" do
-      max_depth = 10
-      num_projects = max_depth + 2
-
       #    root
       #       \
       #        1
@@ -107,7 +104,7 @@ RSpec.describe TreeResolver do
       #          2
       #          ...
       previous_version = root_version
-      projects = (1..num_projects).map do |i|
+      projects = (1..described_class::MAX_TREE_DEPTH + 2).map do |i|
         project = create(:project, name: i)
         version = create(:version, project: project)
         dependency = create(:dependency, version: previous_version, project: project, project_name: project.name, requirements: "> 0")
@@ -121,20 +118,20 @@ RSpec.describe TreeResolver do
       end
 
       expected_terminal_dependency = {
-        version: projects[max_depth - 1][:version].as_json,
-        dependency: projects[max_depth - 1][:dependency].as_json,
+        version: projects[described_class::MAX_TREE_DEPTH - 1][:version].as_json,
+        dependency: projects[described_class::MAX_TREE_DEPTH - 1][:dependency].as_json,
         requirements: "> 0",
         normalized_licenses: ["MIT"],
-        dependencies: [["MORE"]],
+        dependencies: [],
       }
 
       terminal_dependency = subject
         .tree
         .as_json
-        .dig(*["dependencies", 0] * max_depth)
+        .dig(*["dependencies", 0] * described_class::MAX_TREE_DEPTH)
 
       expect(terminal_dependency).to eq(expected_terminal_dependency.deep_stringify_keys)
-      expect(subject.project_names).to match_array(projects[0..max_depth].map { |p| p[:project].name })
+      expect(subject.project_names).to match_array(projects[0..described_class::MAX_TREE_DEPTH].map { |p| p[:project].name })
       expect(subject.license_names).to eq(["MIT"])
     end
   end

--- a/spec/models/tree_resolver_spec.rb
+++ b/spec/models/tree_resolver_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe TreeResolver do
 
       expect(subject.tree.as_json).to eq(expected_tree.deep_stringify_keys)
       expect(subject.project_names).to eq([])
-      expect(subject.license_names).to eq([["MIT"]])
+      expect(subject.license_names).to eq(["MIT"])
     end
   end
 
@@ -91,7 +91,7 @@ RSpec.describe TreeResolver do
 
       expect(subject.tree.as_json).to eq(expected_tree.deep_stringify_keys)
       expect(subject.project_names).to match_array(["one", "two", "three", "four"])
-      expect(subject.license_names).to eq([["MIT"], ["MIT"], ["MIT"], ["MIT"], ["MIT"]])
+      expect(subject.license_names).to eq(["MIT"])
     end
   end
 
@@ -135,7 +135,7 @@ RSpec.describe TreeResolver do
 
       expect(terminal_dependency).to eq(expected_terminal_dependency.deep_stringify_keys)
       expect(subject.project_names).to match_array(projects[0..max_depth].map { |p| p[:project].name })
-      expect(subject.license_names).to eq([["MIT"]] * (max_depth + 1)) # includes root
+      expect(subject.license_names).to eq(["MIT"])
     end
   end
 end

--- a/spec/models/tree_resolver_spec.rb
+++ b/spec/models/tree_resolver_spec.rb
@@ -1,0 +1,142 @@
+require "rails_helper"
+
+RSpec.describe TreeResolver do
+  let(:root_project) { create(:project, name: "root") }
+  let(:root_version) { create(:version, project: root_project) }
+
+  subject { described_class.new(root_version, "runtime", Date.today + 1.year) }
+
+  context "with a single node tree" do
+    it "produces the expected tree" do
+      expected_tree = {
+        version: root_version.as_json,
+        dependency: nil,
+        requirements: nil,
+        normalized_licenses: ["MIT"],
+        dependencies: [],
+      }
+
+      expect(subject.tree.as_json).to eq(expected_tree.deep_stringify_keys)
+      expect(subject.project_names).to eq([])
+      expect(subject.license_names).to eq([["MIT"]])
+    end
+  end
+
+  context "with a typical tree" do
+    it "produces the expected tree" do
+      #       root
+      #      /   \
+      #    one   two
+      #    /     /  \
+      # three  four one
+      one = create(:project, name: "one")
+      two = create(:project, name: "two")
+      three = create(:project, name: "three")
+      four = create(:project, name: "four")
+      one_version = create(:version, project: one)
+      two_version = create(:version, project: two)
+      three_version = create(:version, project: three)
+      four_version = create(:version, project: four)
+      one_dependency = create(:dependency, version: root_version, project: one, project_name: one.name, requirements: "> 0")
+      two_dependency = create(:dependency, version: root_version, project: two, project_name: two.name, requirements: "> 0")
+      three_dependency = create(:dependency, version: one_version, project: three, project_name: three.name, requirements: "> 0")
+      four_dependency = create(:dependency, version: two_version, project: four, project_name: four.name, requirements: "> 0")
+      deep_one_dependency = create(:dependency, version: two_version, project: one, project_name: one.name, requirements: "> 0")
+
+      expected_tree = {
+        version: root_version.as_json,
+        dependency: nil,
+        requirements: nil,
+        normalized_licenses: ["MIT"],
+        dependencies: [
+          {
+            version: one_version.as_json,
+            dependency: one_dependency.as_json,
+            requirements: "> 0",
+            normalized_licenses: ["MIT"],
+            dependencies: [
+              {
+                version: three_version.as_json,
+                dependency: three_dependency.as_json,
+                requirements: "> 0",
+                normalized_licenses: ["MIT"],
+                dependencies: [],
+              },
+            ],
+          },
+          {
+            version: two_version.as_json,
+            dependency: two_dependency.as_json,
+            requirements: "> 0",
+            normalized_licenses: ["MIT"],
+            dependencies: [
+              {
+                version: four_version.as_json,
+                dependency: four_dependency.as_json,
+                requirements: "> 0",
+                normalized_licenses: ["MIT"],
+                dependencies: [],
+              },
+              {
+                version: one_version.as_json,
+                dependency: deep_one_dependency.as_json,
+                requirements: "> 0",
+                normalized_licenses: ["MIT"],
+                dependencies: [], # Dependencies truncated since this dependency already appears above
+              },
+            ],
+          },
+        ],
+      }
+
+      expect(subject.tree.as_json).to eq(expected_tree.deep_stringify_keys)
+      expect(subject.project_names).to match_array(["one", "two", "three", "four"])
+      expect(subject.license_names).to eq([["MIT"], ["MIT"], ["MIT"], ["MIT"], ["MIT"]])
+    end
+  end
+
+  context "with a max-depth tree" do
+    it "produces the truncated tree" do
+      max_depth = 10
+      num_projects = max_depth + 2
+
+      #    root
+      #       \
+      #        1
+      #         \
+      #          2
+      #          ...
+      previous_version = root_version
+      projects = (1..num_projects).map do |i|
+        project = create(:project, name: i)
+        version = create(:version, project: project)
+        dependency = create(:dependency, version: previous_version, project: project, project_name: project.name, requirements: "> 0")
+        previous_version = version
+
+        {
+          dependency: dependency,
+          project: project,
+          version: version,
+        }
+      end
+
+      expected_terminal_dependency = {
+        version: projects[max_depth - 1][:version].as_json,
+        dependency: projects[max_depth - 1][:dependency].as_json,
+        requirements: "> 0",
+        normalized_licenses: ["MIT"],
+        dependencies: [["MORE"]],
+      }
+
+      terminal_dependency = subject
+        .tree
+        .as_json
+        .dig(*["dependencies", 0] * max_depth)
+
+      expect(terminal_dependency).to eq(expected_terminal_dependency.deep_stringify_keys)
+      expect(subject.project_names).to match_array(projects[0..max_depth].map { |p| p[:project].name })
+      expect(subject.license_names).to eq([["MIT"]] * (max_depth + 1)) # includes root
+    end
+  end
+end
+

--- a/spec/models/tree_resolver_spec.rb
+++ b/spec/models/tree_resolver_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe TreeResolver do
   context "with a single node tree" do
     it "produces the expected tree" do
       expected_tree = {
-        version: root_version.as_json,
+        version: root_version,
         dependency: nil,
         requirements: nil,
         normalized_licenses: ["MIT"],
         dependencies: [],
       }
 
-      expect(subject.tree.as_json).to eq(expected_tree.deep_stringify_keys)
+      expect(JSON.parse(subject.tree.to_json)).to eq(JSON.parse(expected_tree.to_json))
       expect(subject.project_names).to eq([])
       expect(subject.license_names).to eq(["MIT"])
     end
@@ -44,20 +44,20 @@ RSpec.describe TreeResolver do
       deep_one_dependency = create(:dependency, version: two_version, project: one, project_name: one.name, requirements: "> 0")
 
       expected_tree = {
-        version: root_version.as_json,
+        version: root_version,
         dependency: nil,
         requirements: nil,
         normalized_licenses: ["MIT"],
         dependencies: [
           {
-            version: one_version.as_json,
-            dependency: one_dependency.as_json,
+            version: one_version,
+            dependency: one_dependency,
             requirements: "> 0",
             normalized_licenses: ["MIT"],
             dependencies: [
               {
-                version: three_version.as_json,
-                dependency: three_dependency.as_json,
+                version: three_version,
+                dependency: three_dependency,
                 requirements: "> 0",
                 normalized_licenses: ["MIT"],
                 dependencies: [],
@@ -65,21 +65,21 @@ RSpec.describe TreeResolver do
             ],
           },
           {
-            version: two_version.as_json,
-            dependency: two_dependency.as_json,
+            version: two_version,
+            dependency: two_dependency,
             requirements: "> 0",
             normalized_licenses: ["MIT"],
             dependencies: [
               {
-                version: four_version.as_json,
-                dependency: four_dependency.as_json,
+                version: four_version,
+                dependency: four_dependency,
                 requirements: "> 0",
                 normalized_licenses: ["MIT"],
                 dependencies: [],
               },
               {
-                version: one_version.as_json,
-                dependency: deep_one_dependency.as_json,
+                version: one_version,
+                dependency: deep_one_dependency,
                 requirements: "> 0",
                 normalized_licenses: ["MIT"],
                 dependencies: [], # Dependencies truncated since this dependency already appears above
@@ -89,7 +89,7 @@ RSpec.describe TreeResolver do
         ],
       }
 
-      expect(subject.tree.as_json).to eq(expected_tree.deep_stringify_keys)
+      expect(JSON.parse(subject.tree.to_json)).to eq(JSON.parse(expected_tree.to_json))
       expect(subject.project_names).to match_array(["one", "two", "three", "four"])
       expect(subject.license_names).to eq(["MIT"])
     end
@@ -118,19 +118,18 @@ RSpec.describe TreeResolver do
       end
 
       expected_terminal_dependency = {
-        version: projects[described_class::MAX_TREE_DEPTH - 1][:version].as_json,
-        dependency: projects[described_class::MAX_TREE_DEPTH - 1][:dependency].as_json,
+        version: projects[described_class::MAX_TREE_DEPTH - 1][:version],
+        dependency: projects[described_class::MAX_TREE_DEPTH - 1][:dependency],
         requirements: "> 0",
         normalized_licenses: ["MIT"],
         dependencies: [],
       }
 
-      terminal_dependency = subject
-        .tree
-        .as_json
+      terminal_dependency = JSON
+        .parse(subject.tree.to_json)
         .dig(*["dependencies", 0] * described_class::MAX_TREE_DEPTH)
 
-      expect(terminal_dependency).to eq(expected_terminal_dependency.deep_stringify_keys)
+      expect(terminal_dependency).to eq(JSON.parse(expected_terminal_dependency.to_json))
       expect(subject.project_names).to match_array(projects[0..described_class::MAX_TREE_DEPTH].map { |p| p[:project].name })
       expect(subject.license_names).to eq(["MIT"])
     end


### PR DESCRIPTION
Two things I wanted to change here:
1. Increase max tree depth to 15 (which lets eg: `npm/gulp` get to the leaves of its tree)
2. Remove the `["MORE"]` magic string when truncating

To get there, I did some refactoring.

The "Add TreeResolver tests" commit adds tests for `TreeResolver` that pass before any changes to that class.

Probably best to review this commit-by-commit!