### PR TITLE
Avoid Error on Missing Method

### DIFF
--- a/app/models/repository_host/base.rb
+++ b/app/models/repository_host/base.rb
@@ -113,6 +113,11 @@ module RepositoryHost
       RepositoryMaintenanceStatWorker.enqueue(repository.id, priority: :medium)
     end
 
+    def gather_maintenance_stats
+      # should be overwritten in individual repository_host class
+      []
+    end
+
     private
 
     attr_reader :repository

--- a/spec/workers/repository_maintenance_stat_worker_spec.rb
+++ b/spec/workers/repository_maintenance_stat_worker_spec.rb
@@ -42,4 +42,17 @@ describe RepositoryMaintenanceStatWorker do
       expect(Sidekiq::Queues["repo_maintenance_stat_low"].size).to eql 1
     end
   end
+
+  context "with unsupported repository host_type" do
+    let!(:repository) { create(:repository, host_type: 'gitlab') }
+
+    it "should gracefully not gather stats" do
+      # call directly
+      expect(repository.gather_maintenance_stats).to eql []
+
+      # call worker and fail on error
+      expect(Repository).to receive(:find).with(repository.id).and_return(repository)
+      subject.perform(repository.id)
+    end
+  end
 end


### PR DESCRIPTION
I noticed a lot of failed Sidekiq messages because Gitlab repositories would getting stats synced. This should fix the errors causing the Sidekiq jobs to fail and reduce some churn in the workers.