### PR TITLE
Retry on Calls to Get Dependencies

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -241,7 +241,8 @@ module PackageManager
         builder.use :http_cache, store: Rails.cache, logger: Rails.logger, shared_cache: false, serializer: Marshal
         builder.use FaradayMiddleware::Gzip
         builder.use FaradayMiddleware::FollowRedirects, limit: 3
-        builder.request :retry
+        builder.request :retry, { max: 2, interval: 0.05, interval_randomness: 0.5, backoff_factor: 2 }
+        
         builder.use :instrumentation
         builder.adapter :typhoeus
       end

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -162,6 +162,7 @@ module PackageManager
       name = mapped_project[:name]
       proj = Project.find_by(name: name, platform: self.name.demodulize)
       proj.versions.includes(:dependencies).each do |version|
+        next if version.dependencies.any?
         deps = dependencies(name, version.number, mapped_project) rescue []
         next unless deps && deps.any? && version.dependencies.empty?
         deps.each do |dep|
@@ -240,6 +241,7 @@ module PackageManager
         builder.use :http_cache, store: Rails.cache, logger: Rails.logger, shared_cache: false, serializer: Marshal
         builder.use FaradayMiddleware::Gzip
         builder.use FaradayMiddleware::FollowRedirects, limit: 3
+        builder.request :retry
         builder.use :instrumentation
         builder.adapter :typhoeus
       end


### PR DESCRIPTION
This was specifically made to try and help reduce our errors when calling for Python dependencies. This will skip a version if we have already seen dependencies for it, which should hopefully cut down on calls. This also adds a retry to the connection object used in the `PackageManager` classes.

I think a lot of the Python libraries do not have any dependencies. I would love some thoughts on how to prevent duplicate calls for packages like that. Perhaps adding a `deps_last_updated` time column for `versions`?