### PR TITLE
Remove Unique Setting for Package Download Worker

### DIFF
--- a/app/workers/package_manager_download_worker.rb
+++ b/app/workers/package_manager_download_worker.rb
@@ -1,6 +1,6 @@
 class PackageManagerDownloadWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :critical, unique: :until_executed
+  sidekiq_options queue: :critical
 
   def perform(class_name, name)
     return unless class_name.present?

--- a/spec/models/package_manager/go_spec.rb
+++ b/spec/models/package_manager/go_spec.rb
@@ -37,7 +37,7 @@ describe PackageManager::Go do
     end
   end
 
-  describe '#get_repository_url', focus: true do
+  describe '#get_repository_url' do
     it 'follows redirects to get correct url' do
       VCR.use_cassette('go_redirects') do
         expect(described_class.get_repository_url({'Package' => 'github.com/DarthSim/imgproxy'})).to eq("https://github.com/imgproxy/imgproxy")


### PR DESCRIPTION
I think this may be causing issues with packages never syncing. I've run into issues before where the lock on a job is never cleared.