### PR TITLE
Add noindex meta tags for removed/non-existent pages

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -204,7 +204,8 @@ module ApplicationHelper
 
   def render_meta(record = nil)
     render(partial: 'meta/facebook', locals: { meta: meta_tags_for(record) }) +
-    render(partial: 'meta/twitter', locals: { meta: meta_tags_for(record) })
+    render(partial: 'meta/twitter', locals: { meta: meta_tags_for(record) }) +
+    render(partial: 'meta/seo', locals: { seo: meta_seo_tags_for(record) })
   end
 
   def default_meta_tags
@@ -238,6 +239,16 @@ module ApplicationHelper
       hash = {}
     end
     default_meta_tags.merge(hash)
+  end
+
+  def meta_seo_tags_for(record)
+    return {noindex: true} if record.nil?
+    case record.class.name
+    when 'Project', 'Repository'
+      hash = {noindex: record.is_removed?}
+    else
+      hash = {noindex: false}
+    end
   end
 
   def tree_path(options={})

--- a/app/views/meta/_seo.html.erb
+++ b/app/views/meta/_seo.html.erb
@@ -1,0 +1,3 @@
+<% if seo[:noindex] %>
+<meta name="robots" content="noindex">
+<% end %>


### PR DESCRIPTION
Let's stop the googlebot from indexing things that are removed packages or packages that don't exist

/cc @amytidelift