### PR TITLE
Create Endpoint to Begin Watching Projects Maintenance Stats in Bulk

### DIFF
--- a/app/controllers/api/bulk_project_controller.rb
+++ b/app/controllers/api/bulk_project_controller.rb
@@ -1,0 +1,21 @@
+class Api::BulkProjectController < Api::ApplicationController
+  def project_status_queries
+    @project_status_queries ||= params[:projects]
+      .group_by { |project| project[:platform] }
+      .map { |platform, group| ProjectStatusQuery.new(platform, group.map { |p| p[:name] }) }
+  end
+
+  def projects
+    project_status_queries
+      .map(&:projects_by_name)
+      .flat_map(&:values)
+  end
+
+  def project_names
+    project_status_queries.each_with_object({}) do |psq, result|
+      psq.projects_by_name.each do |requested_name, project|
+        result[[project.platform, project.name]] = requested_name
+      end
+    end
+  end
+end

--- a/app/controllers/api/maintenance_stats_controller.rb
+++ b/app/controllers/api/maintenance_stats_controller.rb
@@ -13,7 +13,7 @@ class Api::MaintenanceStatsController < Api::BulkProjectController
   end
 
   def begin_watching_bulk
-    projects.map(&method(:begin_project_watch))
+    projects.each(&method(:begin_project_watch))
     head :accepted
   end
 

--- a/app/controllers/api/maintenance_stats_controller.rb
+++ b/app/controllers/api/maintenance_stats_controller.rb
@@ -1,5 +1,6 @@
-class Api::MaintenanceStatsController < Api::ApplicationController
-  before_action :require_internal_api_key, :find_project
+class Api::MaintenanceStatsController < Api::BulkProjectController
+  before_action :require_internal_api_key
+  before_action :find_project, except: [:begin_watching_bulk]
 
   def enqueue
     @project.update_maintenance_stats_async(priority: :high)
@@ -7,7 +8,16 @@ class Api::MaintenanceStatsController < Api::ApplicationController
   end
 
   def begin_watching
-    @project.update_maintenance_stats_async(priority: :high) unless @project.repository_maintenance_stats.exists?
+    begin_project_watch(@project)
     head :accepted
+  end
+
+  def begin_watching_bulk
+    projects.map(&method(:begin_project_watch))
+    head :accepted
+  end
+
+  def begin_project_watch(project)
+    project.update_maintenance_stats_async(priority: :high) unless project.repository_maintenance_stats.exists?
   end
 end

--- a/app/controllers/api/status_controller.rb
+++ b/app/controllers/api/status_controller.rb
@@ -1,4 +1,4 @@
-class Api::StatusController < Api::ApplicationController
+class Api::StatusController < Api::BulkProjectController
   before_action :require_api_key
 
   def check
@@ -9,27 +9,5 @@ class Api::StatusController < Api::ApplicationController
       show_stats: internal_api_key?,
       project_names: project_names
     )
-  end
-
-  private
-
-  def project_status_queries
-    @project_status_queries ||= params[:projects]
-      .group_by { |project| project[:platform] }
-      .map { |platform, group| ProjectStatusQuery.new(platform, group.map { |p| p[:name] }) }
-  end
-
-  def projects
-    project_status_queries
-      .map(&:projects_by_name)
-      .flat_map(&:values)
-  end
-
-  def project_names
-    project_status_queries.each_with_object({}) do |psq, result|
-      psq.projects_by_name.each do |requested_name, project|
-        result[[project.platform, project.name]] = requested_name
-      end
-    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
     VERSION_CONSTRAINT = /[\w\.\-]+/
 
     put '/maintenance/stats/enqueue/:platform/:name', as: :maintenance_stat_enqueue, to: 'maintenance_stats#enqueue', constraints: { :platform => PLATFORM_CONSTRAINT, :name => PROJECT_CONSTRAINT }
+    post '/maintenance/stats/begin/bulk', to: 'maintenance_stats#begin_watching_bulk'
     get '/maintenance/stats/begin/:platform/:name', to: 'maintenance_stats#begin_watching', constraints: { :platform => PLATFORM_CONSTRAINT, :name => PROJECT_CONSTRAINT }
 
     get '/:platform/:name/usage', to: 'project_usage#show', as: :project_usage, constraints: { :platform => PLATFORM_CONSTRAINT, :name => PROJECT_CONSTRAINT }

--- a/spec/requests/api/maintenance_stat_spec.rb
+++ b/spec/requests/api/maintenance_stat_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+describe "API::MaintenanceStatsController" do
+  let(:internal_user) { create(:user) }
+  let(:normal_user) { create(:user) }
+  let!(:repository) { create(:repository) }
+  let!(:repository_django) { create(:repository, full_name: 'django/django') }
+  let!(:project) { create(:project, repository: repository) }
+  let!(:project_django) { create(:project, name: 'Django', platform: 'Pypi', repository: repository_django) }
+
+  before do
+    internal_user.current_api_key.update_attribute(:is_internal, true)
+  end
+
+  describe "POST /api/maintenance/stats/begin/bulk", type: :request do
+    it "begins watching projects" do
+      expect(RepositoryMaintenanceStatWorker).to receive(:enqueue).with(repository_django.id, priority: :high).exactly(1).times
+      expect(RepositoryMaintenanceStatWorker).to receive(:enqueue).with(repository.id, priority: :high).exactly(1).times
+
+      post(
+        "/api/maintenance/stats/begin/bulk",
+        params: {
+          api_key: internal_user.api_key,
+          projects: [
+            { name: project_django.name.downcase, platform: project_django.platform },
+            { name: project.name.downcase, platform: project.platform }
+          ]
+        }
+      )
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it "skips projects with stats" do
+      create(:repository_maintenance_stat, repository: repository)
+      expect(RepositoryMaintenanceStatWorker).to receive(:enqueue).with(repository_django.id, priority: :high).exactly(1).times
+      expect(RepositoryMaintenanceStatWorker).to receive(:enqueue).with(repository.id, priority: :high).exactly(0).times
+
+      post(
+        "/api/maintenance/stats/begin/bulk",
+        params: {
+          api_key: internal_user.api_key,
+          projects: [
+            { name: project_django.name.downcase, platform: project_django.platform },
+            { name: project.name.downcase, platform: project.platform }
+          ]
+        }
+      )
+
+      expect(response).to have_http_status(:success)
+    end
+
+    context "with normal API key" do
+      it "returns no maintenance stats" do
+        post(
+          "/api/maintenance/stats/begin/bulk",
+          params: {
+            api_key: normal_user.api_key,
+            projects: [
+              { name: project_django.name.downcase, platform: project_django.platform },
+              { name: project.name.downcase, platform: project.platform }
+            ]
+          }
+        )
+        expect(response).to have_http_status(403)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This creates a new endpoint that lets us take in a list of projects to watch for maintenance stats. I've reused the queries and work done in the StatusController to handle looking up the Projects and moved that code to a common controller class.