### PR TITLE
Ignore `.x-dev` Packagist versions that aren't releases as defined by spec.

### DIFF
--- a/app/models/package_manager/packagist.rb
+++ b/app/models/package_manager/packagist.rb
@@ -59,7 +59,8 @@ module PackageManager
 
     def self.acceptable_versions(project)
       project['versions'].select do |k, _v|
-        (k =~ /^dev-.*/i).nil?
+        # See: https://getcomposer.org/doc/articles/versions.md#branches
+        (k =~ /^dev-.*/i).nil? && (k =~ /\.x-dev$/i).nil?
       end
     end
 

--- a/spec/models/package_manager/packagist_spec.rb
+++ b/spec/models/package_manager/packagist_spec.rb
@@ -16,4 +16,17 @@ describe PackageManager::Packagist do
       expect(described_class.package_link(project, '2.0.0')).to eq("https://packagist.org/packages/foo#2.0.0")
     end
   end
+
+  describe ".versions" do
+    it "rejects dev branches that aren't really releases" do
+      unmapped_project = {
+        "versions" => {
+          "1.2.3" => {"version" => "1.2.3", "time" => "2020-01-08T08:45:45+00:00"},
+          "1.2.x-dev" => {"version" => "1.2.x-dev", "time" => "2020-01-08T08:45:45+00:00"},
+        }
+      }
+
+      expect(described_class.versions(unmapped_project)).to eq([{number: "1.2.3", published_at: "2020-01-08T08:45:45+00:00"}])
+    end
+  end
 end

--- a/spec/models/package_manager/packagist_spec.rb
+++ b/spec/models/package_manager/packagist_spec.rb
@@ -25,9 +25,9 @@ describe PackageManager::Packagist do
         "time" =>	"2012-09-18T06:46:25+00:00",
         "maintainers" => [],
         "versions" => {
-          "dev-master" => {"version" => "dev-master", "time" => "2020-01-08T08:45:45+00:00"},
-          "1.2.3" => {"version" => "1.2.3", "time" => "2020-01-08T08:45:45+00:00"},
-          "1.2.x-dev" => {"version" => "1.2.x-dev", "time" => "2020-01-08T08:45:45+00:00"},
+          "dev-master" => {"version" => "dev-master", "time" => "2020-01-08T08:45:45+00:00", "license" => ["BSD-3-Clause"], "name" =>	"librariesio/fakepkg", "description" => "A Libraries package."},
+          "1.2.3" => {"version" => "1.2.3", "time" => "2020-01-08T08:45:45+00:00", "license" => ["BSD-3-Clause"], "name" =>	"librariesio/fakepkg", "description" => "A Libraries package."},
+          "1.2.x-dev" => {"version" => "1.2.x-dev", "time" => "2020-01-08T08:45:45+00:00", "license" => ["BSD-3-Clause"], "name" =>	"librariesio/fakepkg", "description" => "A Libraries package."},
         },
         "type" =>	"library",
         "repository" => "https://github.com/librariesio/fakepkg"
@@ -39,14 +39,14 @@ describe PackageManager::Packagist do
         expect(described_class.mapping(subject)).to eq({
           name: "librariesio/fakepkg",
           description: "A Libraries package.",
-          homepage: "",
+          homepage: nil,
           keywords_array: [],
-          licenses: "",
-          repository_url: "https://github.com/libariesio/fakepkg",
+          licenses: "BSD-3-Clause",
+          repository_url: "https://github.com/librariesio/fakepkg",
           versions: {
-            "dev-master" => {"version" => "dev-master", "time" => "2020-01-08T08:45:45+00:00"},
-            "1.2.3" => {"version" => "1.2.3", "time" => "2020-01-08T08:45:45+00:00"},
-            "1.2.x-dev" => {"version" => "1.2.x-dev", "time" => "2020-01-08T08:45:45+00:00"},
+            "dev-master" => {"version" => "dev-master", "time" => "2020-01-08T08:45:45+00:00", "license" => ["BSD-3-Clause"], "name" =>	"librariesio/fakepkg", "description" => "A Libraries package."},
+            "1.2.3" => {"version" => "1.2.3", "time" => "2020-01-08T08:45:45+00:00", "license" => ["BSD-3-Clause"], "name" =>	"librariesio/fakepkg", "description" => "A Libraries package."},
+            "1.2.x-dev" => {"version" => "1.2.x-dev", "time" => "2020-01-08T08:45:45+00:00", "license" => ["BSD-3-Clause"], "name" =>	"librariesio/fakepkg", "description" => "A Libraries package."},
           }
         })
       end

--- a/spec/models/package_manager/packagist_spec.rb
+++ b/spec/models/package_manager/packagist_spec.rb
@@ -17,16 +17,45 @@ describe PackageManager::Packagist do
     end
   end
 
-  describe ".versions" do
-    it "rejects dev branches that aren't really releases" do
-      unmapped_project = {
+  context "with an unmapped package" do
+   subject do
+      {
+        "name" =>	"librariesio/fakepkg",
+        "description" => "A Libraries package.",
+        "time" =>	"2012-09-18T06:46:25+00:00",
+        "maintainers" => [],
         "versions" => {
+          "dev-master" => {"version" => "dev-master", "time" => "2020-01-08T08:45:45+00:00"},
           "1.2.3" => {"version" => "1.2.3", "time" => "2020-01-08T08:45:45+00:00"},
           "1.2.x-dev" => {"version" => "1.2.x-dev", "time" => "2020-01-08T08:45:45+00:00"},
-        }
+        },
+        "type" =>	"library",
+        "repository" => "https://github.com/librariesio/fakepkg"
       }
+    end
 
-      expect(described_class.versions(unmapped_project)).to eq([{number: "1.2.3", published_at: "2020-01-08T08:45:45+00:00"}])
+    describe ".mapping" do
+      it "maps correctly" do
+        expect(described_class.mapping(subject)).to eq({
+          name: "librariesio/fakepkg",
+          description: "A Libraries package.",
+          homepage: "",
+          keywords_array: [],
+          licenses: "",
+          repository_url: "https://github.com/libariesio/fakepkg",
+          versions: {
+            "dev-master" => {"version" => "dev-master", "time" => "2020-01-08T08:45:45+00:00"},
+            "1.2.3" => {"version" => "1.2.3", "time" => "2020-01-08T08:45:45+00:00"},
+            "1.2.x-dev" => {"version" => "1.2.x-dev", "time" => "2020-01-08T08:45:45+00:00"},
+          }
+        })
+      end
+    end
+
+    describe ".versions" do
+      it "rejects dev branches that aren't really releases" do
+        expect(described_class.versions(subject)).to eq([{number: "1.2.3", published_at: "2020-01-08T08:45:45+00:00"}])
+      end
     end
   end
 end


### PR DESCRIPTION
The Packagist spec says:

> When branch names look like versions, we have to clarify for composer that we're trying to check out a branch and not a tag. In the above example, we have two version branches: v1 and v2. To get Composer to check out one of these branches, you must specify a version constraint that looks like this: v1.x-dev. The .x is an arbitrary string that Composer requires to tell it that we're talking about the v1 branch and not a v1 tag (alternatively, you can name the branch v1.x instead of v1). In the case of a branch with a version-like name (v1, in this case), you append -dev as a suffix, rather than using dev- as a prefix.

Currently there are about ~60k Packagist releases with this suffix, like [this one](https://libraries.io/packagist/graham-campbell%2Fsecurity):

![Screenshot 2020-01-07 18 04 03](https://user-images.githubusercontent.com/5054/71936683-3304a380-3178-11ea-8e86-2a84e285c17b.png)

This change ignores that suffix when ingesting. After merging, we could run a one-off script to clean out old ones like [this](https://github.com/librariesio/libraries.io/pull/135/files#diff-0fbc15f8d188458fc05c8d0e257b2455R4)?
