### PR TITLE
match dl/dt order for tagged releases

### DIFF
--- a/app/views/projects/_releases.html.erb
+++ b/app/views/projects/_releases.html.erb
@@ -46,9 +46,9 @@
   </h4>
   <dl class='row releases'>
     <% @tags.each do |tag| %>
-      <dl class='col-sm-4'>
+      <dt class='col-sm-4'>
         <%= link_to tag, version_path(@project.to_param.merge(number: tag.name)) %>
-      </dl>
+      </dt>
       <dd class='col-sm-4 hidden-xs'>
         <% if tag.published_at.present? %>
           <small class='text-muted'>


### PR DESCRIPTION
This fixes the Tagged Releases side bar to match the Releases Side bar.
there was a missing `<dt>` here, which caused the `<dl>` css margin-bottom: 20px to add it on every row, not just the block.