### PR TITLE
Adds Dependency#version_project_id, and Project#dependent_projects_v2

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -76,7 +76,7 @@ class ProjectsController < ApplicationController
   end
 
   def dependents
-    @dependents = @project.dependent_projects_v2.visible.paginate(page: page_number)
+    @dependents = @project.dependent_projects.visible.paginate(page: page_number)
   end
 
   def dependent_repos

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -76,7 +76,7 @@ class ProjectsController < ApplicationController
   end
 
   def dependents
-    @dependents = @project.dependent_projects.visible.paginate(page: page_number)
+    @dependents = @project.dependent_projects_v2.visible.paginate(page: page_number)
   end
 
   def dependent_repos

--- a/app/models/dependency.rb
+++ b/app/models/dependency.rb
@@ -2,6 +2,7 @@ class Dependency < ApplicationRecord
   include DependencyChecks
 
   belongs_to :version
+  belongs_to :version_project, class_name: 'Project'
   belongs_to :project
 
   validates_presence_of :project_name, :version_id, :requirements, :platform
@@ -13,6 +14,7 @@ class Dependency < ApplicationRecord
   scope :platform, ->(platform) { where('lower(dependencies.platform) = ?', platform.try(:downcase)) }
 
   before_create :set_project_id
+  before_create :set_version_project_id
 
   alias_attribute :name, :project_name
   alias_attribute :latest_stable, :latest_stable_release_number
@@ -47,6 +49,10 @@ class Dependency < ApplicationRecord
 
   def set_project_id
     self.project_id = find_project_id unless project_id.present?
+  end
+
+  def set_version_project_id
+    self.version_project_id = version.project_id if version.present?
   end
 
   def update_project_id

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -43,7 +43,9 @@ class Project < ApplicationRecord
   has_many :published_tags, -> { where('published_at IS NOT NULL') }, through: :repository, class_name: 'Tag'
   has_many :dependents, class_name: 'Dependency'
   has_many :dependent_versions, through: :dependents, source: :version, class_name: 'Version'
+  # Deprecated in favor of dependent_projects_v2, which uses the new version_project_id column.
   has_many :dependent_projects, -> { group('projects.id').order('projects.rank DESC NULLS LAST') }, through: :dependent_versions, source: :project, class_name: 'Project'
+  has_many :dependent_projects_v2, -> { distinct('projects.id').order('projects.rank DESC NULLS LAST') }, through: :dependents, source: :version_project, class_name: 'Project'
   has_many :repository_dependencies
   has_many :dependent_repositories, -> { group('repositories.id').order('repositories.rank DESC NULLS LAST, repositories.stargazers_count DESC') }, through: :repository_dependencies, source: :repository
   has_many :subscriptions

--- a/db/migrate/20200111210321_add_version_project_id_to_dependency.rb
+++ b/db/migrate/20200111210321_add_version_project_id_to_dependency.rb
@@ -1,23 +1,5 @@
 class AddVersionProjectIdToDependency < ActiveRecord::Migration[5.2]
-  def up
+  def change
     add_column :dependencies, :version_project_id, :integer
-
-    say_with_time "Backfilling Dependency#version_project_id" do
-      max_id = Dependency.maximum(:id)
-      Dependency.includes(:version).find_in_batches do |b|
-        b.each { |dep|
-          dep.set_version_project_id
-          dep.save!
-        }
-        last_id = b.last.id
-        if last_id % 1_000_000 == 0
-          puts "#{((last_id / max_id.to_f) * 100).round(3)}% done."
-        end
-      end
-    end
-  end
-
-  def down
-    remove_column :dependencies, :version_project_id
   end
 end

--- a/db/migrate/20200111210321_add_version_project_id_to_dependency.rb
+++ b/db/migrate/20200111210321_add_version_project_id_to_dependency.rb
@@ -1,0 +1,23 @@
+class AddVersionProjectIdToDependency < ActiveRecord::Migration[5.2]
+  def up
+    add_column :dependencies, :version_project_id, :integer
+
+    say_with_time "Backfilling Dependency#version_project_id" do
+      max_id = Dependency.maximum(:id)
+      Dependency.includes(:version).find_in_batches do |b|
+        b.each { |dep|
+          dep.set_version_project_id
+          dep.save!
+        }
+        last_id = b.last.id
+        if last_id % 1_000_000 == 0
+          puts "#{((last_id / max_id.to_f) * 100).round(3)}% done."
+        end
+      end
+    end
+  end
+
+  def down
+    remove_column :dependencies, :version_project_id
+  end
+end

--- a/db/migrate/20200111210321_add_version_project_id_to_dependency.rb
+++ b/db/migrate/20200111210321_add_version_project_id_to_dependency.rb
@@ -1,5 +1,9 @@
 class AddVersionProjectIdToDependency < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
   def change
     add_column :dependencies, :version_project_id, :integer
+    remove_index :dependencies, :project_id
+    add_index :dependencies, [:project_id, :version_project_id], algorithm: :concurrently
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_16_195047) do
+ActiveRecord::Schema.define(version: 2020_01_11_210321) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 2019_10_16_195047) do
     t.string "requirements"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "version_project_id"
     t.index ["project_id"], name: "index_dependencies_on_project_id"
     t.index ["version_id"], name: "index_dependencies_on_version_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -58,7 +58,7 @@ ActiveRecord::Schema.define(version: 2020_01_11_210321) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "version_project_id"
-    t.index ["project_id"], name: "index_dependencies_on_project_id"
+    t.index ["project_id", "version_project_id"], name: "index_dependencies_on_project_id_and_version_project_id"
     t.index ["version_id"], name: "index_dependencies_on_version_id"
   end
 

--- a/lib/tasks/one_off.rake
+++ b/lib/tasks/one_off.rake
@@ -1,8 +1,8 @@
 namespace :one_off do
   desc 'backfill Dependency#version_project'
   task backfill_dependency_version_project: :environment do
+    max_id = Dependency.maximum(:id)
     scope = Dependency.where(version_project_id: nil)
-    max_id = scope.maximum(:id)
     puts "Before: #{scope.count}"
     scope.includes(:version).find_in_batches do |b|
       b.each do |dep|

--- a/lib/tasks/one_off.rake
+++ b/lib/tasks/one_off.rake
@@ -1,4 +1,19 @@
 namespace :one_off do
+  desc 'backfill Dependency#version_project'
+  task backfill_dependency_version_project: :environment do
+    scope = Dependency.where(version_project_id: nil)
+    max_id = scope.maximum(:id)
+    puts "Before: #{scope.count}"
+    scope.includes(:version).find_in_batches do |b|
+      b.each do |dep|
+        dep.set_version_project_id
+        dep.save
+        puts "#{((dep.id / max_id.to_f) * 100).round(3)}% done." if dep.id % 1_000_000 == 0
+      end
+    end
+    puts "After: #{scope.count}"
+  end
+
   # put your one off tasks here and delete them once they've been ran
   desc 'set stable flag on all versions'
   task set_stable_versions: :environment do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -43,6 +43,7 @@ FactoryBot.define do
   factory :dependency do
     version
     project
+    version_project { version.project }
     kind { 'runtime' }
     platform { 'Rubygems' }
     project_name { 'rails' }

--- a/spec/models/dependency_spec.rb
+++ b/spec/models/dependency_spec.rb
@@ -8,4 +8,12 @@ describe Dependency, type: :model do
   it { should validate_presence_of(:version_id) }
   it { should validate_presence_of(:requirements) }
   it { should validate_presence_of(:platform) }
+
+  context "a dependency" do
+    subject { create(:dependency, version_project: nil) }
+
+    it "should set version_project_id before create" do
+      expect(subject.version_project).to eq(subject.version.project)
+    end
+  end
 end


### PR DESCRIPTION
This denormalizes the `Dependency#version#project` association as `Dependency#version_project`, to speed up queries that do lookups for dependent projects, e.g. `/npm/foo/dependents`

### Query using the existing `@project.dependent_projects`

``` mysql
SELECT  "projects".* FROM "projects"  
  INNER JOIN "versions" ON "projects"."id" = "versions"."project_id" 
  INNER JOIN "dependencies" ON "versions"."id" = "dependencies"."version_id" 
WHERE "dependencies"."project_id" = $1 
  GROUP BY projects.id 
  ORDER BY projects.rank DESC NULLS LAST;
```

### Query using the new `@project.dependent_projects_v2`

``` mysql
SELECT DISTINCT "projects".* FROM "projects"  
  INNER JOIN "dependencies" ON "projects"."id" = "dependencies"."version_project_id" 
WHERE "dependencies"."project_id" = $1 
  ORDER BY projects.rank DESC NULLS LAST;
```

I'm not sure why the existing one uses a `GROUP BY` instead of `DISTINCT`, so please lmk if anyone has background on that.

Hard to say how much this will improve the query until it's deployed bc there are millions of dependency rows on production.