### PR TITLE
Newest semantic_range

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -531,7 +531,7 @@ GEM
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
     sdl4r (0.9.11)
-    semantic_range (2.2.1)
+    semantic_range (2.3.0)
     sexp_processor (4.12.0)
     shoulda (3.6.0)
       shoulda-context (~> 1.0, >= 1.0.1)

--- a/app/models/concerns/dependency_checks.rb
+++ b/app/models/concerns/dependency_checks.rb
@@ -36,6 +36,8 @@ module DependencyChecks
     end
     version_numbers = versions.map {|v| SemanticRange.clean(v.number) }.compact
     number = SemanticRange.max_satisfying(version_numbers, semantic_requirements, false, platform)
+    return nil unless number.present?
+
     versions.find{|v| SemanticRange.clean(v.number) == number }
   end
 


### PR DESCRIPTION
Upgrades semantic_range to pull in https://github.com/librariesio/semantic_range/pull/69, plus one additional change to stop if `max_satisfying` can't find a version.