### PR TITLE
Handle comma or space separated keywords for pypi

### DIFF
--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -45,7 +45,7 @@ module PackageManager
         name: project["info"]["name"],
         description: project["info"]["summary"],
         homepage: project["info"]["home_page"],
-        keywords_array: Array.wrap(project["info"]["keywords"].try(:split, ",")),
+        keywords_array: Array.wrap(project["info"]["keywords"].try(:split, /[\s.,]+/)),
         licenses: licenses(project),
         repository_url: repo_fallback(
           project.dig("info", "project_urls", "Source").presence || project.dig("info", "project_urls", "Source Code"),


### PR DESCRIPTION
pypi has clarified that keywords are supposed to be comma separated
but the spec historically said space (... even though the tools
have mostly worked with commas). So be generous in what we support

Fixes #2507
