### PR TITLE
Handle yanked/hidden NPM packages that have no versions.

### DIFF
--- a/app/models/package_manager/npm.rb
+++ b/app/models/package_manager/npm.rb
@@ -91,7 +91,7 @@ module PackageManager
     def self.versions(project, _name)
       # npm license fields are supposed to be SPDX expressions now https://docs.npmjs.com/files/package.json#license
       return [] if project.nil?
-      project["versions"].map do |k, v|
+      project.fetch("versions", {}).map do |k, v|
         license = v.fetch("license", nil)
         license = licenses(v) unless license.is_a?(String)
         license = "" if license.nil?
@@ -104,7 +104,7 @@ module PackageManager
     end
 
     def self.dependencies(_name, version, project)
-      vers = project[:versions][version]
+      vers = project.fetch(:versions, {})[version]
       return [] if vers.nil?
 
       map_dependencies(vers.fetch("dependencies", {}), "runtime") +

--- a/app/workers/license_backfill_worker.rb
+++ b/app/workers/license_backfill_worker.rb
@@ -11,7 +11,7 @@ class LicenseBackfillWorker
     versions = pm.versions(json_project, project.name)
     versions.each do |vers|
       version = project.versions.find_by(number: vers[:number])
-      version.update(original_license: vers[:original_license]) if version&.original_license.nil?
+      version.update(original_license: vers[:original_license]) if version && version&.original_license.nil?
     end
   end
 end


### PR DESCRIPTION
There are about ~500k failing ﻿﻿LicenseBackfillWorker jobs in Sidekiq because the projects are yanked and don't have versions. This handles this gracefully and assumes these packages have 0 versions.

Example for `npm/bundlerjs`:

```
curl http://registry.npmjs.org/bundlerjs | jq
{
  "_id": "bundlerjs",
  "name": "bundlerjs",
  "time": {
    "modified": "2019-11-13T20:00:39.709Z",
    "created": "2014-09-15T14:35:48.983Z",
    "0.0.0": "2014-09-15T14:35:48.983Z",
    "unpublished": {
      "name": "npm-support",
      "time": "2019-11-13T20:00:39.708Z",
      "tags": {
        "latest": "0.0.0"
      },
      "versions": [
        "0.0.0"
      ],
      "maintainers": [
        {
          "name": "ericprieto",
          "email": "ericprieto@live.com"
        }
      ]
    }
  }
}
````

![Screenshot 2020-06-17 10 20 16](https://user-images.githubusercontent.com/5054/84910750-413ee000-b085-11ea-9eff-e978f043e2bd.png)
