### PR TITLE
Tiegz/fix package manager base private methods

### DIFF
--- a/app/models/package_manager/go.rb
+++ b/app/models/package_manager/go.rb
@@ -47,8 +47,8 @@ module PackageManager
         overview_html = get_html("https://pkg.go.dev/#{name}?tab=overview")
 
         # NB fetching versions from the html only gets dates without timestamps, but we could alternatively use the go proxy too:
-        #   1) Fetch the list of versions: http://proxy.golang.org/#{module_name}/@v/list
-        #   2) And for each version, fetch http://proxy.golang.org/#{module_name}/@v/#{v}.info
+        #   1) Fetch the list of versions: https://proxy.golang.org/#{module_name}/@v/list
+        #   2) And for each version, fetch https://proxy.golang.org/#{module_name}/@v/#{v}.info
         versions_html = get_html("https://pkg.go.dev/#{name}?tab=versions")
 
         # Some package pages don't have a Versions tab, but the parent module page may have the Versions tab (e.g. golang.org/x/tools)

--- a/app/models/repository_owner/gitlab.rb
+++ b/app/models/repository_owner/gitlab.rb
@@ -36,9 +36,13 @@ module RepositoryOwner
       return if owner.org?
 
       # GitLab doesn't have an API to get a users public group memberships so we scrape it instead
-      rsp = PackageManager::Base.get_json("https://gitlab.com/users/#{owner.login}/groups")
+      r = Typhoeus::Request.new("https://gitlab.com/users/#{owner.login}/groups",
+        method: :get,
+        headers: { 'Accept' => 'application/json' }).run
+      json = Oj.load(r.body)
+
       return if rsp.nil?
-      groups_html = Nokogiri::HTML(rsp['html'])
+      groups_html = Nokogiri::HTML(json['html'])
       return if groups_html.nil?
       links = groups_html.css('a.group-name').map{|l| l['href'][1..-1]}.compact
 

--- a/app/models/repository_owner/gitlab.rb
+++ b/app/models/repository_owner/gitlab.rb
@@ -171,7 +171,7 @@ module RepositoryOwner
     private
 
     def get_json(url)
-      r = Typhoeus::Request.new("https://gitlab.com/users/#{owner.login}/groups",
+      r = Typhoeus::Request.new(url,
         method: :get,
         headers: { 'Accept' => 'application/json' }).run
       Oj.load(r.body)

--- a/app/models/repository_owner/gitlab.rb
+++ b/app/models/repository_owner/gitlab.rb
@@ -36,9 +36,7 @@ module RepositoryOwner
       return if owner.org?
 
       # GitLab doesn't have an API to get a users public group memberships so we scrape it instead
-      json = get_json("https://gitlab.com/users/#{owner.login}/groups",
-        method: :get,
-        headers: { 'Accept' => 'application/json' }).run
+      json = get_json("https://gitlab.com/users/#{owner.login}/groups")
 
       return if json.nil?
       groups_html = Nokogiri::HTML(json['html'])


### PR DESCRIPTION
GitLab code is using `PackageManager::Base.get_json`, which was turned into a private class method a few months ago. Instead of using that method, this uses a single Typhoeus request instead. Fixes this Sidekiq error:

![Screenshot 2020-06-22 09 39 41](https://user-images.githubusercontent.com/5054/85294517-bab34580-b46c-11ea-8f37-40fe1a4b73ee.png)
