### PR TITLE
Included updated_at in package API replies and add /updated endpoint

### DIFF
--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -34,7 +34,7 @@ class Api::ApplicationController < ApplicationController
   end
 
   def internal_api_key?
-    current_api_key.is_internal?
+    !!current_api_key&.is_internal?
   end
 
   def record_api_usage

--- a/app/controllers/api/status_controller.rb
+++ b/app/controllers/api/status_controller.rb
@@ -7,6 +7,7 @@ class Api::StatusController < Api::BulkProjectController
       each_serializer: ProjectStatusSerializer,
       show_score: params[:score],
       show_stats: internal_api_key?,
+      show_updated_at: internal_api_key?,
       project_names: project_names
     )
   end

--- a/app/models/deleted_project.rb
+++ b/app/models/deleted_project.rb
@@ -1,0 +1,17 @@
+class DeletedProject < ApplicationRecord
+  scope :updated_within, ->(start, stop) { where('updated_at >= ? and updated_at <= ? ', start, stop).order(updated_at: :asc) }
+
+  def self.digest_from_platform_and_name(platform, name)
+    sha1 = Digest::SHA256.new
+    # the .lowercase ensures it's easy for everyone to get the digest right
+    sha1.update(platform.downcase)
+    # package names are case-sensitive though, so no lowercase here
+    sha1.update(name)
+    sha1.hexdigest
+  end
+
+  def self.create_from_platform_and_name!(platform, name)
+    DeletedProject.create!(digest: digest_from_platform_and_name(platform, name))
+  end
+
+end

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -27,4 +27,10 @@ class ProjectSerializer < ActiveModel::Serializer
   ]
 
   has_many :versions
+
+  attribute :updated_at, if: :show_updated_at?
+
+  def show_updated_at?
+    instance_options[:show_updated_at]
+  end
 end

--- a/app/serializers/project_status_serializer.rb
+++ b/app/serializers/project_status_serializer.rb
@@ -14,6 +14,7 @@ class ProjectStatusSerializer < ActiveModel::Serializer
 
   has_many :versions
   has_many :repository_maintenance_stats, if: :show_stats?
+  attribute :updated_at, if: :show_updated_at?
 
   def score?
     instance_options[:show_score]
@@ -21,6 +22,10 @@ class ProjectStatusSerializer < ActiveModel::Serializer
 
   def show_stats?
     instance_options[:show_stats]
+  end
+
+  def show_updated_at?
+    instance_options[:show_updated_at]
   end
 
   def name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
     delete '/subscription/:platform/:name', to: 'subscriptions#destroy'
 
     post '/projects/dependencies', to: 'projects#dependencies_bulk'
+    get '/projects/updated', to: 'projects#updated'
 
     scope constraints: {host_type: /(github|gitlab|bitbucket)/i}, defaults: { host_type: 'github' } do
       get '/:host_type/issues/help-wanted', to: 'issues#help_wanted'

--- a/db/migrate/20200709221449_create_deleted_projects.rb
+++ b/db/migrate/20200709221449_create_deleted_projects.rb
@@ -1,0 +1,11 @@
+class CreateDeletedProjects < ActiveRecord::Migration[5.2]
+  def change
+    create_table :deleted_projects do |t|
+      t.string "digest", null: false
+      t.timestamps
+    end
+
+    add_index :deleted_projects, [:digest], unique: true
+    add_index :deleted_projects, :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_26_151754) do
+ActiveRecord::Schema.define(version: 2020_07_09_221449) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -45,6 +45,14 @@ ActiveRecord::Schema.define(version: 2020_05_26_151754) do
     t.string "platform"
     t.index ["repository_id", "repository_user_id"], name: "index_contributions_on_repository_id_and_user_id"
     t.index ["repository_user_id"], name: "index_contributions_on_repository_user_id"
+  end
+
+  create_table "deleted_projects", force: :cascade do |t|
+    t.string "digest", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["digest"], name: "index_deleted_projects_on_digest", unique: true
+    t.index ["updated_at"], name: "index_deleted_projects_on_updated_at"
   end
 
   create_table "dependencies", id: :serial, force: :cascade do |t|

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -247,4 +247,28 @@ describe Project, type: :model do
       end
     end
   end
+
+  describe 'DeletedProject management' do
+    let!(:project) { Project.create(platform: 'NPM', name: 'react') }
+
+    it 'should create a DeletedProject when destroyed' do
+      expect(DeletedProject.count).to eq(0)
+      digest = DeletedProject.digest_from_platform_and_name(project.platform, project.name)
+      expect(digest).to eq("ef64ba66a6ca7f649a3e384bf2345e05698d6100b931fe14a21853a3af82900c")
+      project.destroy!
+      expect(DeletedProject.count).to eq(1)
+      dp = DeletedProject.first
+      expect(dp.digest).to eq(digest)
+    end
+
+    it 'should remove a DeletedProject when resurrected' do
+      expect(DeletedProject.count).to eq(0)
+      digest = DeletedProject.digest_from_platform_and_name(project.platform, project.name)
+      expect(digest).to eq("ef64ba66a6ca7f649a3e384bf2345e05698d6100b931fe14a21853a3af82900c")
+      project.destroy!
+      expect(DeletedProject.count).to eq(1)
+      recreated = Project.create(platform: 'NPM', name: 'react')
+      expect(DeletedProject.count).to eq(0)
+    end
+  end
 end

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -9,8 +9,10 @@ describe "Api::ProjectsController" do
   let!(:version) { create(:version, project: project) }
   let!(:dependent_version) { create(:version, project: dependent_project) }
   let!(:dependency) { create(:dependency, version: version, project: dependent_project) }
+  let!(:internal_user) { create(:user) }
 
   before :each do
+    internal_user.current_api_key.update_attribute(:is_internal, true)
     project.reload
     dependent_project.reload
   end
@@ -21,6 +23,17 @@ describe "Api::ProjectsController" do
       expect(response).to have_http_status(:success)
       expect(response.content_type).to eq("application/json")
       expect(response.body).to be_json_eql project_json_response(project).to_json
+    end
+
+    it "renders successfully with internal API key" do
+      get "/api/#{project.platform}/#{project.name}?api_key=#{internal_user.api_key}"
+      expect(response).to have_http_status(:success)
+      expect(response.content_type).to eq("application/json")
+
+      # with internal API key we add updated_at field
+      expected_response = project_json_response(project)
+      expected_response[:updated_at] = project.updated_at.iso8601(3)
+      expect(response.body).to be_json_eql expected_response.to_json
     end
   end
 
@@ -48,6 +61,93 @@ describe "Api::ProjectsController" do
       expect(response).to have_http_status(:success)
       expect(response.content_type).to eq("application/json")
       expect(JSON.parse(response.body)).to contain_exactly(project.repository_url, dependent_project.repository_url)
+    end
+  end
+
+  describe "GET /api/projects/updated", type: :request do
+    it "renders successfully" do
+      get "/api/projects/updated?start_time=#{1.year.ago.utc.iso8601}&api_key=#{internal_user.api_key}"
+      expect(response).to have_http_status(:success)
+      expect(response.content_type).to eq("application/json")
+      expect(response.body).to be_json_eql ({
+        updated: [
+          {
+            platform: project.platform,
+            name: project.name,
+            updated_at: project.updated_at.utc.iso8601(3)
+          },
+          {
+            platform: dependent_project.platform,
+            name: dependent_project.name,
+            updated_at: dependent_project.updated_at.utc.iso8601(3)
+          }
+        ],
+        deleted: []
+      }).to_json
+    end
+
+    it "ignores stuff after end_time" do
+      get "/api/projects/updated?start_time=#{1.year.ago.utc.iso8601}&end_time=#{1.month.ago.utc.iso8601}&api_key=#{internal_user.api_key}"
+      expect(response).to have_http_status(:success)
+      expect(response.content_type).to eq("application/json")
+      expect(response.body).to be_json_eql ({
+        updated: [],
+        deleted: []
+      }).to_json
+    end
+
+    it "ignores stuff before start_time" do
+      after_everything = [project.updated_at, dependent_project.updated_at].max + 1
+      get "/api/projects/updated?start_time=#{after_everything.utc.iso8601}&api_key=#{internal_user.api_key}"
+      expect(response).to have_http_status(:success)
+      expect(response.content_type).to eq("application/json")
+      expect(response.body).to be_json_eql ({
+        updated: [],
+        deleted: []
+      }).to_json
+    end
+
+    it "errors if no start_time" do
+      expect { get "/api/projects/updated?api_key=#{internal_user.api_key}" }
+        .to raise_exception(ActionController::ParameterMissing)
+    end
+
+    it "errors if api_key is not internal" do
+      expect { get "/api/projects/updated?api_key=#{user.api_key}" }
+        .to raise_exception(ActionController::BadRequest)
+    end
+
+    it "errors if start_time is garbage" do
+      expect { get "/api/projects/updated?start_time=NOTADATE&api_key=#{internal_user.api_key}" }
+        .to raise_exception(ArgumentError)
+    end
+
+    it "errors if end_time is garbage" do
+      expect { get "/api/projects/updated?start_time=#{1.year.ago.utc.iso8601}&end_time=NOTADATE&api_key=#{internal_user.api_key}" }
+        .to raise_exception(ArgumentError)
+    end
+
+    it "notices deletions" do
+      deleted_digest = DeletedProject.digest_from_platform_and_name(project.platform, project.name)
+      project.destroy!
+      get "/api/projects/updated?start_time=#{1.year.ago.utc.iso8601}&api_key=#{internal_user.api_key}"
+      expect(response).to have_http_status(:success)
+      expect(response.content_type).to eq("application/json")
+      expect(response.body).to be_json_eql ({
+        updated: [
+          {
+            platform: dependent_project.platform,
+            name: dependent_project.name,
+            updated_at: dependent_project.updated_at.utc.iso8601(3)
+          }
+        ],
+        deleted: [
+          {
+            digest: deleted_digest,
+            updated_at: DeletedProject.first.updated_at.utc.iso8601(3)
+          }
+        ]
+      }).to_json
     end
   end
 

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -47,7 +47,7 @@ describe "Api::ProjectsController" do
       get "/api/searchcode"
       expect(response).to have_http_status(:success)
       expect(response.content_type).to eq("application/json")
-      expect(response.body).to be_json_eql [project.repository_url, dependent_project.repository_url].to_json
+      expect(JSON.parse(response.body)).to contain_exactly(project.repository_url, dependent_project.repository_url)
     end
   end
 

--- a/spec/requests/api/status_spec.rb
+++ b/spec/requests/api/status_spec.rb
@@ -25,6 +25,10 @@ describe "API::StatusController" do
       expect(maintenance_stats.length).to be 1
       expect(maintenance_stats.first["category"]).to eql maintenance_stat.category
       expect(maintenance_stats.first["value"]).to eql maintenance_stat.value
+
+      # and updated_at
+      updated_at = json_response.first["updated_at"]
+      expect(updated_at).not_to be(nil)
     end
 
     it "renders empty json list if cannot find Project" do
@@ -142,7 +146,7 @@ describe "API::StatusController" do
 
     context "with normal API key" do
 
-      it "returns no maintenance stats" do
+      it "returns no maintenance stats or updated_at" do
         post "/api/check", params: {api_key: normal_user.api_key, projects: [{name: project_django.name, platform: project_django.platform}] }
         expect(response).to have_http_status(:success)
         expect(response.content_type).to eq('application/json')
@@ -150,6 +154,7 @@ describe "API::StatusController" do
 
         json_response = JSON.parse(response.body)
         expect(json_response.first.key? "repository_maintenance_stats").to be false
+        expect(json_response.first.key? "updated_at").to be false
       end
     end
 

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -1,36 +1,48 @@
 require 'rails_helper'
 
 describe ProjectSerializer do
-  subject { described_class.new(build(:project)) }
 
-  it 'should have expected attribute names' do
-    expect(subject.attributes.keys).to eq(
-      %i[
-        dependent_repos_count
-        dependents_count
-        deprecation_reason
-        description
-        forks
-        homepage
-        keywords
-        language
-        latest_download_url
-        latest_release_number
-        latest_release_published_at
-        latest_stable_release
-        latest_stable_release_number
-        latest_stable_release_published_at
-        license_normalized
-        licenses
-        name
-        normalized_licenses
-        package_manager_url
-        platform
-        rank
-        repository_url
-        stars
-        status
-      ]
-    )
+  let (:default_attribute_names) { %i[
+      dependent_repos_count
+      dependents_count
+      deprecation_reason
+      description
+      forks
+      homepage
+      keywords
+      language
+      latest_download_url
+      latest_release_number
+      latest_release_published_at
+      latest_stable_release
+      latest_stable_release_number
+      latest_stable_release_published_at
+      license_normalized
+      licenses
+      name
+      normalized_licenses
+      package_manager_url
+      platform
+      rank
+      repository_url
+      stars
+      status
+    ]
+  }
+
+  context "without updated_at" do
+    subject { described_class.new(build(:project)) }
+
+    it 'should have expected attribute names' do
+      expect(subject.attributes.keys).to eq(default_attribute_names)
+    end
+  end
+
+  context "with updated_at" do
+    subject { described_class.new(build(:project), show_updated_at: true) }
+
+    it 'should have expected attribute names' do
+      expect(subject.attributes.keys).to eq(default_attribute_names + %i[updated_at])
+    end
   end
 end


### PR DESCRIPTION
The /updated endpoint returns a list of packages with updated_at
in a given time window.

The purpose of this is to simplify mirroring.