### PR TITLE
Echo error and then exit in bin/deploy.sh

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -4,7 +4,7 @@ set -e
 
 REVISION=$(git show-ref origin/master |cut -f 1 -d ' ')
 TAGGED_IMAGE=gcr.io/${GOOGLE_PROJECT}/libraries.io:${REVISION}
-gcloud --quiet container images describe ${TAGGED_IMAGE} || exit "Container not finished building"
+gcloud --quiet container images describe ${TAGGED_IMAGE} || status=$?; echo "Container not finished building" >&2; exit $status
 
 gcloud --quiet container images add-tag ${TAGGED_IMAGE} gcr.io/${GOOGLE_PROJECT}/libraries.io:latest
 


### PR DESCRIPTION
Fixes issue #2544 

If something goes wrong with `gcloud --quiet container images describe ${TAGGED_IMAGE}` then:

- save the status of the command
- echo the existing test to stderr
- exit with the saved status

This will let the caller have both the human-readable text in stderr and the actuall error status of the `gcloud`  command.