### PR TITLE
Remove duplicated number section in config/locales/en.yml

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,13 +20,12 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
+  hello: "Hello world"
   number:
     currency:
       format:
         format: "%n%u"
         unit: "GBP"
-  hello: "Hello world"
-  number:
     human:
       decimal_units:
         format: "%n%u"


### PR DESCRIPTION
Fixes issue #2546 

Condense the "number" section in `config/locales/en.yml` to a single section.