### PR TITLE
Fix typo of 'change' in app/assets/javascripts/application.js

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -84,7 +84,7 @@ document.addEventListener('turbolinks:load', function(){
   })
 
   $('input[name="subscription[include_prerelease]"]').on('change',function(){
-    console.log('chanage')
+    console.log('change')
     $(this).parents('form').submit();
   });
 })


### PR DESCRIPTION
This looks like "just a typo" that has no real consequence for an ordinary user!

Was introduced by https://github.com/phil-davis/libraries.io/commit/da555b600012656d2a2e89160b251a1c0dea9f35