### PR TITLE
Fix operator-command precedence in deploy.sh

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -4,7 +4,7 @@ set -e
 
 REVISION=$(git show-ref origin/master |cut -f 1 -d ' ')
 TAGGED_IMAGE=gcr.io/${GOOGLE_PROJECT}/libraries.io:${REVISION}
-gcloud --quiet container images describe ${TAGGED_IMAGE} || status=$?; echo "Container not finished building" >&2; exit $status
+gcloud --quiet container images describe ${TAGGED_IMAGE} || { status=$?; echo "Container not finished building" >&2; exit $status; }
 
 gcloud --quiet container images add-tag ${TAGGED_IMAGE} gcr.io/${GOOGLE_PROJECT}/libraries.io:latest
 


### PR DESCRIPTION
PR #2545 "enhanced" the error handling in `bin/deploy.sh` But the command is now always exiting. It should exit only when there was an error.

Put the sequence of error-handling commands in brackets so that they are all considered together as a group on the right-side of the "or" expression.

http://www.gnu.org/software/bash/manual/html_node/Command-Grouping.html - I used the "curly braces" grouping because that does not create a subshell. There is less thinking with that - we want to save the status, emit some text, then exit the current shell. Using `()` syntax would send us down into a subshell.