### PR TITLE
Use the newer semver2 endpoint to get more nuget packages

### DIFF
--- a/app/models/package_manager/nu_get.rb
+++ b/app/models/package_manager/nu_get.rb
@@ -58,7 +58,7 @@ module PackageManager
     end
 
     def self.get_releases(name)
-      latest_version = get_json("https://api.nuget.org/v3/registration5-semver1/#{name.downcase}/index.json")
+      latest_version = get_json("https://api.nuget.org/v3/registration5-gz-semver2/#{name.downcase}/index.json")
       if latest_version["items"][0]["items"]
         releases = []
         latest_version["items"].each do |items|

--- a/app/views/shared/flashes/idc-webinar.html.erb
+++ b/app/views/shared/flashes/idc-webinar.html.erb
@@ -1,0 +1,8 @@
+Joint IDC / Tidelift Webinar: The future of open source software support.
+<strong>
+  <a href="https://tidelift.com/subscription/webinar/idc?utm_source=libraries&utm_medium=referral&utm_campaign=idc-webinar"
+    target="_blank"
+    style="text-decoration:underline;color: white;">
+    Register now.
+  </a>
+</strong>


### PR DESCRIPTION
More nuget packages are being released with semver2 style
versioning; this will let us index those versions
