### PR TITLE
Two-table online migration for repository_dependencies bigint.

### DIFF
--- a/db/migrate/20200921173826_convert_repository_dependency_id_to_big_int.rb
+++ b/db/migrate/20200921173826_convert_repository_dependency_id_to_big_int.rb
@@ -1,6 +1,6 @@
 class ConvertRepositoryDependencyIdToBigInt < ActiveRecord::Migration[5.2]
   # This is a long-running migration so we don't want to do the entire thing in a transaction.
-  # disable_ddl_transaction!
+  disable_ddl_transaction!
 
   def up
     if ENV['CIRCLE_CI']

--- a/db/migrate/20200921173826_convert_repository_dependency_id_to_big_int.rb
+++ b/db/migrate/20200921173826_convert_repository_dependency_id_to_big_int.rb
@@ -1,0 +1,145 @@
+class ConvertRepositoryDependencyIdToBigInt < ActiveRecord::Migration[5.2]
+  # This is a long-running migration so we don't want to do the entire thing in a transaction.
+  # disable_ddl_transaction!
+
+  def up
+    if ENV['CIRCLE_CI']
+      say "Skipping ConvertRepositoryDependencyIdToBigInt migration in Circle. To run, reverse it and run it again in a persistent shell on production."
+      return
+    end
+
+    @start_time = Time.now
+
+    create_new_table
+    create_triggers
+    copy_old_to_new
+    rename_tables
+    delete_triggers
+    puts "Done! Archived table is at #{archived_table_name}. Drop table when you have verified the new one is correct."
+  end
+
+  def down
+    # no-op
+  end
+
+  def self.manual_cleanup
+    delete_triggers
+  end
+
+  private
+
+    def create_new_table
+      # JIC renaming indices locks table, we're just going to keep the same names and add a unique suffix.
+      index_suffix = @start_time.to_i
+
+      # Clone table and make change: bigserial pkey, instead of serial.
+      create_table "repository_dependencies_new", id: :bigserial, force: :cascade do |t|
+        t.integer "project_id"
+        t.integer "manifest_id"
+        t.boolean "optional"
+        t.string "project_name"
+        t.string "platform"
+        t.string "requirements"
+        t.string "kind"
+        t.datetime "created_at", null: false
+        t.datetime "updated_at", null: false
+        t.integer "repository_id"
+        t.index ["manifest_id"], name: "index_repository_dependencies_on_manifest_id_#{index_suffix}"
+        t.index ["project_id"], name: "index_repository_dependencies_on_project_id_#{index_suffix}"
+        t.index ["repository_id"], name: "index_repository_dependencies_on_repository_id_#{index_suffix}"
+      end
+    end
+
+    def rename_tables
+      # TODO make sure that lock table is using most restrictive lock mode by default
+      say_with_time "Renaming tables (archive will be #{archived_table_name})." do
+        connection.execute "begin"
+        connection.execute "lock table repository_dependencies, repository_dependencies_new"
+        connection.execute "alter table repository_dependencies rename to #{archived_table_name}"
+        connection.execute "alter table repository_dependencies_new rename to repository_dependencies"
+        connection.execute "commit"
+      end
+    end
+
+    def copy_old_to_new
+      chunk_size = 100_000
+      min = connection.select_value("select min(id) from repository_dependencies").to_i
+      max = connection.select_value("select max(id) from repository_dependencies").to_i
+      current_min = min
+      current_max = current_min + chunk_size - 1
+
+      say "Copying old rows to new table: ids #{min} to #{max}, in chunks of #{chunk_size}."
+      while current_min < max
+        num_rows = connection.update(%Q!
+          insert into repository_dependencies_new (id, project_id, manifest_id, optional, project_name, platform, requirements, kind, created_at, updated_at, repository_id)
+            select id, project_id, manifest_id, optional, project_name, platform, requirements, kind, created_at, updated_at, repository_id 
+            from repository_dependencies
+            where repository_dependencies.id between #{ current_min } and #{ current_max }
+            on conflict do nothing
+        !)
+        print "."
+        puts " #{((current_min / current_max.to_f) * 100).round}% " if current_min % 10_000_000 
+        current_min = current_max + 1
+        current_max = current_min + chunk_size - 1
+      end
+    end
+
+    def create_triggers
+      say "Creating insert trigger function"
+      connection.execute %Q!CREATE OR REPLACE FUNCTION on_insert_repository_dependencies()  RETURNS TRIGGER LANGUAGE plpgsql AS $$
+          BEGIN
+            insert into repository_dependencies_new (id, project_id, manifest_id, optional, project_name, platform, requirements, kind, created_at, updated_at, repository_id)
+            values (NEW.project_id, NEW.manifest_id, NEW.optional, NEW.project_name, NEW.platform, NEW.requirements, NEW.kind, NEW.created_at, NEW.updated_at, NEW.repository_id)
+            on conflict (id) do update
+              set id=NEW.id, project_id=NEW.project_id, manifest_id=NEW.manifest_id, optional=NEW.optional, project_name=NEW.project_name, platform=NEW.platform, requirements=NEW.requirements, kind=NEW.kind, created_at=NEW.created_at, updated_at=NEW.updated_at, repository_id=NEW.repository_id;
+          END;
+          $$!
+
+      say "Creating insert trigger"
+      connection.execute "create trigger migration_insert_repository_dependencies after insert on repository_dependencies for each row EXECUTE PROCEDURE on_insert_repository_dependencies()"
+
+      say "Creating update trigger function"
+      connection.execute %Q!CREATE OR REPLACE FUNCTION on_update_repository_dependencies() RETURNS TRIGGER LANGUAGE plpgsql AS $$
+          BEGIN
+            insert into repository_dependencies_new (id, project_id, manifest_id, optional, project_name, platform, requirements, kind, created_at, updated_at, repository_id)
+            values (NEW.project_id, NEW.manifest_id, NEW.optional, NEW.project_name, NEW.platform, NEW.requirements, NEW.kind, NEW.created_at, NEW.updated_at, NEW.repository_id)
+            on conflict (id) do update
+              set id=NEW.id, project_id=NEW.project_id, manifest_id=NEW.manifest_id, optional=NEW.optional, project_name=NEW.project_name, platform=NEW.platform, requirements=NEW.requirements, kind=NEW.kind, created_at=NEW.created_at, updated_at=NEW.updated_at, repository_id=NEW.repository_id;
+          END;
+          $$!
+
+      say "Creating update trigger"
+      connection.execute "create trigger migration_update_repository_dependencies after update on repository_dependencies for each row EXECUTE PROCEDURE on_update_repository_dependencies()"
+
+      # Is it possible in postgres to ignore errors while deleting? (eg ON ERROR)
+      say "Creating delete trigger function"
+      connection.execute %Q!CREATE OR REPLACE FUNCTION on_delete_repository_dependencies() RETURNS TRIGGER LANGUAGE plpgsql AS $$
+        BEGIN
+          delete from repository_dependencies_new where repository_dependencies_new.id = OLD.id;
+        END;
+        $$;!
+
+      say "Creating delete trigger"
+      connection.execute "create trigger migration_delete_repository_dependencies after delete on repository_dependencies for each row EXECUTE PROCEDURE on_delete_repository_dependencies()"
+    end
+
+    def delete_triggers
+      say "Deleting delete trigger"
+      connection.execute "drop trigger migration_delete_repository_dependencies ON #{archived_table_name}"
+      say "Deleting insert trigger"
+      connection.execute "drop trigger migration_insert_repository_dependencies ON #{archived_table_name}"
+      say "Deleting update trigger"
+      connection.execute "drop trigger migration_update_repository_dependencies ON #{archived_table_name}"
+      
+      say "Deleting insert trigger functions"
+      connection.execute "drop function on_insert_repository_dependencies()"
+      say "Deleting update trigger functions"
+      connection.execute "drop function on_update_repository_dependencies()"
+      say "Deleting delete trigger functions"
+      connection.execute "drop function on_delete_repository_dependencies()"
+    end
+
+    def archived_table_name
+      @archived_table_name ||= "archived_#{ @start_time.strftime "%Y_%m_%d_%H_%M_%S_#{ '%03d' % (@start_time.usec / 1000) }" }_repository_dependencies"[0...64]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_09_221449) do
+ActiveRecord::Schema.define(version: 2020_09_21_173826) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -258,7 +258,7 @@ ActiveRecord::Schema.define(version: 2020_07_09_221449) do
     t.index ["status"], name: "index_repositories_on_status"
   end
 
-  create_table "repository_dependencies", id: :serial, force: :cascade do |t|
+  create_table "repository_dependencies", id: :bigint, default: -> { "nextval('repository_dependencies_new_id_seq6'::regclass)" }, force: :cascade do |t|
     t.integer "project_id"
     t.integer "manifest_id"
     t.boolean "optional"
@@ -269,9 +269,9 @@ ActiveRecord::Schema.define(version: 2020_07_09_221449) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "repository_id"
-    t.index ["manifest_id"], name: "index_repository_dependencies_on_manifest_id"
-    t.index ["project_id"], name: "index_repository_dependencies_on_project_id"
-    t.index ["repository_id"], name: "index_repository_dependencies_on_repository_id"
+    t.index ["manifest_id"], name: "index_repository_dependencies_on_manifest_id_1600871050"
+    t.index ["project_id"], name: "index_repository_dependencies_on_project_id_1600871050"
+    t.index ["repository_id"], name: "index_repository_dependencies_on_repository_id_1600871050"
   end
 
   create_table "repository_maintenance_stats", force: :cascade do |t|
@@ -417,11 +417,11 @@ ActiveRecord::Schema.define(version: 2020_07_09_221449) do
      FROM (( SELECT repositories.id,
               repositories.rank,
               repositories.stargazers_count,
-              repository_dependencies.project_id
+              archived_2020_09_23_09_53_18_556_repository_dependencies.project_id
              FROM (repositories
-               JOIN repository_dependencies ON ((repositories.id = repository_dependencies.repository_id)))
+               JOIN archived_2020_09_23_09_53_18_556_repository_dependencies ON ((repositories.id = archived_2020_09_23_09_53_18_556_repository_dependencies.repository_id)))
             WHERE (repositories.private = false)
-            GROUP BY repositories.id, repository_dependencies.project_id) t1
+            GROUP BY repositories.id, archived_2020_09_23_09_53_18_556_repository_dependencies.project_id) t1
        JOIN projects ON ((t1.project_id = projects.id)));
   SQL
   add_index "project_dependent_repositories", ["project_id", "rank", "stargazers_count"], name: "index_project_dependent_repos_on_rank", order: { rank: "DESC NULLS LAST", stargazers_count: :desc }


### PR DESCRIPTION
This migrates `repository_dependencies` from an integer to bigint primary key.

The process is:
* create new table, with the change
* create triggers, which will copy any inserts/udpates/deletes from old to new
* copy rows over from old to new, in chunks
* rename new to "archived_TIMESTAMP_repository_dependencies" and old to "repository_dependencies"
* drop triggers

### Blockers
* [ ] new primary key default doesn't get updated
* [ ] what to do with the materialized view that still points to old table?

### Output 

```
== 20200921173826 ConvertRepositoryDependencyIdToBigInt: migrating ============
-- create_table("repository_dependencies_new", {:id=>:bigserial, :force=>:cascade})
   -> 0.0233s
-- Creating insert trigger function
-- Creating insert trigger
-- Creating update trigger function
-- Creating update trigger
-- Creating delete trigger function
-- Creating delete trigger
-- Copying old rows to new table: 1 to 2, in chunks of 100000.
.--  0% 
-- Renaming tables (archive will be archived_2020_09_23_10_24_10_244_repository_dependencies).
   -> 0.0034s
-- Deleting delete trigger
-- Deleting insert trigger
-- Deleting update trigger
-- Deleting insert trigger functions
-- Deleting update trigger functions
-- Deleting delete trigger functions
== 20200921173826 ConvertRepositoryDependencyIdToBigInt: migrated (0.0916s) ===
```
