### PR TITLE
 RepositoryDependency id migration step 2: migrate from integer to bigint

### DIFF
--- a/db/migrate/20200921173826_convert_repository_dependency_id_to_big_int.rb
+++ b/db/migrate/20200921173826_convert_repository_dependency_id_to_big_int.rb
@@ -1,0 +1,10 @@
+class ConvertRepositoryDependencyIdToBigInt < ActiveRecord::Migration[5.2]
+  def up
+    # NB this locks the table, so we're disabling related code temporarily, while it runs.
+    change_column :repository_dependencies, :id, :bigint
+  end
+
+  def down
+    change_column :repository_dependencies, :id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_09_221449) do
+ActiveRecord::Schema.define(version: 2020_09_21_173826) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -258,7 +258,7 @@ ActiveRecord::Schema.define(version: 2020_07_09_221449) do
     t.index ["status"], name: "index_repositories_on_status"
   end
 
-  create_table "repository_dependencies", id: :serial, force: :cascade do |t|
+  create_table "repository_dependencies", force: :cascade do |t|
     t.integer "project_id"
     t.integer "manifest_id"
     t.boolean "optional"


### PR DESCRIPTION
* converts `repository_dependencies.id` from integer to bigint 

This migration assumes that we're ok waiting for the table lock, and just temporarily serving bad data for this table until it's done.
