### PR TITLE
fix(API-Doc): show correct Output for SourceRank

### DIFF
--- a/app/views/api/docs/index.html.erb
+++ b/app/views/api/docs/index.html.erb
@@ -158,7 +158,7 @@
     </p>
     <% cache "api-docs-#{@cache_version}sourcerank", :expires_in => 1.day do %>
       <pre class='well well-small'>
-<%= JSON.pretty_generate @project.source_rank.as_json %></pre>
+<%= JSON.pretty_generate @project.source_rank_breakdown.as_json %></pre>
     <% end %>
 
     <h3 id="project-usage">Project Usage</h3>


### PR DESCRIPTION
Fixes #2361 

Uses `source_rank_breakdown` instead of `source_rank` to show output as defined in `app/controllers/api/projects_controller.rb#L8`

```ruby
  def sourcerank
    render json: @project.source_rank_breakdown
  end
```