### PR TITLE
Add create(hash) Back into Version Save

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -102,9 +102,11 @@ module PackageManager
       if self::HAS_VERSIONS
         class_name = name.demodulize
         versions(project, dbproject.name).each do |version|
-          dbversion = dbproject.versions.find_by(number: version[:number]) || dbproject.versions.create(version) 
-          dbversion.repository_sources = Set.new(dbversion.repository_sources).add(class_name).to_a if self::HAS_MULTIPLE_REPO_SOURCES
-          dbversion.save
+          existing = dbproject.versions.find_or_initialize_by(number: version[:number]) do |new_version|
+            new_version.update_attributes(version)
+          end
+          existing.repository_sources = Set.new(existing.repository_sources).add(class_name).to_a if self::HAS_MULTIPLE_REPO_SOURCES
+          existing.save
         end
       end
 

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -102,9 +102,9 @@ module PackageManager
       if self::HAS_VERSIONS
         class_name = name.demodulize
         versions(project, dbproject.name).each do |version|
-          existing = dbproject.versions.find_or_initialize_by(number: version[:number])
-          existing.repository_sources = Set.new(existing.repository_sources).add(class_name).to_a if self::HAS_MULTIPLE_REPO_SOURCES
-          existing.save
+          dbversion = dbproject.versions.find_by(number: version[:number]) || dbproject.versions.create(version) 
+          dbversion.repository_sources = Set.new(dbversion.repository_sources).add(class_name).to_a if self::HAS_MULTIPLE_REPO_SOURCES
+          dbversion.save
         end
       end
 


### PR DESCRIPTION
The code that was changed here in https://github.com/librariesio/libraries.io/pull/2590 wasn't functionally equivalent. We need to create using the hash passed in to grab other data points outside of the version number like the published date.