### PR TITLE
Maven Download Rake Tasks For Multiple Repository Sources

### DIFF
--- a/app/controllers/hooks_controller.rb
+++ b/app/controllers/hooks_controller.rb
@@ -14,7 +14,7 @@ class HooksController < ApplicationController
   end
 
   def package
-    PackageManagerDownloadWorker.perform_async(params['platform'], params['name'])
+    PackageManagerDownloadWorker.perform_async("PackageManager::#{params['platform']}", params['name'])
 
     render json: nil, status: :ok
   end

--- a/app/controllers/hooks_controller.rb
+++ b/app/controllers/hooks_controller.rb
@@ -14,7 +14,7 @@ class HooksController < ApplicationController
   end
 
   def package
-    PackageManagerDownloadWorker.perform_async("PackageManager::#{params['platform']}", params['name'])
+    PackageManagerDownloadWorker.perform_async("PackageManager::#{params['platform']}", params["name"])
 
     render json: nil, status: :ok
   end

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -284,7 +284,7 @@ module PackageManager
 
     private_class_method def self.download_async(names)
       names.each_slice(1000).each_with_index do |group, index|
-        group.each { |name| PackageManagerDownloadWorker.perform_in(index.hours, self.name.demodulize, name) }
+        group.each { |name| PackageManagerDownloadWorker.perform_in(index.hours, self, name) }
       end
     end
   end

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -284,7 +284,7 @@ module PackageManager
 
     private_class_method def self.download_async(names)
       names.each_slice(1000).each_with_index do |group, index|
-        group.each { |name| PackageManagerDownloadWorker.perform_in(index.hours, self, name) }
+        group.each { |name| PackageManagerDownloadWorker.perform_in(index.hours, self.name, name) }
       end
     end
   end

--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -234,10 +234,6 @@ module PackageManager
       "Maven"
     end
 
-    def self.provider(provider)
-      PROVIDER_MAP[provider]
-    end
-
     class MavenUrl
       def self.from_name(name, repo_base)
         new(*name.split(":", 2), repo_base)

--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -234,6 +234,10 @@ module PackageManager
       "Maven"
     end
 
+    def self.provider(provider)
+      PROVIDER_MAP[provider]
+    end
+
     class MavenUrl
       def self.from_name(name, repo_base)
         new(*name.split(":", 2), repo_base)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -170,7 +170,7 @@ class Project < ApplicationRecord
   end
 
   def async_sync
-    PackageManagerDownloadWorker.perform_async(platform_class, name)
+    PackageManagerDownloadWorker.perform_async(platform_class.name, name)
   end
 
   def recently_synced?

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -170,7 +170,7 @@ class Project < ApplicationRecord
   end
 
   def async_sync
-    PackageManagerDownloadWorker.perform_async(platform, name)
+    PackageManagerDownloadWorker.perform_async(platform_class, name)
   end
 
   def recently_synced?

--- a/app/workers/package_manager_download_worker.rb
+++ b/app/workers/package_manager_download_worker.rb
@@ -1,10 +1,15 @@
+# frozen_string_literal: true
+
 class PackageManagerDownloadWorker
   include Sidekiq::Worker
   sidekiq_options queue: :critical
 
-  def perform(class_name, name)
-    return unless class_name.present?
-    logger.info("Beginning update for #{class_name}/#{name}")
-    "PackageManager::#{class_name}".constantize.update(name)
+  def perform(clazz, name)
+    return unless clazz.present?
+
+    # need to maintain compatibility with things that pass in the name of the class under PackageManager module
+    clazz = "PackageManager::#{clazz}".constantize if clazz.is_a? String
+    logger.info("Beginning update for #{clazz.name}/#{name}")
+    clazz.update(name)
   end
 end

--- a/app/workers/package_manager_download_worker.rb
+++ b/app/workers/package_manager_download_worker.rb
@@ -4,12 +4,11 @@ class PackageManagerDownloadWorker
   include Sidekiq::Worker
   sidekiq_options queue: :critical
 
-  def perform(clazz, name)
-    return unless clazz.present?
+  def perform(class_name, name)
+    return unless class_name.present?
 
     # need to maintain compatibility with things that pass in the name of the class under PackageManager module
-    clazz = "PackageManager::#{clazz}".constantize if clazz.is_a? String
-    logger.info("Beginning update for #{clazz.name}/#{name}")
-    clazz.update(name)
+    logger.info("Beginning update for #{class_name}/#{name}")
+    class_name.constantize.update(name)
   end
 end

--- a/lib/tasks/download.rake
+++ b/lib/tasks/download.rake
@@ -178,9 +178,13 @@ namespace :download do
 
   desc "Download all Maven packages asynchronously"
   task :maven_all, [:provider] => :environment do |_task, args|
-    provider = args.provider.presence || "default"
-    provider_class = PackageManager::Maven.provider(provider)
-    provider_class.import_async
+    PackageManager::Maven::PROVIDER_MAP.values do |sub_class|
+      begin
+        sub_class.import_async
+      rescue StandardError
+        next
+      end
+    end
   end
 
   desc "Download all Meteor packages asynchronously"

--- a/lib/tasks/download.rake
+++ b/lib/tasks/download.rake
@@ -176,7 +176,7 @@ namespace :download do
   end
 
   desc "Download all Maven packages asynchronously"
-  task :maven_all, [:provider] => :environment do |_task, _args|
+  task maven_all: :environment do
     PackageManager::Maven::PROVIDER_MAP.values.each do |sub_class|
       sub_class.import_async
     rescue StandardError => e

--- a/lib/tasks/download.rake
+++ b/lib/tasks/download.rake
@@ -168,24 +168,20 @@ namespace :download do
   desc "Download recent Maven packages asynchronously"
   task maven: :environment do
     PackageManager::Maven::PROVIDER_MAP.values.each do |sub_class|
-      begin
-        sub_class.import_recent_async
-      rescue StandardError => e
-        puts e
-        next
-      end
+      sub_class.import_recent_async
+    rescue StandardError => e
+      puts e
+      next
     end
   end
 
   desc "Download all Maven packages asynchronously"
-  task :maven_all, [:provider] => :environment do |_task, args|
+  task :maven_all, [:provider] => :environment do |_task, _args|
     PackageManager::Maven::PROVIDER_MAP.values.each do |sub_class|
-      begin
-        sub_class.import_async
-      rescue StandardError => e
-        puts e
-        next
-      end
+      sub_class.import_async
+    rescue StandardError => e
+      puts e
+      next
     end
   end
 

--- a/lib/tasks/download.rake
+++ b/lib/tasks/download.rake
@@ -1,298 +1,302 @@
+# frozen_string_literal: true
+
 namespace :download do
-  desc 'Download undownloaded github repositories'
+  desc "Download undownloaded github repositories"
   task new_github_repos: :environment do
-    exit if ENV['READ_ONLY'].present?
-    Project.undownloaded_repos.order('created_at DESC').find_each(&:update_repository_async)
+    exit if ENV["READ_ONLY"].present?
+    Project.undownloaded_repos.order("created_at DESC").find_each(&:update_repository_async)
   end
 
-  desc 'Download small registries all packages'
-  task small_registries: [:emacs, :hackage, :sublime, :inqlude, :shards]
+  desc "Download small registries all packages"
+  task small_registries: %i[emacs hackage sublime inqlude shards]
 
-  desc 'Download Alcatraz packages asynchronously'
+  desc "Download Alcatraz packages asynchronously"
   task alcatraz: :environment do
     PackageManager::Alcatraz.import_async
   end
 
-  desc 'Download recent Atom packages asynchronously'
+  desc "Download recent Atom packages asynchronously"
   task atom: :environment do
     PackageManager::Atom.import_recent_async
   end
 
-  desc 'Download all Atom packages asynchronously'
+  desc "Download all Atom packages asynchronously"
   task atom_all: :environment do
     PackageManager::Atom.import_async
   end
 
-  desc 'Download new Bower packages asynchronously'
+  desc "Download new Bower packages asynchronously"
   task bower: :environment do
     PackageManager::Bower.import_new_async
   end
 
-  desc 'Download all Bower packages'
+  desc "Download all Bower packages"
   task bower_all: :environment do
     PackageManager::Bower.import
   end
 
-  desc 'Download recent Cargo packages asynchronously'
+  desc "Download recent Cargo packages asynchronously"
   task cargo: :environment do
     PackageManager::Cargo.import_recent_async
   end
 
-  desc 'Download all Carthage packages asynchronously'
+  desc "Download all Carthage packages asynchronously"
   task carthage: :environment do
     PackageManager::Carthage.import_async
   end
 
-  desc 'Download recent Clojars packages'
+  desc "Download recent Clojars packages"
   task clojars: :environment do
     PackageManager::Clojars.import_recent
   end
 
-  desc 'Download all Puppet packages asynchronously'
+  desc "Download all Puppet packages asynchronously"
   task puppet_all: :environment do
     PackageManager::Puppet.import_async
   end
 
-  desc 'Download recent CPAN packages asynchronously'
+  desc "Download recent CPAN packages asynchronously"
   task cpan: :environment do
     PackageManager::CPAN.import_recent_async
   end
 
-  desc 'Download all CPAN packages asynchronously'
+  desc "Download all CPAN packages asynchronously"
   task cpan_all: :environment do
     PackageManager::CPAN.import_async
   end
 
-  desc 'Download recent CocoaPods packages asynchronously'
+  desc "Download recent CocoaPods packages asynchronously"
   task cocoapods: :environment do
     PackageManager::CocoaPods.import_recent_async
   end
 
-  desc 'Download all CocoaPods packages asynchronously'
+  desc "Download all CocoaPods packages asynchronously"
   task cocoapods_all: :environment do
     PackageManager::CocoaPods.import_async
   end
 
-  desc 'Download all Conda packages asynchronously'
+  desc "Download all Conda packages asynchronously"
   task conda_all: :environment do
     PackageManager::Conda.import_async
   end
 
-  desc 'Download recent Conda packages asynchronously'
+  desc "Download recent Conda packages asynchronously"
   task conda: :environment do
     PackageManager::Conda.import_recent_async
   end
 
-  desc 'Download recent CRAN packages asynchronously'
+  desc "Download recent CRAN packages asynchronously"
   task cran: :environment do
     PackageManager::CRAN.import_recent_async
   end
 
-  desc 'Download all CRAN packages asynchronously'
+  desc "Download all CRAN packages asynchronously"
   task cran_all: :environment do
     PackageManager::CRAN.import_async
   end
 
-  desc 'Download all Dub packages asynchronously'
+  desc "Download all Dub packages asynchronously"
   task dub: :environment do
     PackageManager::Dub.import_async
   end
 
-  desc 'Download recent Elm packages asynchronously'
+  desc "Download recent Elm packages asynchronously"
   task elm: :environment do
     PackageManager::Elm.import_recent_async
   end
 
-  desc 'Download all Elm packages asynchronously'
+  desc "Download all Elm packages asynchronously"
   task elm_all: :environment do
     PackageManager::Elm.import_async
   end
 
-  desc 'Download all emacs packages asynchronously'
+  desc "Download all emacs packages asynchronously"
   task emacs: :environment do
     PackageManager::Emacs.import_async
   end
 
-  desc 'Download recent Hackage packages asynchronously'
+  desc "Download recent Hackage packages asynchronously"
   task hackage: :environment do
     PackageManager::Hackage.import_recent_async
   end
 
-  desc 'Download all Hackage packages asynchronously'
+  desc "Download all Hackage packages asynchronously"
   task hackage_all: :environment do
     PackageManager::Hackage.import_async
   end
 
-  desc 'Download recent Haxelib packages asynchronously'
+  desc "Download recent Haxelib packages asynchronously"
   task haxelib: :environment do
     PackageManager::Haxelib.import_recent_async
   end
 
-  desc 'Download all Haxelib packages asynchronously'
+  desc "Download all Haxelib packages asynchronously"
   task haxelib_all: :environment do
     PackageManager::Haxelib.import_async
   end
 
-  desc 'Download recent Hex packages asynchronously'
+  desc "Download recent Hex packages asynchronously"
   task hex: :environment do
     PackageManager::Hex.import_recent_async
   end
 
-  desc 'Download all Hex packages'
+  desc "Download all Hex packages"
   task hex_all: :environment do
     PackageManager::Hex.import
   end
 
-  desc 'Download recent Homebrew packages asynchronously'
+  desc "Download recent Homebrew packages asynchronously"
   task homebrew: :environment do
     PackageManager::Homebrew.import_recent_async
   end
 
-  desc 'Download all Homebrew packages asynchronously'
+  desc "Download all Homebrew packages asynchronously"
   task homebrew_all: :environment do
     PackageManager::Homebrew.import_async
   end
 
-  desc 'Download all Inqlude packages'
+  desc "Download all Inqlude packages"
   task inqlude: :environment do
     PackageManager::Inqlude.import
   end
 
-  desc 'Download all Julia packages asynchronously'
+  desc "Download all Julia packages asynchronously"
   task julia: :environment do
     PackageManager::Julia.import_async
   end
 
-  desc 'Download recent Maven packages asynchronously'
-  task maven: :environment do
-    PackageManager::Maven.load_names(50)
-    PackageManager::Maven.import_recent_async
+  desc "Download recent Maven packages asynchronously"
+  task :maven, [:provider] => :environment do |_task, args|
+    provider = args.provider.presence || "default"
+    provider_class = PackageManager::Maven.provider(provider)
+    provider_class.import_recent_async
   end
 
-  desc 'Download all Maven packages asynchronously'
-  task maven_all: :environment do
-    PackageManager::Maven.load_names
-    PackageManager::Maven.import_async
+  desc "Download all Maven packages asynchronously"
+  task :maven_all, [:provider] => :environment do |_task, args|
+    provider = args.provider.presence || "default"
+    provider_class = PackageManager::Maven.provider(provider)
+    provider_class.import_async
   end
 
-  desc 'Download all Meteor packages asynchronously'
+  desc "Download all Meteor packages asynchronously"
   task meteor: :environment do
     PackageManager::Meteor.import_async
   end
 
-  desc 'Download all Nimble packages asynchronously'
+  desc "Download all Nimble packages asynchronously"
   task nimble: :environment do
     PackageManager::Nimble.import_async
   end
 
-  desc 'Download recent NuGet packages asynchronously'
+  desc "Download recent NuGet packages asynchronously"
   task nuget: :environment do
     PackageManager::NuGet.load_names(3)
     PackageManager::NuGet.import_recent_async
   end
 
-  desc 'Download all NuGet packages asynchronously'
+  desc "Download all NuGet packages asynchronously"
   task nuget_all: :environment do
     PackageManager::NuGet.load_names
     PackageManager::NuGet.import_async
   end
 
-  desc 'Download recent NPM packages asynchronously'
+  desc "Download recent NPM packages asynchronously"
   task npm: :environment do
     PackageManager::NPM.import_recent_async
   end
 
-  desc 'Download all NPM packages'
+  desc "Download all NPM packages"
   task npm_all: :environment do
     PackageManager::NPM.import
   end
 
-  desc 'Download recent Packagist packages asynchronously'
+  desc "Download recent Packagist packages asynchronously"
   task packagist: :environment do
     PackageManager::Packagist.import_recent_async
   end
 
-  desc 'Download all Packagist packages asynchronously'
+  desc "Download all Packagist packages asynchronously"
   task packagist_all: :environment do
     PackageManager::Packagist.import_async
   end
 
-  desc 'Download packages asynchronously'
+  desc "Download packages asynchronously"
   task platformio: :environment do
     PackageManager::PlatformIO.import_async
   end
 
-  desc 'Download new PureScript packages asynchronously'
+  desc "Download new PureScript packages asynchronously"
   task purescript: :environment do
     PackageManager::PureScript.import_new_async
   end
 
-  desc 'Download all PureScript packages asynchronously'
+  desc "Download all PureScript packages asynchronously"
   task purescript_all: :environment do
     PackageManager::PureScript.import_async
   end
 
-  desc 'Download recent Pub packages asynchronously'
+  desc "Download recent Pub packages asynchronously"
   task pub: :environment do
     PackageManager::Pub.import_recent_async
   end
 
-  desc 'Download recent Pypi packages asynchronously'
+  desc "Download recent Pypi packages asynchronously"
   task pypi: :environment do
     PackageManager::Pypi.import_recent_async
   end
 
-  desc 'Download all Pypi packages asynchronously'
+  desc "Download all Pypi packages asynchronously"
   task pypi_all: :environment do
     PackageManager::Pypi.import_async
   end
 
-  desc 'Download recent Racket packages asynchronously'
+  desc "Download recent Racket packages asynchronously"
   task racket: :environment do
     PackageManager::Racket.import_async
   end
 
-  desc 'Download recent Rubygems packages asynchronously'
+  desc "Download recent Rubygems packages asynchronously"
   task rubygems: :environment do
     PackageManager::Rubygems.import_recent_async
   end
 
-  desc 'Download all Rubygems packages asynchronously'
+  desc "Download all Rubygems packages asynchronously"
   task rubygems_all: :environment do
     PackageManager::Rubygems.import_async
   end
 
-  desc 'Download all Shards packages asynchronously'
+  desc "Download all Shards packages asynchronously"
   task shards: :environment do
     PackageManager::Shards.import_async
   end
 
-  desc 'Download all SwiftPM packages'
+  desc "Download all SwiftPM packages"
   task swift: :environment do
     PackageManager::SwiftPM.import
   end
 
-  desc 'Download all Sublime packages asynchronously'
+  desc "Download all Sublime packages asynchronously"
   task sublime: :environment do
     PackageManager::Sublime.import_async
   end
 
-  desc 'Download recent Wordpress packages asynchronously'
+  desc "Download recent Wordpress packages asynchronously"
   task wordpress: :environment do
     PackageManager::Wordpress.import_recent_async
   end
 
-  desc 'Download all Wordpress packages asynchronously'
+  desc "Download all Wordpress packages asynchronously"
   task wordpress_all: :environment do
     PackageManager::Wordpress.import_async
   end
 
-  desc 'Download new Go packages asynchronously'
+  desc "Download new Go packages asynchronously"
   task go: :environment do
     PackageManager::Go.import_new_async
   end
 
-  desc 'Download all Go packages asynchronously'
+  desc "Download all Go packages asynchronously"
   task go_all: :environment do
     PackageManager::Go.import_async
   end

--- a/lib/tasks/download.rake
+++ b/lib/tasks/download.rake
@@ -166,10 +166,14 @@ namespace :download do
   end
 
   desc "Download recent Maven packages asynchronously"
-  task :maven, [:provider] => :environment do |_task, args|
-    provider = args.provider.presence || "default"
-    provider_class = PackageManager::Maven.provider(provider)
-    provider_class.import_recent_async
+  task maven: :environment do
+    PackageManager::Maven::PROVIDER_MAP.values do |sub_class|
+      begin
+        sub_class.import_recent_async
+      rescue StandardError
+        next
+      end
+    end
   end
 
   desc "Download all Maven packages asynchronously"

--- a/lib/tasks/download.rake
+++ b/lib/tasks/download.rake
@@ -167,10 +167,11 @@ namespace :download do
 
   desc "Download recent Maven packages asynchronously"
   task maven: :environment do
-    PackageManager::Maven::PROVIDER_MAP.values do |sub_class|
+    PackageManager::Maven::PROVIDER_MAP.values.each do |sub_class|
       begin
         sub_class.import_recent_async
-      rescue StandardError
+      rescue StandardError => e
+        puts e
         next
       end
     end
@@ -178,10 +179,11 @@ namespace :download do
 
   desc "Download all Maven packages asynchronously"
   task :maven_all, [:provider] => :environment do |_task, args|
-    PackageManager::Maven::PROVIDER_MAP.values do |sub_class|
+    PackageManager::Maven::PROVIDER_MAP.values.each do |sub_class|
       begin
         sub_class.import_async
-      rescue StandardError
+      rescue StandardError => e
+        puts e
         next
       end
     end

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -109,7 +109,7 @@ namespace :projects do
       if project
         project.async_sync if project.potentially_outdated? rescue nil
       else
-        PackageManagerDownloadWorker.perform_async(platform, name)
+        PackageManagerDownloadWorker.perform_async("PackageManager::#{platform}", name)
       end
     end
   end

--- a/spec/workers/package_manager_download_worker_spec.rb
+++ b/spec/workers/package_manager_download_worker_spec.rb
@@ -6,7 +6,7 @@ describe PackageManagerDownloadWorker do
   end
 
   it "should sync an org" do
-    class_name = 'Rubygems'
+    class_name = PackageManager::Rubygems.name
     name = 'rails'
     expect(PackageManager::Rubygems).to receive(:update).with(name)
     subject.perform(class_name, name)

--- a/spec/workers/package_manager_download_worker_spec.rb
+++ b/spec/workers/package_manager_download_worker_spec.rb
@@ -1,4 +1,6 @@
-require 'rails_helper'
+# frozen_string_literal: true
+
+require "rails_helper"
 
 describe PackageManagerDownloadWorker do
   it "should use the critical priority queue" do
@@ -7,7 +9,7 @@ describe PackageManagerDownloadWorker do
 
   it "should sync an org" do
     class_name = PackageManager::Rubygems.name
-    name = 'rails'
+    name = "rails"
     expect(PackageManager::Rubygems).to receive(:update).with(name)
     subject.perform(class_name, name)
   end


### PR DESCRIPTION
Adjust the `rake download:maven` tasks to take in an optional provider parameter to run the sync with.