### PR TITLE
Clean Up Maven Package Manager

### DIFF
--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -5,11 +5,9 @@ module PackageManager
     HAS_VERSIONS = true
     HAS_DEPENDENCIES = true
     HAS_MULTIPLE_REPO_SOURCES = true
-    REPOSITORY_SOURCE_NAME = "Maven"
     BIBLIOTHECARY_SUPPORT = true
     SECURITY_PLANNED = true
     URL = "http://maven.org"
-    BASE_URL = "https://maven-repository.com"
     COLOR = "#b07219"
     MAX_DEPTH = 5
     LICENSE_STRINGS = {
@@ -48,7 +46,7 @@ module PackageManager
     end
 
     def self.repository_base
-      "https://repo1.maven.org/maven2"
+      PROVIDER_MAP["default"].repository_base
     end
 
     def self.project_names
@@ -56,7 +54,7 @@ module PackageManager
     end
 
     def self.recent_names
-      get("https://maven.libraries.io/mavenCentral/recent")
+      PROVIDER_MAP["default"].recent_names
     end
 
     def self.project(name)
@@ -227,10 +225,6 @@ module PackageManager
       end
     end
 
-    def self.repository_source_name
-      "Maven"
-    end
-
     class MavenUrl
       def self.from_name(name, repo_base)
         new(*name.split(":", 2), repo_base)
@@ -258,6 +252,7 @@ module PackageManager
         "#{base}/#{version}/#{@artifact_id}-#{version}.pom"
       end
 
+      # this is very specific to Maven Central
       def search(version = nil)
         if version
           "http://search.maven.org/#artifactdetails%7C#{@group_id}%7C#{@artifact_id}%7C#{version}%7Cjar"

--- a/app/models/package_manager/maven/maven_central.rb
+++ b/app/models/package_manager/maven/maven_central.rb
@@ -2,6 +2,21 @@
 
 class PackageManager::Maven::MavenCentral < PackageManager::Maven
   REPOSITORY_SOURCE_NAME = "Maven"
+  HIDDEN = true
+
+  def self.repository_base
+    "https://repo1.maven.org/maven2"
+  end
+
+  def self.recent_names
+    get("https://maven.libraries.io/mavenCentral/recent")
+  end
+
+  def self.versions(_project, name)
+    xml_metadata = get_raw(MavenUrl.from_name(name, repository_base).maven_metadata)
+    xml_versions = Nokogiri::XML(xml_metadata).css("version").map(&:text)
+    retrieve_versions(xml_versions.filter { |item| !item.ends_with?("-SNAPSHOT") }, name)
+  end
 
   def self.package_link(project, version = nil)
     MavenUrl.from_name(project.name, repository_base).search(version)
@@ -23,7 +38,11 @@ class PackageManager::Maven::MavenCentral < PackageManager::Maven
     PackageManager::Maven.formatted_name
   end
 
-  def self.name
-    PackageManager::Maven.name
+  def self.db_platform
+    "Maven"
+  end
+
+  def self.repository_source_name
+    "Maven"
   end
 end

--- a/app/models/package_manager/maven/maven_central.rb
+++ b/app/models/package_manager/maven/maven_central.rb
@@ -41,8 +41,4 @@ class PackageManager::Maven::MavenCentral < PackageManager::Maven
   def self.db_platform
     "Maven"
   end
-
-  def self.repository_source_name
-    "Maven"
-  end
 end

--- a/app/models/package_manager/maven/spring_libs.rb
+++ b/app/models/package_manager/maven/spring_libs.rb
@@ -2,6 +2,7 @@
 
 class PackageManager::Maven::SpringLibs < PackageManager::Maven
   REPOSITORY_SOURCE_NAME = "SpringLibs"
+  HIDDEN = true
 
   def self.repository_base
     "https://repo.spring.io/libs-release-local"
@@ -47,11 +48,7 @@ class PackageManager::Maven::SpringLibs < PackageManager::Maven
     retrieve_versions(found_versions.filter { |item| !item.ends_with?("-SNAPSHOT") }, name)
   end
 
-  def self.formatted_name
-    PackageManager::Maven.formatted_name
-  end
-
-  def self.name
-    PackageManager::Maven.name
+  def self.db_platform
+    "Maven"
   end
 end


### PR DESCRIPTION
This tries to remove some properties set in the Maven package manager and defer to the MavenCentral provider. This also changes some logic in the Base package manager to not use `self.name.demodulize` when looking/saving the platform on `Project` and instead use a new property called `db_platform` that defaults to `self.name.demodulize` but is overridden in the Maven provider classes so it all still works.