### PR TITLE
change default repository_source_name in Maven

### DIFF
--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -5,6 +5,7 @@ module PackageManager
     HAS_VERSIONS = true
     HAS_DEPENDENCIES = true
     HAS_MULTIPLE_REPO_SOURCES = true
+    REPOSITORY_SOURCE_NAME = "Maven"
     BIBLIOTHECARY_SUPPORT = true
     SECURITY_PLANNED = true
     URL = "http://maven.org"
@@ -224,10 +225,6 @@ module PackageManager
           &.max_by(&:published_at)
           &.number
       end
-    end
-
-    def self.repository_source_name
-      "Maven"
     end
 
     def self.db_platform


### PR DESCRIPTION
This temporarily fixes the project sync button for Maven projects. This still needs to be fixed to allow Maven to pick the right provider to use for those projects.