### PR TITLE
Project Sync with Multiple Providers

### DIFF
--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -24,13 +24,13 @@ module PackageManager
       "SpringLibs" => SpringLibs,
     }.freeze
 
-    def providers(project)
+    def self.providers(project)
       project
         .versions
-        .flat_map(repository_sources)
+        .flat_map(&:repository_sources)
         .compact
         .uniq
-        .map{ |source| PROVIDER_MAP[repository_source] } || [PROVIDER_MAP["default"]]
+        .map { |source| PROVIDER_MAP[source] } || [PROVIDER_MAP["default"]]
     end
 
     def self.package_link(project, version = nil)

--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -24,13 +24,13 @@ module PackageManager
       "SpringLibs" => SpringLibs,
     }.freeze
 
-    def provider(project)
-      repository_source = project.versions
+    def providers(project)
+      project
+        .versions
         .flat_map(repository_sources)
         .compact
-        .first || "default"
-
-      PROVIDER_MAP[repository_source]
+        .uniq
+        .map{ |source| PROVIDER_MAP[repository_source] } || [PROVIDER_MAP["default"]]
     end
 
     def self.package_link(project, version = nil)

--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -24,6 +24,15 @@ module PackageManager
       "SpringLibs" => SpringLibs,
     }.freeze
 
+    def provider(project)
+      repository_source = project.versions
+        .flat_map(repository_sources)
+        .compact
+        .first || "default"
+
+      PROVIDER_MAP[repository_source]
+    end
+
     def self.package_link(project, version = nil)
       db_version = project.versions.find_by(number: version)
       repository_source = db_version&.repository_sources&.first.presence || "default"

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -174,7 +174,7 @@ class Project < ApplicationRecord
   end
 
   def sync_classes
-    return platform_class.providers(self) if platform_class::HAS_MULTIPLE_REPOS
+    return platform_class.providers(self) if platform_class::HAS_MULTIPLE_REPO_SOURCES
 
     [platform_class]
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -159,7 +159,7 @@ class Project < ApplicationRecord
       return
     end
 
-    result = sync_class.update(name)
+    result = sync_classes.each{ |sync_class| sync_class.update(name)}
     set_last_synced_at unless result
   rescue StandardError
     set_last_synced_at
@@ -170,13 +170,13 @@ class Project < ApplicationRecord
   end
 
   def async_sync
-    PackageManagerDownloadWorker.perform_async(sync_class.name, name)
+    sync_classes.each{ |sync_class| PackageManagerDownloadWorker.perform_async(sync_class.name, name) }
   end
 
-  def sync_class
-    return platform_class.provider(self) if platform_class::HAS_MULTIPLE_REPOS
+  def sync_classes
+    return platform_class.providers(self) if platform_class::HAS_MULTIPLE_REPOS
 
-    platform_class
+    [platform_class]
   end
 
   def recently_synced?

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -159,9 +159,9 @@ class Project < ApplicationRecord
       return
     end
 
-    result = platform_class.update(name)
+    result = sync_class.update(name)
     set_last_synced_at unless result
-  rescue
+  rescue StandardError
     set_last_synced_at
   end
 
@@ -170,7 +170,13 @@ class Project < ApplicationRecord
   end
 
   def async_sync
-    PackageManagerDownloadWorker.perform_async(platform_class.name, name)
+    PackageManagerDownloadWorker.perform_async(sync_class.name, name)
+  end
+
+  def sync_class
+    return platform_class.provider(self) if platform_class::HAS_MULTIPLE_REPOS
+
+    platform_class
   end
 
   def recently_synced?


### PR DESCRIPTION
Right now the resync button is broken for any project that doesn't use the default Maven Central provider. This PR would run the sync through all provider classes that this project has in it's Versions.