### PR TITLE
Fix Type Issues in Go.update()

### DIFF
--- a/spec/models/package_manager/go_spec.rb
+++ b/spec/models/package_manager/go_spec.rb
@@ -121,7 +121,7 @@ describe PackageManager::Go do
 
         expect(project.versions.count).to eql 39
         expect(project.versions.where("number like ?", "v1%").count).to be > 0
-        expect(project.versions.find_by(number: "v1.3.0").published_at).to eql publish_date
+        expect(project.versions.find_by(number: "v1.3.0").published_at.to_date).to eql publish_date.to_date
       end
     end
   end

--- a/spec/models/package_manager/go_spec.rb
+++ b/spec/models/package_manager/go_spec.rb
@@ -110,6 +110,20 @@ describe PackageManager::Go do
         expect(non_versioned_module.versions.where("number like ?", "v2%").count).to eql 8
       end
     end
+
+    it "should use known versions" do
+      project = create(:project, platform: "Go", name: "github.com/urfave/cli")
+      publish_date = Time.now
+      project.versions.create(number: "v1.3.0", published_at: publish_date)
+
+      VCR.use_cassette("pkg_go_dev") do
+        described_class.update("github.com/urfave/cli")
+
+        expect(project.versions.count).to eql 39
+        expect(project.versions.where("number like ?", "v1%").count).to be > 0
+        expect(project.versions.find_by(number: "v1.3.0").published_at).to eql publish_date
+      end
+    end
   end
 
   describe ".project_find_names(name)" do


### PR DESCRIPTION
This is very broken. I thought the tests had covered it, but without an existing database version none of the bad code was hit. Fixed the type and return issues and added a spec that now hits that code.