### PR TITLE
Update Go Versioned with Base Modules

### DIFF
--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -188,7 +188,7 @@ namespace :projects do
     Project.where(platform: "Go").where("name like ?", "%/v#{args[:version]}").find_in_batches do |projects|
       projects.each do |project|
         matches = PackageManager::Go::VERSION_MODULE_REGEX.match(project.name)
-        Project.create(platform: "Go", name: matches[1])
+        Project.find_or_create_by(platform: "Go", name: matches[1])
         PackageManagerDownloadWorker.perform_async("PackageManager::Go", project.name)
         puts "Queued #{project.name} for update"
       end


### PR DESCRIPTION
This task would go through and start updates for Go modules that have a `/vx` on the end of the name. The intention is to get the base module project in place if it doesn't exist and then run the update on the versioned module to get versions added correctly to both projects.