### PR TITLE
Maven: skip versions that have missing poms, rather than raising err.

### DIFF
--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -164,19 +164,23 @@ module PackageManager
     end
 
     def self.retrieve_versions(versions, name)
-      versions.map do |version|
-        begin
+      versions
+        .map do |version|
           pom = get_pom(*name.split(":", 2), version)
-          license_list = licenses(pom)
-        rescue StandardError
-          license_list = nil
+          begin
+            license_list = licenses(pom)
+          rescue StandardError
+            license_list = nil
+          end
+          {
+            number: version,
+            published_at: Time.parse(pom.locate("publishedAt").first.text),
+            original_license: license_list,
+          }
+        rescue Ox::Error
+          next
         end
-        {
-          number: version,
-          published_at: Time.parse(pom.locate("publishedAt").first.text),
-          original_license: license_list,
-        }
-      end
+        .compact
     end
 
     def self.download_pom(group_id, artifact_id, version)

--- a/spec/models/package_manager/maven_spec.rb
+++ b/spec/models/package_manager/maven_spec.rb
@@ -128,7 +128,10 @@ describe PackageManager::Maven do
 
       expect(described_class.project("javax.faces:javax.faces-api")).to eq(expected)
     end
+  end
 
+
+  describe ".versions" do
     it "skips versions that can't be parsed" do
       expect(described_class)
         .to receive(:get_raw)

--- a/spec/models/package_manager/maven_spec.rb
+++ b/spec/models/package_manager/maven_spec.rb
@@ -128,6 +128,29 @@ describe PackageManager::Maven do
 
       expect(described_class.project("javax.faces:javax.faces-api")).to eq(expected)
     end
+
+    it "skips versions that can't be parsed" do
+      expect(described_class)
+        .to receive(:get_raw)
+          .with("https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/maven-metadata.xml")
+          .and_return(File.open("spec/fixtures/proto-google-common-protos-0.1.9.pom").read)
+      allow(described_class)
+        .to receive(:get_pom)
+          .with("com.google.api.grpc", "proto-google-common-protos", "0.1.9")
+          .and_raise(Ox::ParseError.new(""))
+
+      # TODO: these are probably bugs... it's using the version 3.2.0/etc of a depdendency and looking that up on itself
+      allow(described_class)
+        .to receive(:get_pom)
+          .with("com.google.api.grpc", "proto-google-common-protos", "3.2.0")
+          .and_raise(Ox::ParseError.new(""))
+      allow(described_class)
+        .to receive(:get_pom)
+          .with("com.google.api.grpc", "proto-google-common-protos", "${api.version}")
+          .and_raise(Ox::ParseError.new(""))
+
+      expect(described_class.versions(nil, "com.google.api.grpc:proto-google-common-protos")).to eq([])
+    end
   end
 
   describe "mapping_from_pom_xml" do


### PR DESCRIPTION
When parsing versions of a Maven project, we may come across a version with a missing pom (or in the case below, a missing parent pom). 

Currently `retrieve_versions` will blow up if any versions are missing, so instead of blowing up and not updating *any* versions, let's update the versions that work still and ignore the broken version.

As precedent, we're [skipping bad versions](https://github.com/librariesio/libraries.io/blob/master/app/models/package_manager/go.rb#L110-L111) in Go currently too.

### Example:

#### Working
Pom: https://repo1.maven.org/maven2/org/opencastproject/opencast-common/8.5/opencast-common-8.5.pom
Parent pom: https://repo1.maven.org/maven2/org/opencastproject/base/8.5/base-8.5.pom

#### Broken
Pom: https://repo1.maven.org/maven2/org/opencastproject/opencast-common/7.7/opencast-common-7.7.pom
Missing parent pom: https://repo1.maven.org/maven2/org/opencastproject/base/7.7/base-7.7.pom

This results in Opencast's versions not getting updated to the latest (8.9):

![Screen Shot 2020-12-09 at 2 51 00 PM](https://user-images.githubusercontent.com/5054/101679983-0ca55300-3a2e-11eb-9def-666776f05659.png)
