### PR TITLE
Fix VersionsMailer nil email bug

### DIFF
--- a/app/mailers/versions_mailer.rb
+++ b/app/mailers/versions_mailer.rb
@@ -5,7 +5,7 @@ class VersionsMailer < ApplicationMailer
     @project = project
     @repos = @project.subscribed_repos(@user)
 
-    return if user.email.empty?
+    return if user.email.blank?
 
     mail to: user.email, subject: "New release of #{@project} (#{version.number}) on #{@project.platform_name}"
   end


### PR DESCRIPTION
Quick fix for a job failure that shows up a lot for `VersionsMailer#new_version ` jobs:

`"undefined method `empty?' for nil:NilClass"`
