### PR TITLE
Kick off CheckStatusWorker in Project#async_sync.

### DIFF
--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -218,7 +218,7 @@ describe Project, type: :model do
   end
 
   describe "#async_sync" do
-    let!(:project) { Project.create(platform: 'NPM', name: 'jade',) }
+    let!(:project) { Project.create(platform: 'NPM', name: 'jade') }
 
     it "should kick off package manager download jobs" do
       expect { project.async_sync }.to change { PackageManagerDownloadWorker.jobs.size }.by(1)

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -217,6 +217,18 @@ describe Project, type: :model do
     end
   end
 
+  describe "#async_sync" do
+    let!(:project) { Project.create(platform: 'NPM', name: 'jade',) }
+
+    it "should kick off package manager download jobs" do
+      expect { project.async_sync }.to change { PackageManagerDownloadWorker.jobs.size }.by(1)
+    end
+
+    it "should kick off status check job" do
+      expect { project.async_sync }.to change { CheckStatusWorker.jobs.size }.by(1)
+    end
+  end
+
   describe '#check_status' do
     context 'entire project deprecated with message' do
       let!(:project) { Project.create(platform: 'NPM', name: 'jade', status: '') }


### PR DESCRIPTION
* removes the `Project#sync` method because I don't think it's called from anywhere
* instead of checking deprecation/removal status via ^, we can check it by kicking off `CheckStatusWorker` when an async sync happens on the project

NB There **are** currently deprecated and removed projects in the database, but I think that's because Projects **sometimes** get marked as such by their parent repository [here](https://github.com/librariesio/libraries.io/blob/41159948ff612c0813f909b73a4bda697bb92e7f/app/models/repository.rb#L272-L287). In NPM's case, deprecation happens via the NPM CLI, so we'd never get triggered to update the Repository's status. This should update it more often on Projects.

