### PR TITLE
Add fallbacks for error endpoints and backfill a missing template.

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -4,6 +4,7 @@ class ErrorsController < ApplicationController
       format.html { render status: :not_found }
       format.atom { render xml: "not found", root: "error", status: :not_found }
       format.json { render json: { error: "not found" }, status: :not_found }
+      format.any { head :not_found }
     end
   end
 
@@ -12,6 +13,7 @@ class ErrorsController < ApplicationController
       format.html { render status: :unprocessable_entity }
       format.atom { render xml: "unprocessable", root: "error", status: :unprocessable_entity }
       format.json { render json: { error: "unprocessable" }, status: :unprocessable_entity }
+      format.any { head :unprocessable_entity }
     end
   end
 
@@ -20,6 +22,7 @@ class ErrorsController < ApplicationController
       format.html { render status: :not_acceptable }
       format.atom { render xml: "not_acceptable", root: "error", status: :not_acceptable }
       format.json { render json: { error: "not_acceptable" }, status: :not_acceptable }
+      format.any { head :not_acceptable }
     end
   end
 
@@ -28,6 +31,7 @@ class ErrorsController < ApplicationController
       format.html { render status: :internal_server_error }
       format.atom { render xml: "internal server error", root: "error", status: :internal_server_error }
       format.json { render json: { error: "internal server error" }, status: :internal_server_error }
+      format.any { head :internal_server_error }
     end
   end
 end

--- a/app/views/errors/not_acceptable.html.erb
+++ b/app/views/errors/not_acceptable.html.erb
@@ -1,0 +1,12 @@
+<div class="row">
+  <div class="col-sm-8">
+    <h2>Nope. Couldn't understand a word of that.</h2>
+    <p>Whatever you were trying to say, is lost on us.  Might be worth trying again!</p>
+    <p>
+      Email us at <%= mail_to 'support@libraries.io', 'support@libraries.io' %> if this is ruining your day.
+    </p>
+  </div>
+  <div class="col-sm-4">
+
+  </div>
+</div>


### PR DESCRIPTION
Noticed a lot of noise in the container logs for the ErrorsController endpoints:

```
 2020-12-10 16:26:16.558 EST Error during failsafe response: ActionController::UnknownFormat
2020-12-10 16:26:16.558 EST /libraries.io/app/controllers/errors_controller.rb:3:in `not_found'
2020-12-10 16:26:16.558 EST /usr/local/bundle/gems/actionpack-5.2.4.4/lib/abstract_controller/base.rb:194:in `process_action'
2020-12-10 16:26:16.558 EST /usr/local/bundle/gems/marginalia-1.8.0/lib/marginalia.rb:111:in `record_query_comment' 
...
```

This should at least quiet it in the logs. 