### PR TITLE
Fix broken asset urls.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,21 +9,21 @@
   <meta name="description" content="<%= content_for?(:description) ? content_for(:description) : "Discover open source packages, modules and frameworks you can use in your code." %>">
   <%= csrf_meta_tags %>
   <%= content_for :atom %>
-  <link rel="apple-touch-icon-precomposed" sizes="57x57" href="/apple-touch-icon-57x57.png" />
-  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="/apple-touch-icon-114x114.png" />
-  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="/apple-touch-icon-72x72.png" />
-  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/apple-touch-icon-144x144.png" />
-  <link rel="apple-touch-icon-precomposed" sizes="60x60" href="/apple-touch-icon-60x60.png" />
-  <link rel="apple-touch-icon-precomposed" sizes="120x120" href="/apple-touch-icon-120x120.png" />
-  <link rel="apple-touch-icon-precomposed" sizes="76x76" href="/apple-touch-icon-76x76.png" />
-  <link rel="apple-touch-icon-precomposed" sizes="152x152" href="/apple-touch-icon-152x152.png" />
+  <link rel="apple-touch-icon-precomposed" sizes="57x57" href="<%= asset_url "apple-touch-icon-57x57.png" %>" />
+  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="<%= asset_url "apple-touch-icon-114x114.png" %>" />
+  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="<%= asset_url "apple-touch-icon-72x72.png" %>" />
+  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="<%= asset_url "apple-touch-icon-144x144.png" %>" />
+  <link rel="apple-touch-icon-precomposed" sizes="60x60" href="<%= asset_url "apple-touch-icon-60x60.png" %>" />
+  <link rel="apple-touch-icon-precomposed" sizes="120x120" href="<%= asset_url "apple-touch-icon-120x120.png" %>" />
+  <link rel="apple-touch-icon-precomposed" sizes="76x76" href="<%= asset_url "apple-touch-icon-76x76.png" %>" />
+  <link rel="apple-touch-icon-precomposed" sizes="152x152" href="<%= asset_url "apple-touch-icon-152x152.png" %>" />
   <meta name="application-name" content="&nbsp;"/>
   <meta name="msapplication-TileColor" content="#FFFFFF" />
-  <meta name="msapplication-TileImage" content="/mstile-144x144.png" />
-  <meta name="msapplication-square70x70logo" content="/mstile-70x70.png" />
-  <meta name="msapplication-square150x150logo" content="/mstile-150x150.png" />
-  <meta name="msapplication-wide310x150logo" content="/mstile-310x150.png" />
-  <meta name="msapplication-square310x310logo" content="/mstile-310x310.png" />
+  <meta name="msapplication-TileImage" content="<%= asset_url "mstile-144x144.png" %>" />
+  <meta name="msapplication-square70x70logo" content="<%= asset_url "mstile-70x70.png" %>" />
+  <meta name="msapplication-square150x150logo" content="<%= asset_url "mstile-150x150.png" %>" />
+  <meta name="msapplication-wide310x150logo" content="<%= asset_url "mstile-310x150.png" %>" />
+  <meta name="msapplication-square310x310logo" content="<%= asset_url "mstile-310x310.png" %>" />
   <meta property="fb:admins" content="508462908" />
   <meta name="yandex-verification" content="2a6b144b8bd37026" />
   <%= content_for(:meta).presence || render_meta %>
@@ -68,7 +68,7 @@
       "name": "Libraries.io",
       "description": "Discover open source packages, modules and frameworks you can use in your code",
       "url": "https://libraries.io/",
-      "logo": "https://libraries.io/apple-touch-icon-152x152.png",
+      "logo": "<%= asset_url "apple-touch-icon-152x152.png" %>",
       "email": "support@libraries.io",
       "sameAs": [
         "https://twitter.com/librariesio",


### PR DESCRIPTION
More stuff I've noticed in the logs. These are in the asset pipeline so they need to be linked via `asset_url` so they get the proper hash at the end and the `/assets` prefix.
