### PR TITLE
Only consider package deprecated if the last version is deprecated.

### DIFF
--- a/app/models/package_manager/npm.rb
+++ b/app/models/package_manager/npm.rb
@@ -40,11 +40,11 @@ module PackageManager
     end
 
     def self.deprecation_info(name)
-      versions = project(name)["versions"].values
+      last_version = project(name)["versions"].values.last
 
       {
-        is_deprecated: versions.all? { |v| v["deprecated"] },
-        message: versions.last["deprecated"],
+        is_deprecated: !!last_version["deprecated"],
+        message: last_version["deprecated"],
       }
     end
 

--- a/spec/models/package_manager/npm_spec.rb
+++ b/spec/models/package_manager/npm_spec.rb
@@ -32,4 +32,30 @@ describe PackageManager::NPM do
       expect(described_class.install_instructions(project, '2.0.0')).to eq("npm install foo@2.0.0")
     end
   end
+
+  describe '#deprecation_info' do
+    it "returns not-deprecated if last version isn't deprecated" do
+      expect(PackageManager::NPM).to receive(:project).with('foo').and_return({
+        "versions" => {
+            "0.0.1" => {},
+            "0.0.2" => {"deprecated" => "This package is deprecated"},
+            "0.0.3" => {}
+        }
+      })
+
+      expect(described_class.deprecation_info('foo')).to eq({is_deprecated: false, message: nil})
+    end
+
+    it "returns deprecated if last version is deprecated" do
+      expect(PackageManager::NPM).to receive(:project).with('foo').and_return({
+        "versions" => {
+            "0.0.1" => {},
+            "0.0.2" => {"deprecated" => "This package is deprecated"},
+            "0.0.3" => {"deprecated" => "This package is deprecated"}
+        }
+      })
+
+      expect(described_class.deprecation_info('foo')).to eq({is_deprecated: true, message: "This package is deprecated"})
+    end
+  end
 end


### PR DESCRIPTION
This maps to NPM's logic, where the latest version is displayed for the package landing page, and the deprecation message shows up at the top if that version is deprecated.

For example, buildmail:

* https://www.npmjs.com/package/buildmail <-- deprecated, bc it's really 4.0.1
* https://www.npmjs.com/package/buildmail/v/4.0.1 <-- deprecated
* https://www.npmjs.com/package/buildmail/v/3.0.0-beta.0. <-- not deprecated
