### PR TITLE
Optimize status check endpoint

### DIFF
--- a/app/controllers/api/status_controller.rb
+++ b/app/controllers/api/status_controller.rb
@@ -1,7 +1,17 @@
+# frozen_string_literal: true
+
 class Api::StatusController < Api::BulkProjectController
   before_action :require_api_key
 
   def check
+    if params[:v2] == "true"
+      check_new
+    else
+      check_legacy
+    end
+  end
+
+  def check_legacy
     render(
       json: projects,
       each_serializer: ProjectStatusSerializer,
@@ -10,5 +20,12 @@ class Api::StatusController < Api::BulkProjectController
       show_updated_at: internal_api_key?,
       project_names: project_names
     )
+  end
+
+  def check_new
+    # This forces serialization with Oj
+    # TODO: Investigate calling Oj.mimic_JSON on initializationh to swap universally
+    serializer = OptimizedProjectSerializer.new(projects, project_names, internal_api_key?)
+    render json: Oj.dump(serializer.serialize)
   end
 end

--- a/app/serializers/optimized_project_serializer.rb
+++ b/app/serializers/optimized_project_serializer.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+# Note: This is _not_ an active model serializer. To use, instantiate and
+# call #serialize
+class OptimizedProjectSerializer
+  PROJECT_ATTRIBUTES = %w[
+    dependent_repos_count
+    dependents_count
+    deprecation_reason
+    description
+    forks
+    homepage
+    keywords
+    language
+    latest_download_url
+    latest_download_url
+    latest_release_number
+    latest_release_published_at
+    latest_stable_release_number
+    latest_stable_release_published_at
+    license_normalized
+    license_set_by_admin
+    licenses
+    normalized_licenses
+    package_manager_url
+    platform
+    rank
+    repository_url
+    score
+    stars
+    status
+  ].freeze
+
+  VERSION_ATTRIBUTES = %w[
+    number
+    published_at
+    spdx_expression
+    original_license
+    researched_at
+    repository_sources
+  ].freeze
+
+  MAINTENANCE_STAT_ATTRIBUTES = %w[
+    category
+    value
+    updated_at
+  ].freeze
+
+  def initialize(projects, requested_name_map, internal_key = false)
+    @projects = projects
+    @requested_name_map = requested_name_map
+    @internal_key = internal_key
+  end
+
+  def serialize
+    Google::Cloud::Trace.in_span "optimized_project_serializer#serialize" do |_span|
+      @projects.map do |project|
+        serialize_project(project)
+      end
+    end
+  end
+
+  def serialize_project(project)
+    Google::Cloud::Trace.in_span "optimized_project_serializer#serialize_project" do |_span|
+      project
+        .attributes
+        .slice(*PROJECT_ATTRIBUTES)
+        .merge!(
+          canonical_name: project.name,
+          name: @requested_name_map[[project.platform, project.name]],
+          repository_license: project.repository&.license,
+          versions: versions(project)
+        ).tap do |result|
+          if @internal_key
+            result[:updated_at] = project.updated_at
+            result[:repository_maintenance_stats] = maintenance_stats(project)
+          end
+        end
+    end
+  end
+
+  def versions(project)
+    Google::Cloud::Trace.in_span "optimized_project_serializer#versions" do |_span|
+      project.versions.map do |version|
+        version.slice(*VERSION_ATTRIBUTES)
+      end
+    end
+  end
+
+  def maintenance_stats(project)
+    Google::Cloud::Trace.in_span "optimized_project_serializer#maintenance_stats" do |_span|
+      project.repository_maintenance_stats.map do |stat|
+        stat.slice(*MAINTENANCE_STAT_ATTRIBUTES)
+      end
+    end
+  end
+end

--- a/config/initializers/active_model_serializers.rb
+++ b/config/initializers/active_model_serializers.rb
@@ -2,17 +2,15 @@
 
 module ASMTrace
   def serializable_hash(*)
-    if Rails.env.production?
-      Google::Cloud::Trace.in_span "active_model_serializers#serializable_hash##{self.class.name}" do |_span|
-        super
-      end
-    elsif ENV["ASM_TRACING"]
+    if ENV["ASM_TRACING"]
       result = nil
       b = Benchmark.measure { result = super }
       puts "active_model_serializers#serializable_hash##{self.class.name}: #{b.real}ms"
       result
     else
-      super
+      Google::Cloud::Trace.in_span "active_model_serializers#serializable_hash##{self.class.name}" do |_span|
+        super
+      end
     end
   end
 end

--- a/config/initializers/google_cloud_trace.rb
+++ b/config/initializers/google_cloud_trace.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Fake google cloud trace in_span method so we don't have to check our environment
+# where we use it
+unless Rails.env.production?
+  module Google
+    module Cloud
+      class Trace
+        def self.in_span(_span_name)
+          yield
+        end
+      end
+    end
+  end
+end

--- a/lib/query_counter.rb
+++ b/lib/query_counter.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Count queries in the block provided. Usage:
+# count = QueryCounter.count do
+#   # Your code here
+# end
+# puts count
+class QueryCounter
+  attr_reader :count
+
+  def self.count(&block)
+    new.tap do |counter|
+      ActiveSupport::Notifications.subscribed(counter.to_proc, "sql.active_record", &block)
+    end.count
+  end
+
+  def initialize
+    @count = 0
+  end
+
+  def to_proc
+    lambda(&method(:callback))
+  end
+
+  def callback(_, _, _, _, values)
+    return if %w[CACHE SCHEMA].include?(values[:name])
+
+    @count += 1
+  end
+end

--- a/spec/requests/api/status_spec.rb
+++ b/spec/requests/api/status_spec.rb
@@ -1,185 +1,218 @@
+# frozen_string_literal: true
+
 require "rails_helper"
+require "query_counter"
 
 describe "API::StatusController" do
-  let(:internal_user) { create(:user) }
-  let(:normal_user) { create(:user) }
-  let!(:repository) { create(:repository) }
-  let!(:maintenance_stat) { create(:repository_maintenance_stat, repository: repository)}
-  let!(:project) { create(:project, repository: repository) }
-  let!(:project_django) { create(:project, name: 'Django', platform: 'Pypi') }
+  ["/api/check", "/api/check?v2"].each do |url|
+    let(:internal_user) { create(:user) }
+    let(:normal_user) { create(:user) }
+    let!(:repository) { create(:repository) }
+    let!(:maintenance_stat) { create(:repository_maintenance_stat, repository: repository) }
+    let!(:project) { create(:project, repository: repository) }
+    let!(:project_django) { create(:project, name: "Django", platform: "Pypi") }
 
-  before do
-    internal_user.current_api_key.update_attribute(:is_internal, true)
-  end
-
-  describe "GET /api/check", type: :request do
-    it "renders successfully with one" do
-      post "/api/check", params: {api_key: internal_user.api_key, projects: [{name: project.name, platform: project.platform}] }
-      expect(response).to have_http_status(:success)
-      expect(response.content_type).to eq('application/json')
-      expect(response.body.include?(project.name)).to be == true
-
-      # check for maintenance stats being returned
-      json_response = JSON.parse(response.body)
-      maintenance_stats = json_response.first["repository_maintenance_stats"]
-      expect(maintenance_stats.length).to be 1
-      expect(maintenance_stats.first["category"]).to eql maintenance_stat.category
-      expect(maintenance_stats.first["value"]).to eql maintenance_stat.value
-
-      # and updated_at
-      updated_at = json_response.first["updated_at"]
-      expect(updated_at).not_to be(nil)
+    before do
+      internal_user.current_api_key.update_attribute(:is_internal, true)
     end
 
-    it "renders empty json list if cannot find Project" do
-      post "/api/check", params: {api_key: internal_user.api_key, projects: [{name: 'rails', platform: 'rubygems'}] }
-      expect(response).to have_http_status(:success)
-      expect(response.content_type).to eq('application/json')
-      expect(response.body).to be_json_eql []
-    end
-
-    it "renders successfully" do
-      post "/api/check", params: {api_key: internal_user.api_key, projects: [{name: project.name, platform: 'rubygems'}, {name: 'django', platform: 'Pypi'}] }
-      expect(response).to have_http_status(:success)
-      expect(response.content_type).to eq('application/json')
-      expect(response.body.include?(project.name)).to be == true
-      expect(response.body.include?('Django')).to be == true
-    end
-
-    it "renders empty maintenance stats if they don't exist" do
-      post "/api/check", params: {api_key: internal_user.api_key, projects: [{name: project_django.name, platform: project_django.platform}] }
-      expect(response).to have_http_status(:success)
-      expect(response.content_type).to eq('application/json')
-      expect(response.body.include?(project_django.name)).to be == true
-
-      json_response = JSON.parse(response.body)
-      expect(json_response.first["repository_maintenance_stats"].length).to be 0
-    end
-
-    it "contains all expected fields" do
-      # all the fields we expect to come back in the response for a project
-      expected_fields = %w[
-        canonical_name
-        dependent_repos_count
-        dependents_count
-        description
-        forks
-        homepage
-        keywords
-        language
-        latest_download_url
-        latest_release_number
-        latest_release_published_at
-        latest_stable_release_number
-        latest_stable_release_published_at
-        name
-        normalized_licenses
-        package_manager_url
-        platform
-        rank
-        repository_maintenance_stats
-        repository_url
-        score
-        stars
-        status
-        versions
-      ]
-
-      post(
-        "/api/check",
-        params: {
-          api_key: internal_user.api_key,
-          projects: [{ name: project_django.name, platform: project_django.platform }],
-          score: true
-        }
-      )
-      expect(response).to have_http_status(:success)
-      expect(response.content_type).to eq("application/json")
-
-      project = JSON.parse(response.body).first
-      expected_fields.each do |field|
-        expect(project).to have_key(field)
-      end
-    end
-
-    it "correctly serves the original name" do
-      requested_name = project_django.name.downcase
-
-      post(
-        "/api/check",
-        params: {
-          api_key: internal_user.api_key,
-          projects: [
-            { name: requested_name, platform: project_django.platform }
-          ],
-          score: true
-        }
-      )
-
-      expect(response).to have_http_status(:success)
-      expect(JSON.parse(response.body).dig(0, "name")).to eq(requested_name)
-    end
-
-    it "correctly handles go redirects" do
-      project = create(:project, platform: "Go", name: "known/project")
-      requested_name = "unknown/project"
-      allow(PackageManager::Go)
-        .to receive(:project_find_names)
-        .with(requested_name)
-        .and_return([project.name])
-
-      post(
-        "/api/check",
-        params: {
-          api_key: internal_user.api_key,
-          projects: [
-            { name: requested_name, platform: project.platform }
-          ],
-          score: true
-        }
-      )
-
-      expect(response).to have_http_status(:success)
-      expect(JSON.parse(response.body).dig(0, "name")).to eq(requested_name)
-      expect(JSON.parse(response.body).dig(0, "canonical_name")).to eq(project.name)
-    end
-
-    context "with normal API key" do
-
-      it "returns no maintenance stats or updated_at" do
-        post "/api/check", params: {api_key: normal_user.api_key, projects: [{name: project_django.name, platform: project_django.platform}] }
+    describe "POST #{url}", type: :request do
+      it "renders successfully with one" do
+        post url, params: { api_key: internal_user.api_key, projects: [{ name: project.name, platform: project.platform }] }
         expect(response).to have_http_status(:success)
-        expect(response.content_type).to eq('application/json')
+        expect(response.content_type).to eq("application/json")
+        expect(response.body.include?(project.name)).to be == true
+
+        # check for maintenance stats being returned
+        json_response = JSON.parse(response.body)
+        maintenance_stats = json_response.first["repository_maintenance_stats"]
+        expect(maintenance_stats.length).to be 1
+        expect(maintenance_stats.first["category"]).to eql maintenance_stat.category
+        expect(maintenance_stats.first["value"]).to eql maintenance_stat.value
+
+        # and updated_at
+        updated_at = json_response.first["updated_at"]
+        expect(updated_at).not_to be(nil)
+      end
+
+      it "renders empty json list if cannot find Project" do
+        post url, params: { api_key: internal_user.api_key, projects: [{ name: "rails", platform: "rubygems" }] }
+        expect(response).to have_http_status(:success)
+        expect(response.content_type).to eq("application/json")
+        expect(response.body).to be_json_eql []
+      end
+
+      it "renders successfully" do
+        post url, params: { api_key: internal_user.api_key, projects: [{ name: project.name, platform: "rubygems" }, { name: "django", platform: "Pypi" }] }
+        expect(response).to have_http_status(:success)
+        expect(response.content_type).to eq("application/json")
+        expect(response.body.include?(project.name)).to be == true
+        expect(response.body.include?("Django")).to be == true
+      end
+
+      it "renders empty maintenance stats if they don't exist" do
+        post url, params: { api_key: internal_user.api_key, projects: [{ name: project_django.name, platform: project_django.platform }] }
+        expect(response).to have_http_status(:success)
+        expect(response.content_type).to eq("application/json")
         expect(response.body.include?(project_django.name)).to be == true
 
         json_response = JSON.parse(response.body)
-        expect(json_response.first.key? "repository_maintenance_stats").to be false
-        expect(json_response.first.key? "updated_at").to be false
+        expect(json_response.first["repository_maintenance_stats"].length).to be 0
       end
-    end
 
-    context "with two projects that have the same name but different platforms" do
-      it "returns both" do
-        create(:project, platform: "NPM", name: "bcrypt")
-        create(:project, platform: "Pypi", name: "bcrypt")
+      it "contains all expected fields" do
+        # all the fields we expect to come back in the response for a project
+        expected_fields = %w[
+          canonical_name
+          dependent_repos_count
+          dependents_count
+          description
+          forks
+          homepage
+          keywords
+          language
+          latest_download_url
+          latest_release_number
+          latest_release_published_at
+          latest_stable_release_number
+          latest_stable_release_published_at
+          name
+          normalized_licenses
+          package_manager_url
+          platform
+          rank
+          repository_maintenance_stats
+          repository_url
+          score
+          stars
+          status
+          versions
+        ]
 
         post(
-          "/api/check",
+          url,
+          params: {
+            api_key: internal_user.api_key,
+            projects: [{ name: project_django.name, platform: project_django.platform }],
+            score: true,
+          }
+        )
+        expect(response).to have_http_status(:success)
+        expect(response.content_type).to eq("application/json")
+
+        project = JSON.parse(response.body).first
+        expected_fields.each do |field|
+          expect(project).to have_key(field)
+        end
+      end
+
+      it "correctly serves the original name" do
+        requested_name = project_django.name.downcase
+
+        post(
+          url,
           params: {
             api_key: internal_user.api_key,
             projects: [
-              { name: "bcrypt", platform: "npm" },
-              { name: "bcrypt", platform: "pypi" },
-            ]
+              { name: requested_name, platform: project_django.platform },
+            ],
+            score: true,
           }
         )
 
         expect(response).to have_http_status(:success)
-        json = JSON.parse(response.body)
-        expect(json.size).to eq(2)
-        expect(json.select { |p| p[:name] == "bcrypt" && p[:platform] == "NPM" }).to be
-        expect(json.select { |p| p[:name] == "bcrypt" && p[:platform] == "Pypi" }).to be
+        expect(JSON.parse(response.body).dig(0, "name")).to eq(requested_name)
+      end
+
+      it "correctly handles go redirects" do
+        project = create(:project, platform: "Go", name: "known/project")
+        requested_name = "unknown/project"
+        allow(PackageManager::Go)
+          .to receive(:project_find_names)
+          .with(requested_name)
+          .and_return([project.name])
+
+        post(
+          url,
+          params: {
+            api_key: internal_user.api_key,
+            projects: [
+              { name: requested_name, platform: project.platform },
+            ],
+            score: true,
+          }
+        )
+
+        expect(response).to have_http_status(:success)
+        expect(JSON.parse(response.body).dig(0, "name")).to eq(requested_name)
+        expect(JSON.parse(response.body).dig(0, "canonical_name")).to eq(project.name)
+      end
+
+      context "with normal API key" do
+        it "returns no maintenance stats or updated_at" do
+          post url, params: { api_key: normal_user.api_key, projects: [{ name: project_django.name, platform: project_django.platform }] }
+          expect(response).to have_http_status(:success)
+          expect(response.content_type).to eq("application/json")
+          expect(response.body.include?(project_django.name)).to be == true
+
+          json_response = JSON.parse(response.body)
+          expect(json_response.first.key?("repository_maintenance_stats")).to be false
+          expect(json_response.first.key?("updated_at")).to be false
+        end
+      end
+
+      context "with two projects that have the same name but different platforms" do
+        it "returns both" do
+          create(:project, platform: "NPM", name: "bcrypt")
+          create(:project, platform: "Pypi", name: "bcrypt")
+
+          post(
+            url,
+            params: {
+              api_key: internal_user.api_key,
+              projects: [
+                { name: "bcrypt", platform: "npm" },
+                { name: "bcrypt", platform: "pypi" },
+              ],
+            }
+          )
+
+          expect(response).to have_http_status(:success)
+          json = JSON.parse(response.body)
+          expect(json.size).to eq(2)
+          expect(json.select { |p| p[:name] == "bcrypt" && p[:platform] == "NPM" }).to be
+          expect(json.select { |p| p[:name] == "bcrypt" && p[:platform] == "Pypi" }).to be
+        end
       end
     end
+  end
+
+  xit "is performant with a bunch of projects" do
+    names = 10.times.map { Faker::Name.name.parameterize }.uniq
+
+    names.each do |name|
+      repository = create(:repository, full_name: name)
+      project = create(:project, platform: "Rubygems", name: name, repository: repository)
+      create_list(:repository_maintenance_stat, 10, repository: repository)
+      10.times do |i|
+        create(:version, project: project, number: "1.0.#{i}", published_at: 1.year.ago + i.days)
+      end
+    end
+
+    puts "/api/check?v2=true"
+    puts Benchmark.measure {
+      count = QueryCounter.count do
+        post "/api/check?v2=true", params: { api_key: internal_user.api_key, projects: names.map { |n| { name: n, platform: "rubygems" } } }
+      end
+      puts "====================\nQUERY COUNT: #{count}\n===================="
+    }
+
+    puts "/api/check"
+    puts Benchmark.measure {
+      count = QueryCounter.count do
+        post "/api/check", params: { api_key: internal_user.api_key, projects: names.map { |n| { name: n, platform: "rubygems" } } }
+      end
+      puts "====================\nQUERY COUNT: #{count}\n===================="
+    }
   end
 end


### PR DESCRIPTION
An attempt at optimization for the check endpoint. 

Initially I assumed this was going to be an N+1 fiesta, but in digging around here, it seems like queries are optimized quite nicely thanks to some work done by @kbarrette in https://github.com/librariesio/libraries.io/pull/2399 and https://github.com/librariesio/libraries.io/pull/2418. Turns out the bulk of the work happens in serialization. This adds a stripped down serializer that avoids active model serializers entirely, and tries to optimize a little bit (merge! vs merge, etc...). We also force usage of Oj for json serialization in this endpoint, something we probably want to explore doing universally. I've left a couple things that seemed useful that I hacked in to do some optimization.

A test run on my machine using 500 bootstrapped projects shows a 2.4x improvement, but I suspect it'll be better than that in production. Only one way to find out!

```
/api/check?v2=true
  1.341680   0.018838   1.360518 (  1.389088)

/api/check
  3.230206   0.034801   3.265007 (  3.286004)
```
