### PR TITLE
Further check endpoint optimizations

### DIFF
--- a/app/controllers/api/bulk_project_controller.rb
+++ b/app/controllers/api/bulk_project_controller.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 class Api::BulkProjectController < Api::ApplicationController
   def project_status_queries
     @project_status_queries ||= params[:projects]
       .group_by { |project| project[:platform] }
-      .map { |platform, group| ProjectStatusQuery.new(platform, group.map { |p| p[:name] }) }
+      .map { |platform, group| ProjectStatusQuery.new(platform, group.map { |p| p[:name] }, includes: @includes) }
   end
 
   def projects

--- a/app/controllers/api/status_controller.rb
+++ b/app/controllers/api/status_controller.rb
@@ -12,6 +12,8 @@ class Api::StatusController < Api::BulkProjectController
   end
 
   def check_legacy
+    @includes = %i[repository versions repository_maintenance_stats]
+
     render(
       json: projects,
       each_serializer: ProjectStatusSerializer,
@@ -23,9 +25,11 @@ class Api::StatusController < Api::BulkProjectController
   end
 
   def check_new
+    @includes = %i[repository]
+
     # This forces serialization with Oj
     # TODO: Investigate calling Oj.mimic_JSON on initializationh to swap universally
     serializer = OptimizedProjectSerializer.new(projects, project_names, internal_api_key?)
-    render json: Oj.dump(serializer.serialize)
+    render json: serializer.serialize
   end
 end


### PR DESCRIPTION
Ditching AR includes and plucking what we need for versions and maintenance stats makes this over 4x faster now in a local test with 500 projects.

```
/api/check?v2=true
  0.848421   0.020203   0.868624 (  0.892780)

/api/check
  3.559839   0.027464   3.587303 (  3.628964)
```