### PR TITLE
Add package-deprecation support for pypi yanking.

### DIFF
--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -8,9 +8,14 @@ module PackageManager
     SECURITY_PLANNED = true
     URL = "https://pypi.org/"
     COLOR = "#3572A5"
+    ENTIRE_PACKAGE_CAN_BE_DEPRECATED = true
 
     def self.package_link(project, version = nil)
       "https://pypi.org/project/#{project.name}/#{version}"
+    end
+
+    def self.check_status_url(project)
+      "https://pypi.org/pypi/#{project}/json"
     end
 
     def self.install_instructions(project, version = nil)
@@ -38,6 +43,15 @@ module PackageManager
       get("https://pypi.org/pypi/#{name}/json")
     rescue StandardError
       {}
+    end
+
+    def self.deprecation_info(name)
+      last_version = project(name)["releases"].values.last.first
+
+      {
+        is_deprecated: last_version["yanked"] == true,
+        message: last_version["yanked_reason"],
+      }
     end
 
     def self.mapping(project)

--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -15,7 +15,7 @@ module PackageManager
     end
 
     def self.check_status_url(project)
-      "https://pypi.org/pypi/#{project}/json"
+      "https://pypi.org/pypi/#{project.name}/json"
     end
 
     def self.install_instructions(project, version = nil)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -518,6 +518,9 @@ class Project < ApplicationRecord
       update_attribute(:status, 'Removed')
     elsif platform.downcase != 'packagist' && [400, 404].include?(response.response_code)
       update_attribute(:status, 'Removed')
+    elsif platform.downcase == 'pypi' && [404].include?(response.response_code)
+      # TODO: remove this stanza once this bug is fixed: https://github.com/pypa/warehouse/issues/3709#issuecomment-754973958
+      update_attribute(:status, 'Deprecated')
     elsif can_have_entire_package_deprecated?
       result = platform_class.deprecation_info(name)
       if result[:is_deprecated]

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -516,11 +516,11 @@ class Project < ApplicationRecord
     response = Typhoeus.head(url)
     if platform.downcase == 'packagist' && response.response_code == 302
       update_attribute(:status, 'Removed')
-    elsif platform.downcase != 'packagist' && [400, 404].include?(response.response_code)
-      update_attribute(:status, 'Removed')
-    elsif platform.downcase == 'pypi' && [404].include?(response.response_code)
+    elsif platform.downcase == 'pypi' && response.response_code == 404
       # TODO: remove this stanza once this bug is fixed: https://github.com/pypa/warehouse/issues/3709#issuecomment-754973958
       update_attribute(:status, 'Deprecated')
+    elsif platform.downcase != 'packagist' && [400, 404].include?(response.response_code)
+      update_attribute(:status, 'Removed')
     elsif can_have_entire_package_deprecated?
       result = platform_class.deprecation_info(name)
       if result[:is_deprecated]

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -57,4 +57,30 @@ describe PackageManager::Pypi do
       expect(suggested_find_names).to include('test-underscore', 'test_underscore')
     end
   end
+
+  describe '#deprecation_info' do
+    it "returns not-deprecated if last version isn't deprecated" do
+      expect(PackageManager::Pypi).to receive(:project).with('foo').and_return({
+        "releases" => {
+            "0.0.1" => [{}],
+            "0.0.2" => [{"yanked" => true, "yanked_reason" => "This package is deprecated"}],
+            "0.0.3" => [{}]
+        }
+      })
+
+      expect(described_class.deprecation_info('foo')).to eq({is_deprecated: false, message: nil})
+    end
+
+    it "returns deprecated if last version is deprecated" do
+      expect(PackageManager::Pypi).to receive(:project).with('foo').and_return({
+        "releases" => {
+            "0.0.1" => [{}],
+            "0.0.2" => [{"yanked" => true, "yanked_reason" => "This package is deprecated"}],
+            "0.0.3" => [{"yanked" => true, "yanked_reason" => "This package is deprecated"}]
+        }
+      })
+
+      expect(described_class.deprecation_info('foo')).to eq({is_deprecated: true, message: "This package is deprecated"})
+    end
+  end
 end


### PR DESCRIPTION
Pypi is similar to NPM in that it only allows specific releases to be "yanked", but having the latest release yanked is treated as if the whole package is yanked.

NB: according to PEP 592, yanked packages are still downloadable, and they won't be used by package managers unless they're the only possible release that satisfies a manifest.

