### PR TITLE
Stop using faraday http cache where it is unlikely to help

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -259,7 +259,6 @@ module PackageManager
 
     private_class_method def self.request(url, options = {})
       connection = Faraday.new url.strip, options do |builder|
-        builder.use :http_cache, store: Rails.cache, logger: Rails.logger, shared_cache: false, serializer: Marshal
         builder.use FaradayMiddleware::Gzip
         builder.use FaradayMiddleware::FollowRedirects, limit: 3
         builder.request :retry, { max: 2, interval: 0.05, interval_randomness: 0.5, backoff_factor: 2 }

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -7,7 +7,6 @@ Elasticsearch::Model.client = Elasticsearch::Client.new hosts: url.split(','),
                                                         retry_on_failure: true,
                                                         randomize_hosts: true,
                                                         transport_options: { request: { timeout: 10 } } do |builder|
-  builder.use :http_cache, store: Rails.cache, logger: Rails.logger, shared_cache: false, serializer: Marshal
   builder.use FaradayMiddleware::Gzip
   builder.use Google::Cloud::Trace::FaradayMiddleware if Rails.env.production?
   builder.use :instrumentation

--- a/config/initializers/octokit.rb
+++ b/config/initializers/octokit.rb
@@ -1,6 +1,4 @@
 Octokit.middleware = Faraday::RackBuilder.new do |builder|
-  logger = Logger.new(nil)
-  builder.use :http_cache, store: Rails.cache, logger: logger, shared_cache: false, serializer: Marshal
   builder.use Octokit::Middleware::FollowRedirects
   builder.use Octokit::Response::RaiseError
   builder.use Octokit::Response::FeedParser
@@ -10,5 +8,5 @@ Octokit.middleware = Faraday::RackBuilder.new do |builder|
   builder.adapter :typhoeus
   # ethon doesn't expose any other way to shut up its logging :(
   # https://github.com/typhoeus/ethon/issues/82
-  Ethon.logger = logger
+  Ethon.logger = Logger.new(nil)
 end


### PR DESCRIPTION
We're not hitting the same URLs over and over so this is just overhead
and driving up memcache usage without being effective.
