### PR TITLE
amatch is segfaulting; let's try not using it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source "https://rubygems.org"
 ruby "2.6.5"
 
 gem "active_model_serializers"
-gem "amatch"
 gem "api-pagination"
 gem "asciidoctor"
 gem "bibliothecary"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,9 +88,6 @@ GEM
     after_commit_action (1.1.0)
       activerecord (>= 3.0.0)
       activesupport (>= 3.0.0)
-    amatch (0.4.0)
-      mize
-      tins (~> 1.0)
     api-pagination (4.8.2)
     arel (9.0.0)
     asciidoctor (2.0.9)
@@ -363,8 +360,6 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)
-    mize (0.3.5)
-      protocol
     msgpack (1.2.10)
     multi_json (1.13.1)
     multi_xml (0.6.0)
@@ -429,8 +424,6 @@ GEM
     premailer-rails (1.9.7)
       actionmailer (>= 3, < 6)
       premailer (~> 1.7, >= 1.7.9)
-    protocol (1.0.1)
-      ruby_parser (~> 3.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -535,8 +528,6 @@ GEM
       i18n
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
-    ruby_parser (3.13.1)
-      sexp_processor (~> 4.9)
     rubypants (0.7.0)
     rugged (0.28.1)
     safe_yaml (1.0.5)
@@ -558,7 +549,6 @@ GEM
       railties (>= 4.0.0)
     sdl4r (0.9.11)
     semantic_range (2.3.0)
-    sexp_processor (4.12.0)
     shoulda (3.6.0)
       shoulda-context (~> 1.0, >= 1.0.1)
       shoulda-matchers (~> 3.0)
@@ -625,7 +615,6 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.9)
-    tins (1.20.3)
     toml-rb (1.1.2)
       citrus (~> 3.0, > 3.0)
     treetop (1.6.10)
@@ -662,7 +651,6 @@ PLATFORMS
 DEPENDENCIES
   RedCloth
   active_model_serializers
-  amatch
   api-pagination
   asciidoctor
   bibliothecary

--- a/config/initializers/fuzzy_match.rb
+++ b/config/initializers/fuzzy_match.rb
@@ -1,4 +1,0 @@
-# use amatch for faster string matching
-require 'fuzzy_match'
-require 'amatch'
-FuzzyMatch.engine = :amatch


### PR DESCRIPTION
sidekiq workers crash fairly often with a segfault in amatch. Let's
just use fuzzy match and see if things are more stable; the speed
cost is less important for a background processing job
