### PR TITLE
Add deprecation support for older 'development status' pypi classifier.

### DIFF
--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -46,11 +46,21 @@ module PackageManager
     end
 
     def self.deprecation_info(name)
-      last_version = project(name)["releases"].values.last.first
+      p = project(name)
+
+      is_deprecated, message = if (last_version = p["releases"].values.last&.first)
+        # PEP-0423: newer way of deleting specific versions (https://www.python.org/dev/peps/pep-0592/)
+        [last_version["yanked"] == true, last_version["yanked_reason"]]
+      elsif p["classifiers"].include?("Development Status :: 7 - Inactive")
+        # PEP-0423: older way of renaming/deprecating a project (https://www.python.org/dev/peps/pep-0423/#how-to-rename-a-project)
+        [true, "Development Status :: 7 - Inactive"]
+      else
+        [false, nil]
+      end
 
       {
-        is_deprecated: last_version["yanked"] == true,
-        message: last_version["yanked_reason"],
+        is_deprecated: is_deprecated,
+        message: message,
       }
     end
 

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -82,5 +82,23 @@ describe PackageManager::Pypi do
 
       expect(described_class.deprecation_info('foo')).to eq({is_deprecated: true, message: "This package is deprecated"})
     end
+
+    it "return not-deprecated if 'development status' is not 'inactive'" do
+      expect(PackageManager::Pypi).to receive(:project).with('foo').and_return({
+        "releases" => {},
+        "classifiers" => ["Development Status :: 5 - Production/Stable"]
+      })
+
+      expect(described_class.deprecation_info('foo')).to eq({is_deprecated: false, message: nil})
+    end
+
+    it "return deprecated if 'development status' is 'inactive'" do
+      expect(PackageManager::Pypi).to receive(:project).with('foo').and_return({
+        "releases" => {},
+        "classifiers" => ["Development Status :: 7 - Inactive"]
+      })
+
+      expect(described_class.deprecation_info('foo')).to eq({is_deprecated: true, message: "Development Status :: 7 - Inactive"})
+    end
   end
 end


### PR DESCRIPTION
Previously in https://github.com/librariesio/libraries.io/pull/2658 we started marking PyPi packages as "deprecated" if their latest release was "yanked", per the new PEP-592.

There's also an older method of renaming a project, via [PEP 423](https://www.python.org/dev/peps/pep-0423/#how-to-rename-a-project), which looks to have been used to deprecate projects too. This adds support for them.

Examples in [the wild](https://pypi.org/search/?q=&o=&c=Development+Status+%3A%3A+7+-+Inactive):
* [explicitly deprecated package](https://pypi.org/project/fake-factory/)
* [a package deprecated bc it's buggy](https://pypi.org/project/tempstorage/)
* [an unmaintained Python 2 package](https://pypi.org/project/multilint/)
* [stable but proactively marked as inactive](https://pypi.org/project/memtop/)
* [archived and renamed package](https://pypi.org/project/nbbinder/)
* [package superseded by another one](https://pypi.org/project/zope.app.workflow/)
* [parked domains to avoid typosquatting](https://pypi.org/project/dynamodb-encrpytion/)
