### PR TITLE
Quickfix for Pypi old-style deprecation detection.

### DIFF
--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -51,7 +51,7 @@ module PackageManager
       is_deprecated, message = if (last_version = p["releases"].values.last&.first)
         # PEP-0423: newer way of deleting specific versions (https://www.python.org/dev/peps/pep-0592/)
         [last_version["yanked"] == true, last_version["yanked_reason"]]
-      elsif p["classifiers"].include?("Development Status :: 7 - Inactive")
+      elsif p.fetch("info", {}).fetch("classifiers", []).include?("Development Status :: 7 - Inactive")
         # PEP-0423: older way of renaming/deprecating a project (https://www.python.org/dev/peps/pep-0423/#how-to-rename-a-project)
         [true, "Development Status :: 7 - Inactive"]
       else

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -86,7 +86,9 @@ describe PackageManager::Pypi do
     it "return not-deprecated if 'development status' is not 'inactive'" do
       expect(PackageManager::Pypi).to receive(:project).with('foo').and_return({
         "releases" => {},
-        "classifiers" => ["Development Status :: 5 - Production/Stable"]
+        "info" => {
+          "classifiers" => ["Development Status :: 5 - Production/Stable"]
+        }
       })
 
       expect(described_class.deprecation_info('foo')).to eq({is_deprecated: false, message: nil})
@@ -95,7 +97,9 @@ describe PackageManager::Pypi do
     it "return deprecated if 'development status' is 'inactive'" do
       expect(PackageManager::Pypi).to receive(:project).with('foo').and_return({
         "releases" => {},
-        "classifiers" => ["Development Status :: 7 - Inactive"]
+        "info" => {
+          "classifiers" => ["Development Status :: 7 - Inactive"],
+        }
       })
 
       expect(described_class.deprecation_info('foo')).to eq({is_deprecated: true, message: "Development Status :: 7 - Inactive"})


### PR DESCRIPTION
Forgot to include the `"info"` JSON namespace.