### PR TITLE
Add necessary trailing slash to pypi deprecation url.

### DIFF
--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -15,7 +15,7 @@ module PackageManager
     end
 
     def self.check_status_url(project)
-      "https://pypi.org/pypi/#{project.name}/json"
+      "https://pypi.org/pypi/#{project.name}/json/"
     end
 
     def self.install_instructions(project, version = nil)


### PR DESCRIPTION
We get a 301 instead of 404 without the slash, which was breaking the `check_status_url` method for Pypi projects.
