### PR TITLE
Packagist: save replacement library as deprecated message if it exists.

### DIFF
--- a/app/models/package_manager/packagist.rb
+++ b/app/models/package_manager/packagist.rb
@@ -35,7 +35,7 @@ module PackageManager
 
       {
         is_deprecated: is_deprecated != "",
-        message: "",
+        message: is_deprecated.is_a?(String) && is_deprecated.present? ? "Replacement: #{is_deprecated}"  : "",
       }
     end
 

--- a/spec/models/package_manager/packagist_spec.rb
+++ b/spec/models/package_manager/packagist_spec.rb
@@ -58,4 +58,30 @@ describe PackageManager::Packagist do
       end
     end
   end
+
+  describe '#deprecation_info' do
+    it "return not-deprecated if 'abandoned' is false'" do
+      expect(PackageManager::Packagist).to receive(:project).with('foo').and_return({
+        "abandoned" => false
+      })
+
+      expect(described_class.deprecation_info('foo')).to eq({is_deprecated: false, message: ""})
+    end
+
+    it "return deprecated if 'abandoned' is true'" do
+      expect(PackageManager::Packagist).to receive(:project).with('foo').and_return({
+        "abandoned" => true
+      })
+
+      expect(described_class.deprecation_info('foo')).to eq({is_deprecated: true, message: ""})
+    end
+
+    it "return deprecated if 'abandoned' is set to a replacement package'" do
+      expect(PackageManager::Packagist).to receive(:project).with('foo').and_return({
+        "abandoned" => "use-this/package-instead"
+      })
+
+      expect(described_class.deprecation_info('foo')).to eq({is_deprecated: true, message: "Replacement: use-this/package-instead"})
+    end
+  end
 end


### PR DESCRIPTION
The only way for a Composer package to mark itself as "deprecated" is via the [`abandoned` keyword in composer.json](https://getcomposer.org/doc/04-schema.md#abandoned) (NB this is also supported per-version)

Composer also lets you define a replacement package as that value, so this PR records the replacement package as the deprecation message.