### PR TITLE
Libraries boot time: add Yajl gem so github-linguist will load its samples faster.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,7 @@ gem "turbolinks"
 gem "typhoeus"
 gem "uglifier"
 gem "will_paginate-bootstrap"
+gem "yajl-ruby"
 
 group :development do
   gem "brakeman", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -647,6 +647,7 @@ GEM
       will_paginate (>= 3.0.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yajl-ruby (1.4.1)
 
 PLATFORMS
   ruby
@@ -763,6 +764,7 @@ DEPENDENCIES
   vcr (~> 4.0)
   webmock (~> 3.4)
   will_paginate-bootstrap
+  yajl-ruby
 
 RUBY VERSION
    ruby 2.6.5p114


### PR DESCRIPTION
Libraries requires `github-markup`, which uses `github-linguist` to do syntax highlighting. Some slowness arises from `github-linguist` loading some big JSON files using either `Yajl` (faster) or `YAML` (slower): https://github.com/github/linguist/search?q=%22defined%3F%28yajl%29%22

`github-linguist` only adds `yajl-ruby` as a development dependency, so we don't get it in our lockfile. Adding that gem should decrease boot time by ~2 seconds. 

### Before

```
$ time bin/rails r ""

real    0m7.590s
user    0m5.360s
sys     0m1.341s
```

### After

```
$ time bin/rails r ""
real    0m5.497s
user    0m3.395s
sys     0m1.286s
```