### PR TITLE
dup strings in url parser so we don't try to modify frozen strings

### DIFF
--- a/app/services/url_parser.rb
+++ b/app/services/url_parser.rb
@@ -4,7 +4,7 @@ class URLParser
   end
 
   def initialize(url)
-    @url = url.to_s
+    @url = url.to_s.dup
   end
 
   def parse


### PR DESCRIPTION
We pass frozen strings into url parser sometimes which blows up
when we later do regexes on those strings so dup to lose the frozen
state
