### PR TITLE
Enusre we're not trying to look at earlier than the first contribution

### DIFF
--- a/app/models/maintenance_stats/stats/github/contributor_count_stats.rb
+++ b/app/models/maintenance_stats/stats/github/contributor_count_stats.rb
@@ -18,11 +18,11 @@ module MaintenanceStats
         end
 
         def contributed?(contributor, weeks_ago)
-          # todo: verify weeks are actually within the time period?
           # this assumes the latest week is the last item in the weeks array for this contributor
           # count up the weeks counting backwards from the end of the array
           # return true if there is a commit in any of those weeks
-          contributor.weeks[-1*weeks_ago..-1].sum(&:c) > 0
+          num_weeks = [weeks_ago, contributor.weeks.count].min
+          contributor.weeks[-1*num_weeks..-1].sum(&:c) > 0
         end
       end
     end


### PR DESCRIPTION
This avoids an error when there haven't been weeks_ago contributions
to the project which ends up doing array[-52..-1] and if the array
only has 50 items, we get back a nil.

Instead get back contributions based on the max size of the window
b