### PR TITLE
Fix check_status_url for golang.

### DIFF
--- a/app/models/package_manager/go.rb
+++ b/app/models/package_manager/go.rb
@@ -24,6 +24,10 @@ module PackageManager
 
     VERSION_MODULE_REGEX = /(.+)\/(v\d+)/.freeze
 
+    def self.check_status_url(project)
+      "#{PROXY_BASE_URL}/#{project.name}/@v/list"
+    end
+
     def self.package_link(project, version = nil)
       "https://pkg.go.dev/#{project.name}#{"@#{version}" if version}"
     end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -519,7 +519,7 @@ class Project < ApplicationRecord
     elsif platform.downcase == 'pypi' && response.response_code == 404
       # TODO: remove this stanza once this bug is fixed: https://github.com/pypa/warehouse/issues/3709#issuecomment-754973958
       update_attribute(:status, 'Deprecated')
-    elsif platform.downcase != 'packagist' && [400, 404].include?(response.response_code)
+    elsif platform.downcase != 'packagist' && [400, 404, 410].include?(response.response_code)
       update_attribute(:status, 'Removed')
     elsif can_have_entire_package_deprecated?
       result = platform_class.deprecation_info(name)


### PR DESCRIPTION
The pkg.go.dev url we were using would return 405 for any HEAD request. This proxy url, instead, returns 200 for found and 410 for not found.