### PR TITLE
Handle unfetchable Go versions that have name collisions.

### DIFF
--- a/app/models/package_manager/go.rb
+++ b/app/models/package_manager/go.rb
@@ -106,13 +106,14 @@ module PackageManager
             known_versions[v].slice(:number, :published_at)
           else
             info = get("#{PROXY_BASE_URL}/#{project[:name]}/@v/#{v}.info")
-            # Known Go Modules issue where versions with case-insensitive name collisions break go get
+            # Store nil published_at for known Go Modules issue where case-insensitive name collisions break go get
             # e.g. https://proxy.golang.org/github.com/ysweid/aws-sdk-go/@v/v1.12.68.info
-            next if info.nil?
+            version = info.nil? ? v : info["Version"]
+            published_at = info && info["Time"].presence && Time.parse(info["Time"])
 
             {
-              number: info["Version"],
-              published_at: info["Time"].presence && Time.parse(info["Time"]),
+              number: version,
+              published_at: published_at,
             }
           end
         rescue Oj::ParseError

--- a/app/models/package_manager/go.rb
+++ b/app/models/package_manager/go.rb
@@ -106,11 +106,8 @@ module PackageManager
             known_versions[v].slice(:number, :published_at)
           else
             info = get("#{PROXY_BASE_URL}/#{project[:name]}/@v/#{v}.info")
-            # NB there is a known issue with Go Modules (+Godep) where modules with case-insensitive name collisions
-            # break and the Go Proxy returns an error. Skip these versions for now. For example:
-            # Git tag w/name collision: https://github.com/ysweid/aws-sdk-go/tree/v1.12.68/models/apis
-            # And its proxy request: https://proxy.golang.org/github.com/ysweid/aws-sdk-go/@v/v1.12.68.info
-            # Related GH issue: https://github.com/golang/go/issues/33778
+            # Known Go Modules issue where versions with case-insensitive name collisions break go get
+            # e.g. https://proxy.golang.org/github.com/ysweid/aws-sdk-go/@v/v1.12.68.info
             next if info.nil?
 
             {

--- a/app/models/package_manager/go.rb
+++ b/app/models/package_manager/go.rb
@@ -106,6 +106,13 @@ module PackageManager
             known_versions[v].slice(:number, :published_at)
           else
             info = get("#{PROXY_BASE_URL}/#{project[:name]}/@v/#{v}.info")
+            # NB there is a known issue with Go Modules (+Godep) where modules with case-insensitive name collisions
+            # break and the Go Proxy returns an error. Skip these versions for now. For example:
+            # Git tag w/name collision: https://github.com/ysweid/aws-sdk-go/tree/v1.12.68/models/apis
+            # And its proxy request: https://proxy.golang.org/github.com/ysweid/aws-sdk-go/@v/v1.12.68.info
+            # Related GH issue: https://github.com/golang/go/issues/33778
+            next if info.nil?
+
             {
               number: info["Version"],
               published_at: info["Time"].presence && Time.parse(info["Time"]),


### PR DESCRIPTION
Ignore versions that have case-insensitive name collisions instead of blowing up when we try to fetch their info.

* [example Go Module version with name collision](https://github.com/ysweid/aws-sdk-go/tree/v1.12.68/models/apis)
* [breaking url for ^](https://proxy.golang.org/github.com/ysweid/aws-sdk-go/@v/v1.12.68.info)
* [Go issue](https://github.com/golang/go/issues/33778)
