### PR TITLE
Select created_at when getting Go versions in case published_at nil.

### DIFF
--- a/app/models/package_manager/go.rb
+++ b/app/models/package_manager/go.rb
@@ -90,7 +90,7 @@ module PackageManager
 
       known_versions = Project.find_by(platform: "Go", name: project[:name])
         &.versions
-        &.select(:number, :published_at)
+        &.select(:number, :published_at, :created_at)
         &.index_by(&:number) || {}
 
       # NB fetching versions from the html only gets dates without timestamps, but we could alternatively use the go proxy too:


### PR DESCRIPTION
Followup to https://github.com/librariesio/libraries.io/pull/2687

Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/600f04159833b70018bd5b9f