### PR TITLE
PackageManager specs: only use name of subclass, not full name.

### DIFF
--- a/spec/models/package_manager/atom_spec.rb
+++ b/spec/models/package_manager/atom_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe PackageManager::Atom do
-  let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+  let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
   it 'has formatted name of "Atom"' do
     expect(described_class.formatted_name).to eq('Atom')

--- a/spec/models/package_manager/bower_spec.rb
+++ b/spec/models/package_manager/bower_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe PackageManager::Bower do
-  let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+  let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
   it 'has formatted name of "Bower"' do
     expect(PackageManager::Bower.formatted_name).to eq('Bower')

--- a/spec/models/package_manager/cargo_spec.rb
+++ b/spec/models/package_manager/cargo_spec.rb
@@ -6,7 +6,7 @@ describe PackageManager::Cargo do
   end
 
   describe '#package_link' do
-    let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+    let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
     it 'returns a link to project website' do
       expect(described_class.package_link(project)).to eq("https://crates.io/crates/foo/")

--- a/spec/models/package_manager/clojars_spec.rb
+++ b/spec/models/package_manager/clojars_spec.rb
@@ -6,7 +6,7 @@ describe PackageManager::Clojars do
   end
 
   describe '#package_link' do
-    let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+    let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
     it 'returns a link to project website' do
       expect(described_class.package_link(project)).to eq("https://clojars.org/foo")

--- a/spec/models/package_manager/cocoa_pods_spec.rb
+++ b/spec/models/package_manager/cocoa_pods_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe PackageManager::CocoaPods do
-  let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+  let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
   it 'has formatted name of "CocoaPods"' do
     expect(described_class.formatted_name).to eq('CocoaPods')

--- a/spec/models/package_manager/conda_spec.rb
+++ b/spec/models/package_manager/conda_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe PackageManager::Conda do
-  let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+  let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
   it 'has formatted name of "conda"' do
     expect(described_class.formatted_name).to eq('conda')

--- a/spec/models/package_manager/cpan_spec.rb
+++ b/spec/models/package_manager/cpan_spec.rb
@@ -6,7 +6,7 @@ describe PackageManager::CPAN do
   end
 
   describe '#package_link' do
-    let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+    let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
     it 'returns a link to project website' do
       expect(described_class.package_link(project)).to eq("https://metacpan.org/release/foo")

--- a/spec/models/package_manager/cran_spec.rb
+++ b/spec/models/package_manager/cran_spec.rb
@@ -6,7 +6,7 @@ describe PackageManager::CRAN do
   end
 
   describe '#package_link' do
-    let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+    let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
     it 'returns a link to project website' do
       expect(described_class.package_link(project)).to eq("https://cran.r-project.org/package=foo")

--- a/spec/models/package_manager/dub_spec.rb
+++ b/spec/models/package_manager/dub_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe PackageManager::Dub do
-  let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+  let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
   it 'has formatted name of "Dub"' do
     expect(described_class.formatted_name).to eq('Dub')

--- a/spec/models/package_manager/elm_spec.rb
+++ b/spec/models/package_manager/elm_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe PackageManager::Elm do
-  let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+  let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
   it 'has formatted name of "Elm"' do
     expect(described_class.formatted_name).to eq('Elm')

--- a/spec/models/package_manager/emacs_spec.rb
+++ b/spec/models/package_manager/emacs_spec.rb
@@ -6,7 +6,7 @@ describe PackageManager::Emacs do
   end
 
   describe '#package_link' do
-    let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+    let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
     it 'returns a link to project website' do
       expect(described_class.package_link(project)).to eq("http://melpa.org/#/foo")

--- a/spec/models/package_manager/go_spec.rb
+++ b/spec/models/package_manager/go_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe PackageManager::Go do
-  let(:project) { create(:project, name: "foo", platform: described_class.name) }
+  let(:project) { create(:project, name: "foo", platform: described_class.formatted_name) }
 
   it 'has formatted name of "Go"' do
     expect(described_class.formatted_name).to eq("Go")

--- a/spec/models/package_manager/hackage_spec.rb
+++ b/spec/models/package_manager/hackage_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe PackageManager::Hackage do
-  let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+  let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
   it 'has formatted name of "Hackage"' do
     expect(described_class.formatted_name).to eq('Hackage')

--- a/spec/models/package_manager/haxelib_spec.rb
+++ b/spec/models/package_manager/haxelib_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe PackageManager::Haxelib do
-  let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+  let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
   it 'has formatted name of "Haxelib"' do
     expect(described_class.formatted_name).to eq('Haxelib')

--- a/spec/models/package_manager/hex_spec.rb
+++ b/spec/models/package_manager/hex_spec.rb
@@ -6,7 +6,7 @@ describe PackageManager::Hex do
   end
 
   describe '#package_link' do
-    let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+    let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
     it 'returns a link to project website' do
       expect(described_class.package_link(project)).to eq("https://hex.pm/packages/foo/")

--- a/spec/models/package_manager/homebrew_spec.rb
+++ b/spec/models/package_manager/homebrew_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe PackageManager::Homebrew do
-  let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+  let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
   it 'has formatted name of "Homebrew"' do
     expect(described_class.formatted_name).to eq('Homebrew')

--- a/spec/models/package_manager/inqlude_spec.rb
+++ b/spec/models/package_manager/inqlude_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe PackageManager::Inqlude do
-  let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+  let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
   it 'has formatted name of "Inqlude"' do
     expect(described_class.formatted_name).to eq('Inqlude')

--- a/spec/models/package_manager/julia_spec.rb
+++ b/spec/models/package_manager/julia_spec.rb
@@ -6,7 +6,7 @@ describe PackageManager::Julia do
   end
 
   describe '#package_link' do
-    let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+    let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
     it 'returns a link to project website' do
       expect(described_class.package_link(project)).to eq("http://pkg.julialang.org/?pkg=foo&ver=release")

--- a/spec/models/package_manager/maven_spec.rb
+++ b/spec/models/package_manager/maven_spec.rb
@@ -8,7 +8,7 @@ describe PackageManager::Maven do
   end
 
   describe "#package_link" do
-    let(:project) { create(:project, name: "com.github.jparkie:pdd", platform: described_class.name) }
+    let(:project) { create(:project, name: "com.github.jparkie:pdd", platform: described_class.formatted_name) }
 
     it "returns a link to project website" do
       expect(described_class.package_link(project)).to eq("http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.github.jparkie%22%20AND%20a%3A%22pdd%22")
@@ -64,7 +64,7 @@ describe PackageManager::Maven do
   end
 
   describe "#check_status_url" do
-    let(:project) { create(:project, name: "javax.faces:javax.faces-api", platform: described_class.name) }
+    let(:project) { create(:project, name: "javax.faces:javax.faces-api", platform: described_class.formatted_name) }
 
     it "returns link to maven central folder" do
       expect(described_class.check_status_url(project)).to eq("https://repo1.maven.org/maven2/javax/faces/javax.faces-api")
@@ -88,7 +88,7 @@ describe PackageManager::Maven do
   end
 
   describe "#download_url" do
-    let(:project) { create(:project, name: "javax.faces:javax.faces-api", platform: described_class.name.demodulize) }
+    let(:project) { create(:project, name: "javax.faces:javax.faces-api", platform: described_class.formatted_name.demodulize) }
 
     it "returns link to maven central jar file" do
       expect(described_class.download_url(project.name, "2.3")).to eq("https://repo1.maven.org/maven2/javax/faces/javax.faces-api/2.3/javax.faces-api-2.3.jar")

--- a/spec/models/package_manager/meteor_spec.rb
+++ b/spec/models/package_manager/meteor_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe PackageManager::Meteor do
-  let(:project) { create(:project, name: 'foo:bar', platform: described_class.name) }
+  let(:project) { create(:project, name: 'foo:bar', platform: described_class.formatted_name) }
 
   it 'has formatted name of "Meteor"' do
     expect(described_class.formatted_name).to eq('Meteor')

--- a/spec/models/package_manager/nimble_spec.rb
+++ b/spec/models/package_manager/nimble_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe PackageManager::Nimble do
-  let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+  let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
   it 'has formatted name of "Nimble"' do
     expect(PackageManager::Nimble.formatted_name).to eq('Nimble')

--- a/spec/models/package_manager/npm_spec.rb
+++ b/spec/models/package_manager/npm_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe PackageManager::NPM do
-  let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+  let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
   it 'has formatted name of "npm"' do
     expect(described_class.formatted_name).to eq('npm')

--- a/spec/models/package_manager/nu_get_spec.rb
+++ b/spec/models/package_manager/nu_get_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe PackageManager::NuGet do
-  let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+  let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
   it 'has formatted name of "NuGet"' do
     expect(described_class.formatted_name).to eq('NuGet')

--- a/spec/models/package_manager/packagist_spec.rb
+++ b/spec/models/package_manager/packagist_spec.rb
@@ -6,7 +6,7 @@ describe PackageManager::Packagist do
   end
 
   describe '#package_link' do
-    let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+    let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
     it 'returns a link to project website' do
       expect(described_class.package_link(project)).to eq("https://packagist.org/packages/foo#")

--- a/spec/models/package_manager/pub_spec.rb
+++ b/spec/models/package_manager/pub_spec.rb
@@ -6,7 +6,7 @@ describe PackageManager::Pub do
   end
 
   describe '#package_link' do
-    let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+    let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
     it 'returns a link to project website' do
       expect(described_class.package_link(project)).to eq("https://pub.dartlang.org/packages/foo")

--- a/spec/models/package_manager/puppet_spec.rb
+++ b/spec/models/package_manager/puppet_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe PackageManager::Puppet do
-  let(:project) { create(:project, name: 'foo-bar', platform: described_class.name) }
+  let(:project) { create(:project, name: 'foo-bar', platform: described_class.formatted_name) }
 
   it 'has formatted name of "Puppet"' do
     expect(described_class.formatted_name).to eq('Puppet')

--- a/spec/models/package_manager/pure_script_spec.rb
+++ b/spec/models/package_manager/pure_script_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe PackageManager::PureScript do
-  let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+  let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
   it 'has formatted name of "PureScript"' do
     expect(described_class.formatted_name).to eq('PureScript')

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe PackageManager::Pypi do
-  let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+  let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
   it 'has formatted name of "PyPI"' do
     expect(described_class.formatted_name).to eq('PyPI')

--- a/spec/models/package_manager/racket_spec.rb
+++ b/spec/models/package_manager/racket_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe PackageManager::Racket do
-  let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+  let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
   it 'has formatted name of "Racket"' do
     expect(described_class.formatted_name).to eq('Racket')

--- a/spec/models/package_manager/rubygems_spec.rb
+++ b/spec/models/package_manager/rubygems_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe PackageManager::Rubygems do
-  let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+  let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
   it 'has formatted name of "Rubygems"' do
     expect(described_class.formatted_name).to eq('Rubygems')

--- a/spec/models/package_manager/shards_spec.rb
+++ b/spec/models/package_manager/shards_spec.rb
@@ -6,7 +6,7 @@ describe PackageManager::Shards do
   end
 
   describe '#package_link' do
-    let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+    let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
     it 'returns a link to project website' do
       expect(described_class.package_link(project)).to eq("https://crystal-shards-registry.herokuapp.com/shards/foo")

--- a/spec/models/package_manager/sublime_spec.rb
+++ b/spec/models/package_manager/sublime_spec.rb
@@ -6,7 +6,7 @@ describe PackageManager::Sublime do
   end
 
   describe '#package_link' do
-    let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+    let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
     it 'returns a link to project website' do
       expect(described_class.package_link(project)).to eq("https://packagecontrol.io/packages/foo")

--- a/spec/models/package_manager/wordpress_spec.rb
+++ b/spec/models/package_manager/wordpress_spec.rb
@@ -6,7 +6,7 @@ describe PackageManager::Wordpress do
   end
 
   describe '#package_link' do
-    let(:project) { create(:project, name: 'foo', platform: described_class.name) }
+    let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
 
     it 'returns a link to project website' do
       expect(described_class.package_link(project)).to eq("https://wordpress.org/plugins/foo/")


### PR DESCRIPTION
e.g. `platform: "Go"`, not `platform: "PackageManager::Go"`