### PR TITLE
Fix Hackage scraping that broke bc of a new anchor link in Versions

### DIFF
--- a/app/models/package_manager/hackage.rb
+++ b/app/models/package_manager/hackage.rb
@@ -59,7 +59,7 @@ module PackageManager
     end
 
     def self.find_attribute(page, name)
-      tr = page.css("#content tr").select { |t| t.css("th").text == name }.first
+      tr = page.css("#content tr").select { |t| t.css("th").text.to_s.start_with?(name) }.first
       tr&.css("td")&.text
     end
 


### PR DESCRIPTION
A FAQ link was added to one of the side bar titles ([example](http://hackage.haskell.org/package/atp)), so this just checks the beginning of the sidebar title. Doesn't look like they've added a JSON version of this yet either.

Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/5ffc9822aa4acf00198281f9