### PR TITLE
Silence missing Cocoapods until we can fix the feed.

### DIFF
--- a/app/models/package_manager/cocoa_pods.rb
+++ b/app/models/package_manager/cocoa_pods.rb
@@ -31,7 +31,7 @@ module PackageManager
     end
 
     def self.project(name)
-      versions = get_json("http://cocoapods.libraries.io/pods/#{name}.json")
+      versions = get_json("http://cocoapods.libraries.io/pods/#{name}.json") || {}
       latest_version = versions.keys.max_by { |version| version.split(".").map(&:to_i) }
       versions[latest_version].merge("versions" => versions)
     end
@@ -42,12 +42,12 @@ module PackageManager
         description: project["summary"],
         homepage: project["homepage"],
         licenses: parse_license(project["license"]),
-        repository_url: repo_fallback(project["source"]["git"], ""),
+        repository_url: repo_fallback(project.dig("source", "git"), ""),
       }
     end
 
     def self.versions(project, _name)
-      project["versions"].keys.map do |v|
+      project.fetch("versions", {}).keys.map do |v|
         {
           number: v.to_s,
         }


### PR DESCRIPTION
Sometimes pods that are in our api feed are missing when we look them up in our [api](https://github.com/librariesio/cocoapods-api/). Not sure why yet, but this prevents the pod from raising an error until we can look deeper.

Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/6006f83938be280017c6f1ef?event_id=6010aeb4006995105ac80000&i=em&m=fq