### PR TITLE
Ensure we require rubygems for the tar reader.

### DIFF
--- a/app/models/package_manager/cargo.rb
+++ b/app/models/package_manager/cargo.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rubygems/package'
+
 module PackageManager
   class Cargo < Base
     HAS_VERSIONS = true


### PR DESCRIPTION
Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/60118a93fa872a00174d9f44?event_id=60118a930069a0686dd20000&i=sk&m=nw