### PR TITLE
Lower 'queue weight' of version notification worker and benchmark

### DIFF
--- a/app/workers/version_notifications_worker.rb
+++ b/app/workers/version_notifications_worker.rb
@@ -1,6 +1,6 @@
 class VersionNotificationsWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :critical, unique: :until_executed
+  sidekiq_options queue: :small, unique: :until_executed
 
   def perform(version_id)
     Version.find_by_id(version_id).try(:send_notifications)

--- a/spec/workers/version_notifications_worker_spec.rb
+++ b/spec/workers/version_notifications_worker_spec.rb
@@ -1,10 +1,8 @@
-require 'rails_helper'
+# frozen_string_literal: true
+
+require "rails_helper"
 
 describe VersionNotificationsWorker do
-  it "should use the critical priority queue" do
-    is_expected.to be_processed_in :critical
-  end
-
   it "should send version notifications" do
     version = create(:version)
     expect(Version).to receive(:find_by_id).with(version.id).and_return(version)


### PR DESCRIPTION
I'd like to get some stats and this seemed to be an easy way. What I'm seeing is really odd though in that the time for method execution isn't even close to accounted for in the calls within it. I think I'm misunderstanding something.

```
Benchmark.measure { Version.order("random()").first.send_notifications }.real * 1000
Version#send_notifications benchmark overall: 1921.9531649998771ms dt:1894.0594109999438ms ns:3.391713000155505ms nf:24.29645300003358ms nw:0.05531300007532991ms
=> 23714.67944799997
```