### PR TITLE
Include stacktrace for debugging PackageManagerDownloadWorker

### DIFF
--- a/app/workers/package_manager_download_worker.rb
+++ b/app/workers/package_manager_download_worker.rb
@@ -2,7 +2,7 @@
 
 class PackageManagerDownloadWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :critical, backtrace: true
+  sidekiq_options queue: :critical
 
   PLATFORMS = {
     alcatraz: PackageManager::Alcatraz,

--- a/app/workers/package_manager_download_worker.rb
+++ b/app/workers/package_manager_download_worker.rb
@@ -2,7 +2,7 @@
 
 class PackageManagerDownloadWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :critical
+  sidekiq_options queue: :critical, backtrace: true
 
   PLATFORMS = {
     alcatraz: PackageManager::Alcatraz,

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -8,3 +8,7 @@ end
 Sidekiq.configure_client do |config|
   config.redis = { url: ENV["REDISCLOUD_URL"], id: nil }
 end
+
+Sidekiq.default_worker_options = {
+  backtrace: true,
+}


### PR DESCRIPTION
Seems useful overall, but trying to figure out the problem with a Maven job that's failing:

![Screen Shot 2021-01-29 at 9 21 51 AM](https://user-images.githubusercontent.com/5054/106286312-80d0cb80-6213-11eb-8678-b17a9f67dde8.png)
