### PR TITLE
Properly set removed property of CheckStatusWorker job.

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -159,7 +159,7 @@ class Project < ApplicationRecord
 
   def async_sync
     sync_classes.each{ |sync_class| PackageManagerDownloadWorker.perform_async(sync_class.name, name) }
-    CheckStatusWorker.perform_async(id)
+    CheckStatusWorker.perform_async(id, status == "Removed")
   end
 
   def sync_classes


### PR DESCRIPTION
We should refactor Project#check_status into the PackageManager classes, but this is a quick bandaid.

May fix, but not sure: https://app.bugsnag.com/tidelift/libraries-dot-io/errors/6007059462591d001892e3a9