### PR TITLE
bibliothecary 6.8.7 ~> 6.9.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
     ast (2.4.0)
     autoprefixer-rails (9.5.1.1)
       execjs
-    bibliothecary (6.8.7)
+    bibliothecary (6.9.7)
       commander
       deb_control
       librariesio-gem-parser
@@ -198,7 +198,7 @@ GEM
       rake
       rake-compiler
     fast_xs (0.8.0)
-    ffi (1.13.0)
+    ffi (1.14.2)
     fog-aws (3.5.0)
       fog-core (~> 2.1)
       fog-json (~> 1.1)
@@ -402,7 +402,7 @@ GEM
     org-ruby (0.9.12)
       rubypants (~> 0.2)
     os (1.0.1)
-    ox (2.13.2)
+    ox (2.14.1)
     parallel (1.17.0)
     parser (2.7.0.4)
       ast (~> 2.4.0)
@@ -606,8 +606,8 @@ GEM
       google-cloud-trace (~> 0.33)
     stackdriver-core (1.3.3)
       google-cloud-core (~> 1.2)
-    strings (0.1.8)
-      strings-ansi (~> 0.1)
+    strings (0.2.0)
+      strings-ansi (~> 0.2)
       unicode-display_width (~> 1.5)
       unicode_utils (~> 1.4)
     strings-ansi (0.2.0)


### PR DESCRIPTION
[bibliothecary diff](https://github.com/librariesio/bibliothecary/compare/v6.8.7...v6.9.7)

Should silence these errors: https://app.bugsnag.com/tidelift/libraries-dot-io/errors/5ffcc76ae4560f0017add9ac?event_id=60142d1f00699a746d010000&i=em&m=fq