### PR TITLE
Add a task to remove hidden maven projects with no group id.

### DIFF
--- a/lib/tasks/one_off.rake
+++ b/lib/tasks/one_off.rake
@@ -23,4 +23,16 @@ namespace :one_off do
       end
     end
   end
+
+  desc "delete all hidden maven projects missing a group id"
+  task delete_groupless_maven_projects: :environment do
+    Project.
+      where(platform: "Maven").
+      where(status: "Hidden").
+      where("name NOT LIKE '%:%'").
+      find_each do |p|
+        puts "Deleting Maven project #{p.name} (#{p.id})"
+        p.destroy!
+      end
+  end
 end


### PR DESCRIPTION
There are 20k Maven projects with no group id in their name, and their statuses are all "Hidden". They were all created around the same dates in 2015 and 2018 too. 

Not sure the history behind this batch of Maven projects, but I propose deleting them.

```
Project.where(platform: "Maven").where("name NOT LIKE '%:%'").count
=> 20063
Project.where(platform: "Maven").where("name NOT LIKE '%:%'").group(:status).count
=> {"Hidden"=>20063}
Project.where(platform: "Maven").where("name NOT LIKE '%:%'").group("DATE(created_at)").count
=> {Sun, 07 Jun 2015=>1, Mon, 02 Jul 2018=>17, Thu, 28 Jun 2018=>12425, Sat, 30 Jun 2018=>47, Fri, 29 Jun 2018=>7552, Sun, 01 Jul 2018=>21}
```

Fixes some of https://app.bugsnag.com/tidelift/libraries-dot-io/errors/5ffca22b75b5bf00176c087e