### PR TITLE
Use / to join Clojars package names instead of :.

### DIFF
--- a/app/models/concerns/project_search.rb
+++ b/app/models/concerns/project_search.rb
@@ -55,6 +55,8 @@ module ProjectSearch
     def extra_searchable_names
       if platform == "Maven"
         name.split(":")
+      elsif platform == "Clojars"
+        name.split("/")
       else
         []
       end

--- a/app/models/package_manager/clojars.rb
+++ b/app/models/package_manager/clojars.rb
@@ -7,6 +7,7 @@ module PackageManager
     BIBLIOTHECARY_SUPPORT = true
     URL = "https://clojars.org"
     COLOR = "#db5855"
+    NAME_DELIMITER = ":"
 
     def self.package_link(project, version = nil)
       "https://clojars.org/#{project.name}" + (version ? "/versions/#{version}" : "")
@@ -27,7 +28,11 @@ module PackageManager
     def self.download_url(name, version = nil)
       group_id, artifact_id = name.split("/", 2)
       artifact_id = group_id if artifact_id.nil?
-      MavenUrl.new(group_id, artifact_id, repository_base).jar(version)
+      ClojarsUrl.new(group_id, artifact_id, repository_base).jar(version)
+    end
+
+    class ClojarsUrl < MavenUrl
+      NAME_DELIMITER = "/"
     end
   end
 end

--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -16,6 +16,7 @@ module PackageManager
       "http://www.eclipse.org/legal/epl-v10" => "Eclipse Public License (EPL), Version 1.0",
       "http://www.eclipse.org/org/documents/edl-v10" => "Eclipse Distribution License (EDL), Version 1.0",
     }.freeze
+    NAME_DELIMITER = ":"
 
     PROVIDER_MAP = {
       "Atlassian" => Atlassian,
@@ -70,7 +71,7 @@ module PackageManager
     end
 
     def self.project(name)
-      sections = name.split(":")
+      sections = name.split(NAME_DELIMITER)
       path = sections.join("/")
       versions = versions(nil, name)
       latest_version = latest_version(versions, name)
@@ -166,7 +167,7 @@ module PackageManager
     def self.retrieve_versions(versions, name)
       versions
         .map do |version|
-          pom = get_pom(*name.split(":", 2), version)
+          pom = get_pom(*name.split(NAME_DELIMITER, 2), version)
           begin
             license_list = licenses(pom)
           rescue StandardError
@@ -246,12 +247,14 @@ module PackageManager
     end
 
     class MavenUrl
+      NAME_DELIMITER = ":"
+
       def self.from_name(name, repo_base)
-        new(*name.split(":", 2), repo_base)
+        new(*name.split(NAME_DELIMITER, 2), repo_base)
       end
 
       def self.legal_name?(name)
-        name.present? && name.split(":").size == 2
+        name.present? && name.split(NAME_DELIMITER).size == 2
       end
 
       def initialize(group_id, artifact_id, repo_base)

--- a/lib/tasks/one_off.rake
+++ b/lib/tasks/one_off.rake
@@ -24,6 +24,19 @@ namespace :one_off do
     end
   end
 
+  desc "backfill missing clojars packages with a slash, and remove packages with a dot"
+  task cleanup_clojar_projects: :environment do
+    Project.
+      where(platform: "Clojars").
+      where("name LIKE '%:%'").
+      find_each do |p|
+        good_name, bad_name = p.name.gsub(/:/, '/'), p.name
+        puts "Updating #{good_name}, deleting #{bad_name}"
+        PackageManager::Clojars.update(good_name)
+        p.destroy!
+    end
+  end
+
   desc "delete all hidden maven projects missing a group id"
   task delete_groupless_maven_projects: :environment do
     Project.


### PR DESCRIPTION
* use `/` instead of `:`, because that's what [Clojars uses](https://github.com/clojars/clojars-web/wiki/Groups) and we also have a bunch of pre-2020 Clojars projects that already use `/`.
* a rake task to backfill any missing `/` packages, and delete all the `:` packages.

Depends on https://github.com/librariesio/maven-updater/pull/7

Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/6013958dfaa82200183bb68e?event_id=6019a6a200699dade9aa0000&i=em&m=fq