### PR TITLE
One more fix for Clojars names.

### DIFF
--- a/app/models/package_manager/clojars.rb
+++ b/app/models/package_manager/clojars.rb
@@ -28,11 +28,7 @@ module PackageManager
     def self.download_url(name, version = nil)
       group_id, artifact_id = name.split("/", 2)
       artifact_id = group_id if artifact_id.nil?
-      ClojarsUrl.new(group_id, artifact_id, repository_base).jar(version)
-    end
-
-    class ClojarsUrl < MavenUrl
-      NAME_DELIMITER = "/"
+      MavenUrl.new(group_id, artifact_id, repository_base, NAME_DELIMITER).jar(version)
     end
   end
 end

--- a/app/models/package_manager/clojars.rb
+++ b/app/models/package_manager/clojars.rb
@@ -7,7 +7,7 @@ module PackageManager
     BIBLIOTHECARY_SUPPORT = true
     URL = "https://clojars.org"
     COLOR = "#db5855"
-    NAME_DELIMITER = ":"
+    NAME_DELIMITER = "/"
 
     def self.package_link(project, version = nil)
       "https://clojars.org/#{project.name}" + (version ? "/versions/#{version}" : "")

--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -248,7 +248,14 @@ module PackageManager
 
     class MavenUrl
       def self.from_name(name, repo_base, delimiter = ":")
-        new(*name.split(delimiter, 2), repo_base)
+        group_id, artifact_id = *name.split(delimiter, 2)
+
+        # Clojars names, when missing a group id, are implied to have the same group and artifact ids.
+        if artifact_id == nil && delimiter == PackageManager::Clojars::NAME_DELIMITER
+          artifact_id = group_id
+        end
+
+        new(group_id, artifact_id, repo_base)
       end
 
       def self.legal_name?(name, delimiter = ":")

--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -247,11 +247,11 @@ module PackageManager
     end
 
     class MavenUrl
-      def self.from_name(name, repo_base, delimiter)
+      def self.from_name(name, repo_base, delimiter = ":")
         new(*name.split(delimiter, 2), repo_base)
       end
 
-      def self.legal_name?(name, delimiter)
+      def self.legal_name?(name, delimiter = ":")
         name.present? && name.split(delimiter).size == 2
       end
 

--- a/spec/models/package_manager/maven_spec.rb
+++ b/spec/models/package_manager/maven_spec.rb
@@ -344,13 +344,13 @@ describe PackageManager::Maven::MavenUrl do
   describe "#legal_name?" do
     it "allows names with the format {group_id}:{artifact_name}" do
       ["com.google:guava", "junit:junit", "org.springframework.boot:spring-boot-starter-web", "org.scala-lang:scala-library"].each do |name|
-        expect(described_class.legal_name?(name, PackageManager::Maven::MavenUrl::NAME_DELIMITER)).to be true
+        expect(described_class.legal_name?(name)).to be true
       end
     end
 
     it "does not allow names without the format {group_id}:{artifact_name}" do
       ["guava", "junit", "org.springframework.boot", "org.scala-lang"].each do |name|
-        expect(described_class.legal_name?(name, PackageManager::Maven::MavenUrl::NAME_DELIMITER)).to be false
+        expect(described_class.legal_name?(name)).to be false
       end
     end
   end

--- a/spec/models/package_manager/maven_spec.rb
+++ b/spec/models/package_manager/maven_spec.rb
@@ -344,13 +344,13 @@ describe PackageManager::Maven::MavenUrl do
   describe "#legal_name?" do
     it "allows names with the format {group_id}:{artifact_name}" do
       ["com.google:guava", "junit:junit", "org.springframework.boot:spring-boot-starter-web", "org.scala-lang:scala-library"].each do |name|
-        expect(described_class.legal_name?(name)).to be true
+        expect(described_class.legal_name?(name, PackageManager::Maven::MavenUrl::NAME_DELIMITER)).to be true
       end
     end
 
     it "does not allow names without the format {group_id}:{artifact_name}" do
       ["guava", "junit", "org.springframework.boot", "org.scala-lang"].each do |name|
-        expect(described_class.legal_name?(name)).to be false
+        expect(described_class.legal_name?(name, PackageManager::Maven::MavenUrl::NAME_DELIMITER)).to be false
       end
     end
   end


### PR DESCRIPTION
Followup to https://github.com/librariesio/libraries.io/pull/2711

We use MavenUrl in a couple places, so we should just stick with that instead of subclassing it for Clojars.