### PR TITLE
Clojars urls require a version, so use web url for check_status.

### DIFF
--- a/app/models/package_manager/clojars.rb
+++ b/app/models/package_manager/clojars.rb
@@ -25,10 +25,15 @@ module PackageManager
       get("https://maven.libraries.io/clojars/recent")
     end
 
+    # Clojars download urls require a version
     def self.download_url(name, version = nil)
       group_id, artifact_id = name.split("/", 2)
       artifact_id = group_id if artifact_id.nil?
       MavenUrl.new(group_id, artifact_id, repository_base, NAME_DELIMITER).jar(version)
+    end
+
+    def self.check_status_url(project)
+      package_link(project)
     end
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -522,6 +522,8 @@ class Project < ApplicationRecord
       update_attribute(:status, 'Deprecated')
     elsif platform.downcase != 'packagist' && [400, 404, 410].include?(response.response_code)
       update_attribute(:status, 'Removed')
+    elsif platform.downcase == 'clojars' && response.response_code == 404
+      update_attribute(:status, 'Removed')
     elsif can_have_entire_package_deprecated?
       result = platform_class.deprecation_info(name)
       if result[:is_deprecated]


### PR DESCRIPTION
Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/5ffca22b75b5bf00176c087e