### PR TITLE
Fix accidental clojars argument.

### DIFF
--- a/app/models/package_manager/clojars.rb
+++ b/app/models/package_manager/clojars.rb
@@ -29,7 +29,7 @@ module PackageManager
     def self.download_url(name, version = nil)
       group_id, artifact_id = name.split("/", 2)
       artifact_id = group_id if artifact_id.nil?
-      MavenUrl.new(group_id, artifact_id, repository_base, NAME_DELIMITER).jar(version)
+      MavenUrl.new(group_id, artifact_id, repository_base).jar(version)
     end
 
     def self.check_status_url(project)


### PR DESCRIPTION
Accidentally put the delimiter in the wrong method call:

https://app.bugsnag.com/tidelift/libraries-dot-io/errors/601d7ba5cab0000017044e74?aevent_id=601d7ba50069ac1bf8b30000&i=sk&m=nw