### PR TITLE
Include manifest in Api::Repositories#dependencies to fix N+1

### DIFF
--- a/app/controllers/api/repositories_controller.rb
+++ b/app/controllers/api/repositories_controller.rb
@@ -11,7 +11,7 @@ class Api::RepositoriesController < Api::ApplicationController
 
   def dependencies
     repo_json = RepositorySerializer.new(@repository).as_json
-    repo_json[:dependencies] = map_dependencies(@repository.repository_dependencies.includes(:project) || [])
+    repo_json[:dependencies] = map_dependencies(@repository.repository_dependencies.includes(:project, :manifest) || [])
 
     render json: repo_json
   end


### PR DESCRIPTION
Example with 122 repository deps:

Before:
```
Benchmark.ms { r.repository_dependencies.includes(:project).map { |d| DependencySerializer.new(d) }.as_json }
=> 996.7429660000562
```

After:
```
Benchmark.ms { r.repository_dependencies.includes(:project, :manifest).map { |d| DependencySerializer.new(d) }.as_json }
=> 634.9350350001259
```

There's another N+1 with versions/tags queries, but we can't fix it bc it requires Ruby logic :\
