### PR TITLE
Trace endpoints for better instrumentation.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,14 @@ class ApplicationController < ActionController::Base
 
   before_action :log_active_connections
 
+  around_action :trace_span
+
   private
+
+  def trace_span(&block)
+    Google::Cloud::Trace
+      .in_span("endpoint##{controller_name}##{action_name}", &block)
+  end
 
   def log_active_connections
     # Only log 1 in 10 requests


### PR DESCRIPTION
It's easier to track down bottlenecks when you can drill into specific endpoints.