### PR TITLE
Start using db-based latest_stable_release_number instead of Ruby version

### DIFF
--- a/app/models/concerns/releases.rb
+++ b/app/models/concerns/releases.rb
@@ -20,10 +20,6 @@ module Releases
     latest_stable_version || latest_stable_tag
   end
 
-  def latest_stable_release_number
-    latest_stable_release.try(:number)
-  end
-
   def latest_version
     versions.sort.first
   end


### PR DESCRIPTION
To be merged after this backfill is run: https://github.com/librariesio/libraries.io/pull/2721