### PR TITLE
Add JB gem, and a first JB template for Api::Projects#dependencies.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem "graphql-client", "~> 0.14.0"
 gem "groupdate"
 gem "hiredis"
 gem "indefinite_article"
+gem 'jb'
 gem "jquery-rails"
 gem "license-compatibility"
 gem "listen"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -317,6 +317,7 @@ GEM
       activesupport
     ipaddress (0.8.3)
     jaro_winkler (1.5.4)
+    jb (0.8.0)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -699,6 +700,7 @@ DEPENDENCIES
   groupdate
   hiredis
   indefinite_article
+  jb
   jquery-rails
   json_spec
   license-compatibility

--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -66,15 +66,14 @@ class Api::ProjectsController < Api::ApplicationController
   end
 
   def dependencies
-    subset = params.fetch(:subset, "default")
+    @subset = params.fetch(:subset, "default")
 
     if params[:v2] == "true"
       @project = Project.find_best!(params[:platform], params[:name], [:repository, :versions])
       @version = @project.find_version!(params[:version])
-      @subset = subset
-      # render app/views/api/projects/dependencies.json.b
+      # render app/views/api/projects/dependencies.json.jb
     else
-      project_json = find_project_as_json_with_dependencies!(params[:platform], params[:name], params[:version], subset)
+      project_json = find_project_as_json_with_dependencies!(params[:platform], params[:name], params[:version], @subset)
       render json: project_json
     end
   end

--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -67,9 +67,16 @@ class Api::ProjectsController < Api::ApplicationController
 
   def dependencies
     subset = params.fetch(:subset, "default")
-    project_json = find_project_as_json_with_dependencies!(params[:platform], params[:name], params[:version], subset)
 
-    render json: project_json
+    if params[:v2] == "true"
+      @project = Project.find_best!(params[:platform], params[:name], [:repository, :versions])
+      @version = @project.find_version!(params[:version])
+      @subset = subset
+      # render
+    else
+      project_json = find_project_as_json_with_dependencies!(params[:platform], params[:name], params[:version], subset)
+      render json: project_json
+    end
   end
 
   def dependencies_bulk

--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -72,7 +72,7 @@ class Api::ProjectsController < Api::ApplicationController
       @project = Project.find_best!(params[:platform], params[:name], [:repository, :versions])
       @version = @project.find_version!(params[:version])
       @subset = subset
-      # render
+      # render app/views/api/projects/dependencies.json.b
     else
       project_json = find_project_as_json_with_dependencies!(params[:platform], params[:name], params[:version], subset)
       render json: project_json

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -600,11 +600,11 @@ class Project < ApplicationRecord
   end
 
   def find_version!(version_name)
-    version = if version_name == 'latest'
-                versions.sort.first
-              else
-                versions.find_by_number(version_name)
-              end
+    if version_name == 'latest'
+      version_name = versions.pluck(:number).sort.last
+    end
+
+    version = versions.find_by_number(version_name)
 
     raise ActiveRecord::RecordNotFound if version.nil?
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -15,7 +15,9 @@ class Project < ApplicationRecord
     dependents_count
     deprecation_reason
     description
+    forks
     homepage
+    keywords
     language
     latest_download_url
     latest_release_number
@@ -26,9 +28,12 @@ class Project < ApplicationRecord
     licenses
     name
     normalized_licenses
+    package_manager_url
     platform
     rank
+    repository_license
     repository_url
+    stars
     status
   ].freeze
 

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -4,6 +4,14 @@ class Version < ApplicationRecord
   include Releaseable
 
   STATUSES = %w[Deprecated Removed].freeze
+  API_FIELDS = [
+    :number,
+    :published_at,
+    :spdx_expression,
+    :original_license,
+    :researched_at,
+    :repository_sources
+  ]
 
   validates :project_id, :number, presence: true
   validates :number, uniqueness: { scope: :project_id }

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -11,7 +11,6 @@ class ProjectSerializer < ActiveModel::Serializer
     latest_download_url
     latest_release_number
     latest_release_published_at
-    latest_stable_release
     latest_stable_release_number
     latest_stable_release_published_at
     license_normalized

--- a/app/views/api/projects/dependencies.json.jb
+++ b/app/views/api/projects/dependencies.json.jb
@@ -1,0 +1,30 @@
+dependencies_fields = {
+  dependencies_for_version: @version.number,
+  dependencies: (@version.dependencies.includes(:project) || []).
+    map {|dependency| DependencySerializer.new(dependency) }.
+    as_json
+}
+
+case @subset
+when "default"
+  @project.
+    slice(Project::API_FIELDS).
+    merge({
+      versions: @project.versions.map do |v|
+        {
+          number: v.number,
+          published_at: v.published_at,
+          spdx_expression: v.spdx_expression,
+          original_license: v.original_license,
+          researched_at: v.researched_at,
+          repository_sources: v.repository_sources.presence || [v.project.platform],
+        }
+      end
+    }).
+    merge(dependencies_fields)
+when "minimum"
+  @project.slice(:name, :platform).merge(dependencies_fields)
+else
+  raise ActionController::BadRequest.new("Unsupported subset")
+end
+

--- a/app/views/api/projects/dependencies.json.jb
+++ b/app/views/api/projects/dependencies.json.jb
@@ -1,8 +1,7 @@
 dependencies_fields = {
   dependencies_for_version: @version.number,
   dependencies: (@version.dependencies.includes(:project) || []).
-    map {|dependency| DependencySerializer.new(dependency) }.
-    as_json
+    map { |d| DependencySerializer.new(d) }
 }
 
 case @subset
@@ -10,16 +9,15 @@ when "default"
   @project.
     slice(Project::API_FIELDS).
     merge({
-      versions: @project.versions.map do |v|
-        {
-          number: v.number,
-          published_at: v.published_at,
-          spdx_expression: v.spdx_expression,
-          original_license: v.original_license,
-          researched_at: v.researched_at,
-          repository_sources: v.repository_sources.presence || [v.project.platform],
-        }
-      end
+      versions: @project.
+        versions.
+        pluck(*Version::API_FIELDS).
+        map do |v|
+          Version::API_FIELDS.
+            zip(v).
+            to_h.
+            tap { |v| v[:repository_sources] = [@project.platform] unless v[:repository_sources].present? }
+        end
     }).
     merge(dependencies_fields)
 when "minimum"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -44,7 +44,7 @@ RSpec.configure do |config|
 end
 
 def project_json_response(projects)
-  projects.as_json(only: Project::API_FIELDS, methods: %i[package_manager_url stars forks keywords latest_stable_release latest_download_url repository_license], include: { versions: { only: %i[number published_at original_license spdx_expression researched_at repository_sources] } })
+  projects.as_json(only: Project::API_FIELDS, methods: %i[package_manager_url stars forks keywords latest_download_url repository_license], include: { versions: { only: %i[number published_at original_license spdx_expression researched_at repository_sources] } })
 end
 
 RSpec::Sidekiq.configure do |config|

--- a/spec/requests/api/bower_search_spec.rb
+++ b/spec/requests/api/bower_search_spec.rb
@@ -23,7 +23,6 @@ describe "Api::BowerSearchController", elasticsearch: true do
             latest_download_url: nil,
             latest_release_number: project.latest_release_number,
             latest_release_published_at: project.latest_release_published_at,
-            latest_stable_release: project.latest_stable_release,
             latest_stable_release_number: project.latest_stable_release_number,
             latest_stable_release_published_at: project.latest_stable_release_published_at,
             license_normalized: project.license_normalized,

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -151,85 +151,86 @@ describe "Api::ProjectsController" do
     end
   end
 
-  describe "GET /api/:platform/:name/dependencies", type: :request do
-    it "renders successfully" do
-      get "/api/#{project.platform}/#{project.name}/#{version.number}/dependencies"
-      expect(response).to have_http_status(:success)
-      expect(response.content_type).to eq("application/json")
-      expect(response.body).to be_json_eql(
-        {
-          dependencies_for_version: version.number,
-          dependent_repos_count: project.dependent_repos_count,
-          dependents_count: project.dependents_count,
-          deprecation_reason: project.deprecation_reason,
-          dependencies: version.dependencies.map do |dependency|
+  %w[true false].each do |v2_value|
+    describe "GET /api/:platform/:name/dependencies", type: :request do
+      it "renders successfully" do
+        get "/api/#{project.platform}/#{project.name}/#{version.number}/dependencies?v2=#{v2_value}"
+        expect(response).to have_http_status(:success)
+        expect(response.content_type).to eq("application/json")
+        expect(response.body).to be_json_eql(
+          {
+            dependencies_for_version: version.number,
+            dependent_repos_count: project.dependent_repos_count,
+            dependents_count: project.dependents_count,
+            deprecation_reason: project.deprecation_reason,
+            dependencies: version.dependencies.map do |dependency|
+              {
+                project_name: dependency.name,
+                name: dependency.name,
+                platform: dependency.platform,
+                requirements: dependency.requirements,
+                latest_stable: dependency.latest_stable,
+                latest: dependency.latest,
+                deprecated: dependency.deprecated,
+                outdated: dependency.outdated,
+                filepath: dependency.filepath,
+                kind: dependency.kind,
+                normalized_licenses: dependency.project.normalized_licenses,
+              }
+            end,
+            description: project.description,
+            forks: project.forks,
+            homepage: project.homepage,
+            keywords: project.keywords,
+            language: project.language,
+            latest_download_url: project.latest_download_url,
+            latest_release_number: project.latest_release_number,
+            latest_release_published_at: project.latest_release_published_at,
+            latest_stable_release_number: project.latest_stable_release_number,
+            latest_stable_release_published_at: project.latest_stable_release_published_at,
+            license_normalized: project.license_normalized,
+            licenses: project.licenses,
+            name: project.name,
+            normalized_licenses: project.normalized_licenses,
+            package_manager_url: project.package_manager_url,
+            platform: project.platform,
+            rank: project.rank,
+            repository_license: project.repository_license,
+            repository_url: project.repository_url,
+            stars: project.stars,
+            status: project.status,
+            versions: project.versions.as_json(only: %i[number original_license published_at spdx_expression researched_at repository_sources]),
+          }.to_json
+        )
+      end
+    end
+
+    describe "GET /api/:platform/:name/dependencies?subset=minimum", type: :request do
+      it "renders successfully" do
+        get "/api/#{project.platform}/#{project.name}/#{version.number}/dependencies?subset=minimum&v2=#{v2_value}"
+        expect(response).to have_http_status(:success)
+        expect(response.content_type).to eq("application/json")
+        expect(response.body).to be_json_eql({
+          "name": project.name,
+          "platform": project.platform,
+          "dependencies_for_version": version.number,
+          "dependencies": version.dependencies.map do |dependency|
             {
-              project_name: dependency.name,
-              name: dependency.name,
-              platform: dependency.platform,
-              requirements: dependency.requirements,
-              latest_stable: dependency.latest_stable,
-              latest: dependency.latest,
-              deprecated: dependency.deprecated,
-              outdated: dependency.outdated,
-              filepath: dependency.filepath,
-              kind: dependency.kind,
-              normalized_licenses: dependency.project.normalized_licenses,
+              "project_name": dependency.name,
+              "name": dependency.name,
+              "platform": dependency.platform,
+              "requirements": dependency.requirements,
+              "latest_stable": dependency.latest_stable,
+              "latest": dependency.latest,
+              "deprecated": dependency.deprecated,
+              "outdated": dependency.outdated,
+              "filepath": dependency.filepath,
+              "kind": dependency.kind,
+              "normalized_licenses": dependency.project.normalized_licenses,
             }
           end,
-          description: project.description,
-          forks: project.forks,
-          homepage: project.homepage,
-          keywords: project.keywords,
-          language: project.language,
-          latest_download_url: project.latest_download_url,
-          latest_release_number: project.latest_release_number,
-          latest_release_published_at: project.latest_release_published_at,
-          latest_stable_release: project.latest_stable_release,
-          latest_stable_release_number: project.latest_stable_release_number,
-          latest_stable_release_published_at: project.latest_stable_release_published_at,
-          license_normalized: project.license_normalized,
-          licenses: project.licenses,
-          name: project.name,
-          normalized_licenses: project.normalized_licenses,
-          package_manager_url: project.package_manager_url,
-          platform: project.platform,
-          rank: project.rank,
-          repository_license: project.repository_license,
-          repository_url: project.repository_url,
-          stars: project.stars,
-          status: project.status,
-          versions: project.versions.as_json(only: %i[number original_license published_at spdx_expression researched_at repository_sources]),
-        }.to_json
-      )
-    end
-  end
-
-  describe "GET /api/:platform/:name/dependencies?subset=minimum", type: :request do
-    it "renders successfully" do
-      get "/api/#{project.platform}/#{project.name}/#{version.number}/dependencies?subset=minimum"
-      expect(response).to have_http_status(:success)
-      expect(response.content_type).to eq("application/json")
-      expect(response.body).to be_json_eql({
-        "name": project.name,
-        "platform": project.platform,
-        "dependencies_for_version": version.number,
-        "dependencies": version.dependencies.map do |dependency|
-          {
-            "project_name": dependency.name,
-            "name": dependency.name,
-            "platform": dependency.platform,
-            "requirements": dependency.requirements,
-            "latest_stable": dependency.latest_stable,
-            "latest": dependency.latest,
-            "deprecated": dependency.deprecated,
-            "outdated": dependency.outdated,
-            "filepath": dependency.filepath,
-            "kind": dependency.kind,
-            "normalized_licenses": dependency.project.normalized_licenses,
-          }
-        end,
-      }.to_json)
+        }.to_json)
+      end
     end
   end
 

--- a/spec/requests/api/subscriptions_spec.rb
+++ b/spec/requests/api/subscriptions_spec.rb
@@ -10,7 +10,7 @@ describe "Api::SubscriptionsController" do
       get "/api/subscriptions?api_key=#{user.api_key}"
       expect(response).to have_http_status(:success)
       expect(response.content_type).to eq('application/json')
-      expect(response.body).to be_json_eql [subscription.as_json(only: [:include_prerelease, :created_at, :updated_at], include: {project: {only: Project::API_FIELDS, methods: [:package_manager_url, :stars, :forks, :keywords, :latest_stable_release, :latest_download_url, :repository_license], include: {versions: {only: [:number, :published_at]} }}})].to_json
+      expect(response.body).to be_json_eql [subscription.as_json(only: [:include_prerelease, :created_at, :updated_at], include: {project: {only: Project::API_FIELDS, methods: [:package_manager_url, :stars, :forks, :keywords, :latest_download_url, :repository_license], include: {versions: {only: [:number, :published_at]} }}})].to_json
     end
   end
 
@@ -19,7 +19,7 @@ describe "Api::SubscriptionsController" do
       get "/api/subscriptions/#{subscription.project.platform}/#{subscription.project.name}?api_key=#{user.api_key}"
       expect(response).to have_http_status(:success)
       expect(response.content_type).to eq('application/json')
-      expect(response.body).to be_json_eql subscription.to_json(only: [:include_prerelease, :created_at, :updated_at], include: {project: {only: Project::API_FIELDS, methods: [:package_manager_url, :stars, :forks, :keywords, :latest_stable_release, :latest_download_url, :repository_license], include: {versions: {only: [:number, :published_at]} }}})
+      expect(response.body).to be_json_eql subscription.to_json(only: [:include_prerelease, :created_at, :updated_at], include: {project: {only: Project::API_FIELDS, methods: [:package_manager_url, :stars, :forks, :keywords, :latest_download_url, :repository_license], include: {versions: {only: [:number, :published_at]} }}})
     end
   end
 
@@ -44,7 +44,7 @@ describe "Api::SubscriptionsController" do
       put "/api/subscriptions/#{subscription.project.platform}/#{subscription.project.name}?api_key=#{user.api_key}", params: { subscription: { include_prerelease: true } }
       expect(response).to have_http_status(:success)
       expect(response.content_type).to eq('application/json')
-      expect(response.body).to be_json_eql subscription.reload.to_json(only: [:include_prerelease, :created_at, :updated_at], include: {project: {only: Project::API_FIELDS, methods: [:package_manager_url, :stars, :forks, :keywords, :latest_stable_release, :latest_download_url, :repository_license], include: {versions: {only: [:number, :published_at]} }}})
+      expect(response.body).to be_json_eql subscription.reload.to_json(only: [:include_prerelease, :created_at, :updated_at], include: {project: {only: Project::API_FIELDS, methods: [:package_manager_url, :stars, :forks, :keywords, :latest_download_url, :repository_license], include: {versions: {only: [:number, :published_at]} }}})
     end
   end
 

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -14,7 +14,6 @@ describe ProjectSerializer do
       latest_download_url
       latest_release_number
       latest_release_published_at
-      latest_stable_release
       latest_stable_release_number
       latest_stable_release_published_at
       license_normalized


### PR DESCRIPTION
An attempt at speeding up `/api/projects/:platform/:name/:version/dependencies`:

* adds `jb` gem for simple JSON templates
* adds `v2=true` param that switches from ProjectSerializer to JB template in this endpoint

Sample project with 1820 versions, roughly before and after:

```
> Benchmark.ms { ProjectSerializer.new(p).as_json }
=> 277.5426210137084
> Benchmark.ms { p.versions.map { |v| v.slice(:number, :published_at, :spdx_expression, :original_license, :researched_at, :repository_sources) }.as_json }
=> 82.78486994095147
```