### PR TITLE
Ensure that namespaces are included in controller name spans.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
 
   def trace_span(&block)
     Google::Cloud::Trace
-      .in_span("endpoint##{controller_name}##{action_name}", &block)
+      .in_span("endpoint##{controller_path}##{action_name}", &block)
   end
 
   def log_active_connections


### PR DESCRIPTION
Some endpoints are getting conflated in GCP Trace because the spans are leaving out the controller namespace. 

E.g. for `Api::ProjectsController#dependencies`:

#### Before:
`endpoint#projects#dependencies`
#### After:
`endpoint#api/projects#dependencies`