### PR TITLE
Wordpress' "tags" is Hash if full, or an Array if empty.

### DIFF
--- a/app/models/package_manager/wordpress.rb
+++ b/app/models/package_manager/wordpress.rb
@@ -60,7 +60,7 @@ module PackageManager
         name: project["slug"],
         description: project["short_description"],
         homepage: project["homepage"],
-        keywords_array: Array.wrap(project.fetch("tags", {}).values),
+        keywords_array: (project["tags"].presence || {}).values,
         repository_url: repo_fallback("", project["homepage"]),
       }
     end


### PR DESCRIPTION
Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/5ffc7d823a74ac00181b3361
