### PR TITLE
Tweak GCP intializer.

### DIFF
--- a/config/initializers/google_cloud_trace.rb
+++ b/config/initializers/google_cloud_trace.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-require "google/cloud/trace"
+require "google/cloud/trace/rails"
 
 puts "Google::Cloud::Trace enabled." if Google::Cloud.configure.use_trace

--- a/config/initializers/google_cloud_trace.rb
+++ b/config/initializers/google_cloud_trace.rb
@@ -1,15 +1,5 @@
 # frozen_string_literal: true
 
-# Fake google cloud trace in_span method so we don't have to check our environment
-# where we use it
-unless Rails.env.production?
-  module Google
-    module Cloud
-      class Trace
-        def self.in_span(_span_name)
-          yield
-        end
-      end
-    end
-  end
-end
+require "google/cloud/trace"
+
+puts "Google::Cloud::Trace enabled." if Google::Cloud.configure.use_trace


### PR DESCRIPTION
Just realized that there's a `Google::Cloud.configure.use_trace` variable that gets set in the Railtie, and it determines if the middleware is added. Removing the monkeypatch will mean that some real Trace code will run inside `in_span`, but it should no-op anyway.