### PR TITLE
Cloud Trace middleware fix.

### DIFF
--- a/app/middleware/sidekiq/google_cloud_trace_middleware.rb
+++ b/app/middleware/sidekiq/google_cloud_trace_middleware.rb
@@ -157,7 +157,7 @@ module Sidekiq
       span.labels[Google::Cloud::Trace::LabelKey::PID] = ::Process.pid.to_s
       span.labels[Google::Cloud::Trace::LabelKey::TID] = ::Thread.current.object_id.to_s
       if span.trace.trace_context.capture_stack?
-        Google::Cloud::Trace::LabelKey.set_stack_trace labels,
+        Google::Cloud::Trace::LabelKey.set_stack_trace span.labels,
                                                        skip_frames: 3
       end
 


### PR DESCRIPTION
Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/602c1832d301e70017a4c8bd