### PR TITLE
Disable stacktrace in sidekiq middleware, and include job args in span.

### DIFF
--- a/app/middleware/sidekiq/google_cloud_trace_middleware.rb
+++ b/app/middleware/sidekiq/google_cloud_trace_middleware.rb
@@ -163,8 +163,6 @@ module Sidekiq
       if span.trace.trace_context.capture_stack?
         Google::Cloud::Trace::LabelKey.set_stack_trace span.labels,
                                                        skip_frames: 3
-                                                      end
-
       end
 
       span

--- a/app/middleware/sidekiq/google_cloud_trace_middleware.rb
+++ b/app/middleware/sidekiq/google_cloud_trace_middleware.rb
@@ -28,11 +28,13 @@ require "google/cloud/trace"
 #     chain.add Sidekiq::GoogleCloudTraceMiddleware, {}
 #   end
 # end
+
 module Sidekiq
   class GoogleCloudTraceMiddleware
     ##
     # The name of this trace agent as reported to the Stackdriver backend.
     AGENT_NAME = "ruby #{::Google::Cloud::Trace::VERSION}"
+    SIDEKIQ_ARGS_LABEL_KEY = "/sidekiq/args"
 
     def initialize(options = {})
       load_config options
@@ -51,11 +53,12 @@ module Sidekiq
       if @service
         trace = create_trace
         job_name = "sidekiq:#{job['class'].underscore}"
+        job_args = job["args"]
 
         begin
           Google::Cloud::Trace.set trace
           Google::Cloud::Trace.in_span job_name do |span|
-            configure_span span, job_name
+            configure_span span, job_name, job_args
             yield
           end
         ensure
@@ -151,14 +154,17 @@ module Sidekiq
     #     configure.
     # @param [String] The job name to use as this span name.
     #
-    def configure_span(span, job_name)
+    def configure_span(span, job_name, job_args)
       span.name = job_name
       span.labels[Google::Cloud::Trace::LabelKey::AGENT] = AGENT_NAME
       span.labels[Google::Cloud::Trace::LabelKey::PID] = ::Process.pid.to_s
       span.labels[Google::Cloud::Trace::LabelKey::TID] = ::Thread.current.object_id.to_s
+      span.labels[SIDEKIQ_ARGS_LABEL_KEY] = job_args.to_s
       if span.trace.trace_context.capture_stack?
         Google::Cloud::Trace::LabelKey.set_stack_trace span.labels,
-                                                       skip_frames: 3
+                                                       skip_frames: 13
+                                                      end
+
       end
 
       span

--- a/app/middleware/sidekiq/google_cloud_trace_middleware.rb
+++ b/app/middleware/sidekiq/google_cloud_trace_middleware.rb
@@ -162,7 +162,7 @@ module Sidekiq
       span.labels[SIDEKIQ_ARGS_LABEL_KEY] = job_args.to_s
       if span.trace.trace_context.capture_stack?
         Google::Cloud::Trace::LabelKey.set_stack_trace span.labels,
-                                                       skip_frames: 13
+                                                       skip_frames: 3
                                                       end
 
       end

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -126,7 +126,7 @@ module PackageManager
       end
 
       update(name, sync_versions: false)
-      mapped_project=map_project(project(name))
+      mapped_project = map_project(project(name))
       unless mapped_project.present?
         logger.warn("No mapped project for #{db_platform}/#{name}")
         return

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -5,7 +5,7 @@ require 'resolv-replace' # pure ruby DNS
 Sidekiq.configure_server do |config|
   config.redis = { url: ENV["REDISCLOUD_URL"], id: nil }
   config.server_middleware do |chain|
-    chain.add Sidekiq::GoogleCloudTraceMiddleware, capture_stack: true
+    chain.add Sidekiq::GoogleCloudTraceMiddleware, capture_stack: false
   end
 end
 Sidekiq.configure_client do |config|


### PR DESCRIPTION
Just noticed that the stacktrace isn't very useful because it's the trace for the worker being run.

Also seems like knowing the job args would be useful, so including those in each trace too.