### PR TITLE
Ensure we strip versions in PackageManagerDownloadWorker

### DIFF
--- a/app/workers/package_manager_download_worker.rb
+++ b/app/workers/package_manager_download_worker.rb
@@ -62,6 +62,7 @@ class PackageManagerDownloadWorker
           end
 
     platform = PLATFORMS[key]
+    version = version.to_s.strip
     raise "Platform '#{platform_name}' not found" unless platform
 
     # need to maintain compatibility with things that pass in the name of the class under PackageManager module


### PR DESCRIPTION
Found some of these in the `PackageManagerDownloadWorker` logs:

```
2021-02-17T01:52:34.761Z 8 TID-gt7a9aigw WARN: URI::InvalidURIError: bad URI(is not URI?): "https://repo1.maven.org/maven2/io/service84/library/standardservice/ 1.2.0/standardservice- 1.2.0.pom"
```