### PR TITLE
Don't require rubocop by default.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -128,6 +128,6 @@ end
 
 gem "scenic", "~> 1.4"
 
-gem "rubocop", "~> 0.80.1"
+gem "rubocop", "~> 0.80.1", require: false
 
 gem "chartkick", "~> 3.4"

--- a/Gemfile
+++ b/Gemfile
@@ -103,6 +103,7 @@ end
 group :development, :test do
   gem "pry"
   gem "rspec-rails"
+  gem "rubocop", "~> 0.80.1", require: false
 end
 
 group :test do
@@ -128,6 +129,5 @@ end
 
 gem "scenic", "~> 1.4"
 
-gem "rubocop", "~> 0.80.1", require: false
 
 gem "chartkick", "~> 3.4"


### PR DESCRIPTION
Rubocop loads about 20mb into memory, and we don't need it most of the time (especially in production).