### PR TITLE
 PackageManagerDownloadWorker refactor: step 2

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -105,7 +105,7 @@ module PackageManager
       return false unless mapped_project.present?
 
       db_project = Project.find_or_initialize_by({ name: mapped_project[:name], platform: db_platform })
-      db_project.reformat_repository_url unless db_project.new_record?
+      db_project.reformat_repository_url if sync_version == :all && !db_project.new_record?
       db_project.update(mapped_project.except(:name, :releases, :versions, :version, :dependencies, :properties))
 
       if self::HAS_VERSIONS

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -94,7 +94,7 @@ module PackageManager
 
     def self.update(name, sync_version: :all)
       if sync_version != :all && !self::SUPPORTS_SINGLE_VERSION_UPDATE
-        logger.warn("#{db_platform}.update(#{name}, sync_versions: #{sync_version}) called but not supported on platform")
+        logger.warn("#{db_platform}.update(#{name}, sync_version: #{sync_version}) called but not supported on platform")
         return
       end
 

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -99,7 +99,7 @@ module PackageManager
       end
 
       raw_project = project(name)
-      return unless raw_project.present?
+      return false unless raw_project.present?
 
       mapped_project = map_project(raw_project)
       return false unless mapped_project.present?

--- a/app/models/package_manager/go.rb
+++ b/app/models/package_manager/go.rb
@@ -65,8 +65,8 @@ module PackageManager
       }
     end
 
-    def self.update(name, sync_versions: true)
-      super(name, sync_versions: sync_versions)
+    def self.update(name, sync_version: :all)
+      super(name, sync_version: sync_version)
       # call update on base module name if the name is appended with major version
       # example: github.com/myexample/modulename/v2
       update_base_module(name) if name.match(VERSION_MODULE_REGEX)

--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -158,10 +158,14 @@ module PackageManager
       end
     end
 
-    def self.versions(_project, name)
-      xml_metadata = get_raw(MavenUrl.from_name(name, repository_base, NAME_DELIMITER).maven_metadata)
-      xml_versions = Nokogiri::XML(xml_metadata).css("version").map(&:text)
-      retrieve_versions(xml_versions.filter { |item| !item.ends_with?("-SNAPSHOT") }, name)
+    def self.versions(project, name)
+      if project && project[:versions]
+        return project[:versions]
+      else
+        xml_metadata = get_raw(MavenUrl.from_name(name, repository_base, NAME_DELIMITER).maven_metadata)
+        xml_versions = Nokogiri::XML(xml_metadata).css("version").map(&:text)
+        retrieve_versions(xml_versions.filter { |item| !item.ends_with?("-SNAPSHOT") }, name)
+      end
     end
 
     def self.retrieve_versions(versions, name)

--- a/app/workers/package_manager_download_worker.rb
+++ b/app/workers/package_manager_download_worker.rb
@@ -68,7 +68,7 @@ class PackageManagerDownloadWorker
     # need to maintain compatibility with things that pass in the name of the class under PackageManager module
     if platform::SUPPORTS_SINGLE_VERSION_UPDATE && version.present?
       logger.info("Version update for platform=#{key} name=#{name} version=#{version}")
-      platform.update_version(name, version)
+      platform.update(name, sync_version: version)
     else
       logger.info("Package update for platform=#{key} name=#{name}")
       platform.update(name)


### PR DESCRIPTION
This combines the `PackageManager::Base.update` and `PackageManager::Base.update_version` methods because they're doing similar things, and `update_version` was wrapping `update` anyway.

This should also fix an issue with Maven where we fetched all the versions twice (i.e. if a package has 2000 versions, we'll make 4000 requests total). 😬 