### PR TITLE
Get all Wordpress versions if they're available.

### DIFF
--- a/app/models/package_manager/wordpress.rb
+++ b/app/models/package_manager/wordpress.rb
@@ -66,12 +66,23 @@ module PackageManager
     end
 
     def self.versions(project, _name)
-      [
-        {
-          number: project["version"],
-          published_at: project["last_updated"],
-        },
-      ]
+      if project["versions"].present?
+        project["versions"]
+          .reject { |k, _v| k == "trunk" }
+          .map do |k, _v|
+          {
+            number: k,
+            published_at: k == project["version"] ? project["last_updated"] : nil
+          }
+        end
+      else
+        [
+          {
+            number: project["version"],
+            published_at: project["last_updated"],
+          }
+        ]
+      end
     end
   end
 end

--- a/docs/add-a-package-manager.md
+++ b/docs/add-a-package-manager.md
@@ -123,7 +123,7 @@ This method takes the returned data from the `#project` method and should return
 Here's an example from [NuGet](../app/models/package_manager/nu_get.rb):
 
 ```ruby
-def self.versions(project)
+def self.versions(project, _name)
   project[:releases].map do |item|
     {
       number: item['catalogEntry']['version'],

--- a/spec/models/package_manager/wordpress_spec.rb
+++ b/spec/models/package_manager/wordpress_spec.rb
@@ -17,9 +17,21 @@ describe PackageManager::Wordpress do
     end
   end
 
-  describe 'download_url' do
+  describe '.download_url' do
     it 'returns a link to project tarball' do
       expect(described_class.download_url('foo', '1.0.0')).to eq("https://downloads.wordpress.org/plugin/foo.1.0.0.zip")
+    end
+  end
+
+  describe ".versions" do
+    it "returns all versions if present" do
+      expect(described_class.versions({"versions" => {"1" => "uri.zip", "2" => "uri.zip"}}, "foo-package"))
+        .to eq([{number: "1", published_at: nil}, {number: "2", published_at: nil}])
+    end
+
+    it "returns current version only if other versions not present" do
+      expect(described_class.versions({"version" => "0.0.1", "last_updated" => "2021-02-05 11:17am GMT", "versions" => []}, "foo-package"))
+        .to eq([{number: "0.0.1", published_at: "2021-02-05 11:17am GMT"}])
     end
   end
 end


### PR DESCRIPTION
Wordpress JSON urls offer a `versions` key that is sometimes populated. This hasn't been touched in 6 years and I'm not sure why `versions` wasn't fetched before, so the data might've gotten better since then.