### PR TITLE
 PackageManagerDownloadWorker refactor: step 3

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -121,8 +121,6 @@ module PackageManager
 
       save_dependencies(mapped_project) if self::HAS_DEPENDENCIES
       finalize_db_project(db_project)
-    rescue SystemExit, Interrupt
-      exit 0
     rescue StandardError => e
       if ENV["RACK_ENV"] == "production"
         Bugsnag.notify(e)

--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -232,7 +232,7 @@ module PackageManager
         .map(&:last)
     end
 
-    def self.maven_metadata
+    def self.maven_metadata(name)
       get_raw(MavenUrl.from_name(name, repository_base, NAME_DELIMITER).maven_metadata)
     end
 

--- a/spec/fixtures/tidelift-maven_metadata.xml
+++ b/spec/fixtures/tidelift-maven_metadata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>com.tidelift</groupId>
+  <artifactId>test</artifactId>
+  <versioning>
+    <latest>1.0.5</latest>
+    <release>1.0.4</release>
+    <versions>
+      <version>1.0.2</version>
+      <version>1.0.3</version>
+      <version>1.0.4</version>
+      <version>1.0.5</version>
+    </versions>
+    <lastUpdated>20210219100715</lastUpdated>
+  </versioning>
+</metadata>


### PR DESCRIPTION
TL;DR: this fetches the latest version for Maven packages from maven_metadata.xml, instead of fetching all the versions and picking the newest one.

We need to use `latest_version()` for `mapping()`, so we need the latest version AFAIK.

In the next step, we can make `versions()` optional, so we can get project data without making N requests for the versions.

Here's the original commit that started fetching the latest version to use as the project's POM: https://github.com/librariesio/libraries.io/commit/3b77f008b27cd05870b0bb534c1236e0a1213e9d#diff-ac475c62f3e3faba6f62b8831d6d8b85af275fdb812328fd9cfaec0179718e20R39