### PR TITLE
Update Hash usage to Ruby 1.9 symbol syntax.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,7 +24,7 @@ Lint/AmbiguousBlockAssociation:
 # and docs shouldn't be required. add them when needed.
 Metrics/AbcSize:
   Enabled: false
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 Metrics/ClassLength:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -103,7 +103,7 @@ end
 group :development, :test do
   gem "pry"
   gem "rspec-rails"
-  gem "rubocop", "~> 0.80.1", require: false
+  gem "rubocop", "~> 1.0.0", require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,7 @@ GEM
     api-pagination (4.8.2)
     arel (9.0.0)
     asciidoctor (2.0.9)
-    ast (2.4.0)
+    ast (2.4.2)
     autoprefixer-rails (9.5.1.1)
       execjs
     bibliothecary (6.9.7)
@@ -318,7 +318,6 @@ GEM
     indefinite_article (0.2.4)
       activesupport
     ipaddress (0.8.3)
-    jaro_winkler (1.5.4)
     jb (0.8.0)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
@@ -407,9 +406,8 @@ GEM
     os (1.1.1)
     ox (2.14.1)
     parallel (1.17.0)
-    parser (2.7.0.4)
-      ast (~> 2.4.0)
-    parslet (1.8.2)
+    parser (3.0.0.0)
+      ast (~> 2.4.1)
     pg (1.1.4)
     pg_query (1.1.0)
     pghero (2.7.0)
@@ -485,6 +483,7 @@ GEM
     rb-readline (0.5.5)
     rdoc (6.1.1)
     redis (4.1.2)
+    regexp_parser (2.0.3)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -520,17 +519,20 @@ GEM
     rspec-support (3.8.0)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (0.80.1)
-      jaro_winkler (~> 1.5.1)
+    rubocop (1.0.0)
       parallel (~> 1.10)
-      parser (>= 2.7.0.1)
+      parser (>= 2.7.1.5)
       rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8)
       rexml
+      rubocop-ast (>= 0.6.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (1.4.1)
+      parser (>= 2.7.1.5)
     ruby-enum (0.7.2)
       i18n
-    ruby-progressbar (1.10.1)
+    ruby-progressbar (1.11.0)
     ruby_dep (1.5.0)
     rubypants (0.7.0)
     rugged (0.28.1)
@@ -742,7 +744,7 @@ DEPENDENCIES
   rspec-rails
   rspec-sidekiq
   rspec_junit_formatter
-  rubocop (~> 0.80.1)
+  rubocop (~> 1.0.0)
   sanitize-url
   sassc-rails
   scenic (~> 1.4)

--- a/app/controllers/admin/repository_organisations_controller.rb
+++ b/app/controllers/admin/repository_organisations_controller.rb
@@ -43,7 +43,7 @@ class Admin::RepositoryOrganisationsController < Admin::ApplicationController
     @user = RepositoryUser.host(current_host).login(params[:login]).first
     @user = RepositoryOrganisation.host(current_host).login(params[:login]).first if @user.nil?
     raise ActiveRecord::RecordNotFound if @user.nil?
-    redirect_to url_for(login: @user.login), :status => :moved_permanently if params[:login] != @user.login
+    redirect_to url_for(login: @user.login), status: :moved_permanently if params[:login] != @user.login
   end
 
   def user_params

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -211,7 +211,7 @@ class ApplicationController < ActionController::Base
     raise ActiveRecord::RecordNotFound if @repository.nil?
     raise ActiveRecord::RecordNotFound if @repository.status == 'Hidden'
     raise ActiveRecord::RecordNotFound unless authorized?
-    redirect_to url_for(@repository.to_param), :status => :moved_permanently if full_name != @repository.full_name
+    redirect_to url_for(@repository.to_param), status: :moved_permanently if full_name != @repository.full_name
   end
 
   def authorized?

--- a/app/controllers/explore_controller.rb
+++ b/app/controllers/explore_controller.rb
@@ -1,9 +1,9 @@
 class ExploreController < ApplicationController
   def index
-    @platforms = Project.popular_platforms(:facet_limit => 40).first(28)
-    @keywords = Project.popular_keywords(:facet_limit => 40).first(15)
-    @languages = Project.popular_languages(:facet_limit => 40).first(21)
-    @licenses = Project.popular_licenses(:facet_limit => 40).first(10)
+    @platforms = Project.popular_platforms(facet_limit: 40).first(28)
+    @keywords = Project.popular_keywords(facet_limit: 40).first(15)
+    @languages = Project.popular_languages(facet_limit: 40).first(21)
+    @licenses = Project.popular_licenses(facet_limit: 40).first(10)
 
     project_scope = Project.includes(:repository).maintained.with_description
 

--- a/app/controllers/keywords_controller.rb
+++ b/app/controllers/keywords_controller.rb
@@ -1,6 +1,6 @@
 class KeywordsController < ApplicationController
   def index
-    @keywords = Project.popular_keywords(:facet_limit => 160)
+    @keywords = Project.popular_keywords(facet_limit: 160)
   end
 
   def show
@@ -12,7 +12,7 @@ class KeywordsController < ApplicationController
     @popular = scope.order('projects.rank DESC NULLS LAST').limit(5).includes(:repository)
     @dependend = scope.most_dependents.limit(5).includes(:repository)
 
-    facets = Project.facets(filters: {keywords_array: @keyword}, :facet_limit => 10)
+    facets = Project.facets(filters: {keywords_array: @keyword}, facet_limit: 10)
 
     @languages = facets[:languages].language.buckets
     @platforms = facets[:platforms].platform.buckets

--- a/app/controllers/languages_controller.rb
+++ b/app/controllers/languages_controller.rb
@@ -1,6 +1,6 @@
 class LanguagesController < ApplicationController
   def index
-    @languages = Project.popular_languages(:facet_limit => 160)
+    @languages = Project.popular_languages(facet_limit: 160)
   end
 
   def show
@@ -12,7 +12,7 @@ class LanguagesController < ApplicationController
     @dependend = scope.most_dependents.limit(5).includes(:repository)
     @popular = scope.order('projects.rank DESC NULLS LAST').limit(5).includes(:repository)
 
-    facets = Project.facets(filters: { language: @language }, :facet_limit => 10)
+    facets = Project.facets(filters: { language: @language }, facet_limit: 10)
 
     @platforms = facets[:platforms].platform.buckets
     @licenses = facets[:licenses].normalized_licenses.buckets.reject{ |t| t['key'].downcase == 'other' }
@@ -24,6 +24,6 @@ class LanguagesController < ApplicationController
   def find_language
     @language = Linguist::Language[params[:id]].try(:to_s)
     raise ActiveRecord::RecordNotFound if @language.nil?
-    redirect_to language_path(@language), :status => :moved_permanently if @language != params[:id]
+    redirect_to language_path(@language), status: :moved_permanently if @language != params[:id]
   end
 end

--- a/app/controllers/licenses_controller.rb
+++ b/app/controllers/licenses_controller.rb
@@ -1,6 +1,6 @@
 class LicensesController < ApplicationController
   def index
-    @licenses = Project.popular_licenses(:facet_limit => 300)
+    @licenses = Project.popular_licenses(facet_limit: 300)
   end
 
   def show
@@ -11,7 +11,7 @@ class LicensesController < ApplicationController
     @popular = scope.order('projects.rank DESC NULLS LAST').limit(5).includes(:repository)
     @dependend = scope.most_dependents.limit(5).includes(:repository)
 
-    facets = Project.facets(filters: {normalized_licenses: @license.id}, :facet_limit => 10)
+    facets = Project.facets(filters: {normalized_licenses: @license.id}, facet_limit: 10)
 
     @languages = facets[:languages].language.buckets
     @platforms = facets[:platforms].platform.buckets
@@ -23,6 +23,6 @@ class LicensesController < ApplicationController
   def find_license
     @license = Spdx.find(params[:id])
     raise ActiveRecord::RecordNotFound if @license.nil?
-    redirect_to license_path(@license.id), :status => :moved_permanently if @license.id != params[:id]
+    redirect_to license_path(@license.id), status: :moved_permanently if @license.id != params[:id]
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -16,11 +16,11 @@ class PagesController < ApplicationController
   end
 
   def experiments
-    @platforms = Project.popular_platforms(:facet_limit => 40).first(28)
+    @platforms = Project.popular_platforms(facet_limit: 40).first(28)
   end
 
   def data
-    @platforms = Project.popular_platforms(:facet_limit => 40).first(28)
+    @platforms = Project.popular_platforms(facet_limit: 40).first(28)
   end
 
   def terms

--- a/app/controllers/platforms_controller.rb
+++ b/app/controllers/platforms_controller.rb
@@ -13,7 +13,7 @@ class PlatformsController < ApplicationController
 
     @color = @platform.color
 
-    facets = Project.facets(filters: {platform: @platform_name}, :facet_limit => 10)
+    facets = Project.facets(filters: {platform: @platform_name}, facet_limit: 10)
 
     @languages = facets[:languages].language.buckets
     @licenses = facets[:licenses].normalized_licenses.buckets.reject{ |t| t['key'].downcase == 'other' }

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -27,7 +27,7 @@ class ProjectsController < ApplicationController
       @versions = current_user.all_subscribed_versions.where.not(project_id: muted_ids).where.not(published_at: nil).newest_first.includes(project: :versions).paginate(per_page: 20, page: page_number)
       render 'dashboard/home'
     else
-      facets = Project.facets(:facet_limit => 40)
+      facets = Project.facets(facet_limit: 40)
 
       @platforms = facets[:platforms].platform.buckets
     end
@@ -56,9 +56,9 @@ class ProjectsController < ApplicationController
   def show
     if incorrect_case?
       if params[:number].present?
-        return redirect_to(version_path(@project.to_param.merge(number: params[:number])), :status => :moved_permanently)
+        return redirect_to(version_path(@project.to_param.merge(number: params[:number])), status: :moved_permanently)
       else
-        return redirect_to(project_path(@project.to_param), :status => :moved_permanently)
+        return redirect_to(project_path(@project.to_param), status: :moved_permanently)
       end
     end
     find_version
@@ -90,7 +90,7 @@ class ProjectsController < ApplicationController
 
   def versions
     if incorrect_case?
-      return redirect_to(project_versions_path(@project.to_param), :status => :moved_permanently)
+      return redirect_to(project_versions_path(@project.to_param), status: :moved_permanently)
     else
       @versions = @project.versions.sort.paginate(page: page_number)
       respond_to do |format|
@@ -102,7 +102,7 @@ class ProjectsController < ApplicationController
 
   def tags
     if incorrect_case?
-      return redirect_to(project_tags_path(@project.to_param), :status => :moved_permanently)
+      return redirect_to(project_tags_path(@project.to_param), status: :moved_permanently)
     else
       if @project.repository.nil?
         @tags = []

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -10,7 +10,7 @@ class RepositoriesController < ApplicationController
     @created = repo_search('created_at')
     @updated = repo_search('updated_at')
 
-    facets = Repository.facets(filters: {language: current_language, license: current_license, keywords: current_keywords, host_type: formatted_host}, :facet_limit => 20)
+    facets = Repository.facets(filters: {language: current_language, license: current_license, keywords: current_keywords, host_type: formatted_host}, facet_limit: 20)
 
     @host_types = facets[:host_type].host_type.buckets
     @languages = facets[:language].language.buckets
@@ -32,7 +32,7 @@ class RepositoriesController < ApplicationController
   end
 
   def languages
-    @languages = Repository.search('', :facet_limit => 150).response.aggregations[:language].language.buckets
+    @languages = Repository.search('', facet_limit: 150).response.aggregations[:language].language.buckets
   end
 
   def hacker_news

--- a/app/controllers/repository_users_controller.rb
+++ b/app/controllers/repository_users_controller.rb
@@ -52,7 +52,7 @@ class RepositoryUsersController < ApplicationController
     @user = RepositoryUser.host(current_host).visible.login(params[:login]).first
     @user = RepositoryOrganisation.host(current_host).visible.login(params[:login]).first if @user.nil?
     raise ActiveRecord::RecordNotFound if @user.nil?
-    redirect_to url_for(login: @user.login), :status => :moved_permanently if params[:login] != @user.login
+    redirect_to url_for(login: @user.login), status: :moved_permanently if params[:login] != @user.login
   end
 
   def find_contributions

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -189,7 +189,7 @@ module ApplicationHelper
       options, collection_or_options = collection_or_options, nil
     end
     unless options[:renderer]
-      options = options.merge :renderer => BootstrapPagination::Rails
+      options = options.merge renderer: BootstrapPagination::Rails
     end
     super(*[collection_or_options, options].compact)
   end

--- a/app/models/concerns/issue_search.rb
+++ b/app/models/concerns/issue_search.rb
@@ -10,21 +10,21 @@ module IssueSearch
 
     settings index: { number_of_shards: 3, number_of_replicas: 1 } do
       mapping do
-        indexes :title, type: 'string', :analyzer => 'snowball', :boost => 6
+        indexes :title, type: 'string', analyzer: 'snowball', boost: 6
 
         indexes :created_at, type: 'date'
         indexes :contributions_count, type: 'integer'
         indexes :rank, type: 'integer'
         indexes :comments_count, type: 'integer'
 
-        indexes :language, type: 'string', :analyzer => 'keyword'
-        indexes :license, type: 'string', :analyzer => 'keyword'
+        indexes :language, type: 'string', analyzer: 'keyword'
+        indexes :license, type: 'string', analyzer: 'keyword'
 
         indexes :locked, type: 'boolean'
-        indexes :labels, type: 'string', :analyzer => 'keyword'
-        indexes :state, type: 'string', :analyzer => 'keyword'
+        indexes :labels, type: 'string', analyzer: 'keyword'
+        indexes :state, type: 'string', analyzer: 'keyword'
 
-        indexes :host_type, type: 'string', :index => :not_analyzed
+        indexes :host_type, type: 'string', index: :not_analyzed
       end
     end
 

--- a/app/models/concerns/project_search.rb
+++ b/app/models/concerns/project_search.rb
@@ -10,20 +10,20 @@ module ProjectSearch
 
     settings index: { number_of_shards: 3, number_of_replicas: 1 } do
       mapping do
-        indexes :name, type: 'string', :analyzer => 'snowball', :boost => 6
-        indexes :exact_name, type: 'string', :index => :not_analyzed, :boost => 2
-        indexes :extra_searchable_names, type: 'string', :index => :not_analyzed, :boost => 2
+        indexes :name, type: 'string', analyzer: 'snowball', boost: 6
+        indexes :exact_name, type: 'string', index: :not_analyzed, boost: 2
+        indexes :extra_searchable_names, type: 'string', index: :not_analyzed, boost: 2
 
-        indexes :description, type: 'string', :analyzer => 'snowball'
+        indexes :description, type: 'string', analyzer: 'snowball'
         indexes :homepage, type: 'string'
         indexes :repository_url, type: 'string'
         indexes :repo_name, type: 'string'
-        indexes :latest_release_number, type: 'string', :analyzer => 'keyword'
-        indexes :keywords_array, type: 'string', :analyzer => 'keyword'
-        indexes :language, type: 'string', :analyzer => 'keyword'
-        indexes :normalized_licenses, type: 'string', :analyzer => 'keyword'
-        indexes :platform, type: 'string', :analyzer => 'keyword'
-        indexes :status, type: 'string', :index => :not_analyzed
+        indexes :latest_release_number, type: 'string', analyzer: 'keyword'
+        indexes :keywords_array, type: 'string', analyzer: 'keyword'
+        indexes :language, type: 'string', analyzer: 'keyword'
+        indexes :normalized_licenses, type: 'string', analyzer: 'keyword'
+        indexes :platform, type: 'string', analyzer: 'keyword'
+        indexes :status, type: 'string', index: :not_analyzed
 
         indexes :created_at, type: 'date'
         indexes :updated_at, type: 'date'
@@ -76,7 +76,7 @@ module ProjectSearch
     end
 
     def self.facets(options = {})
-      Rails.cache.fetch "facet:#{options.to_s.gsub(/\W/, '')}", :expires_in => 1.hour, race_condition_ttl: 2.minutes do
+      Rails.cache.fetch "facet:#{options.to_s.gsub(/\W/, '')}", expires_in: 1.hour, race_condition_ttl: 2.minutes do
         search('', options).response.aggregations
       end
     end

--- a/app/models/concerns/repo_search.rb
+++ b/app/models/concerns/repo_search.rb
@@ -10,17 +10,17 @@ module RepoSearch
 
     settings index: { number_of_shards: 3, number_of_replicas: 1 } do
       mapping do
-        indexes :full_name, type: 'string', :analyzer => 'snowball', :boost => 6
-        indexes :exact_name, type: 'string', :index => :not_analyzed, :boost => 2
+        indexes :full_name, type: 'string', analyzer: 'snowball', boost: 6
+        indexes :exact_name, type: 'string', index: :not_analyzed, boost: 2
 
-        indexes :description, type: 'string', :analyzer => 'snowball'
+        indexes :description, type: 'string', analyzer: 'snowball'
         indexes :homepage, type: 'string'
-        indexes :language, type: 'string', :index => :not_analyzed
-        indexes :license, type: 'string', :index => :not_analyzed
-        indexes :keywords, type: 'string', :index => :not_analyzed
-        indexes :host_type, type: 'string', :index => :not_analyzed
+        indexes :language, type: 'string', index: :not_analyzed
+        indexes :license, type: 'string', index: :not_analyzed
+        indexes :keywords, type: 'string', index: :not_analyzed
+        indexes :host_type, type: 'string', index: :not_analyzed
 
-        indexes :status, type: 'string', :index => :not_analyzed
+        indexes :status, type: 'string', index: :not_analyzed
 
         indexes :created_at, type: 'date'
         indexes :updated_at, type: 'date'
@@ -42,7 +42,7 @@ module RepoSearch
     after_commit lambda { __elasticsearch__.delete_document rescue nil },  on: :destroy
 
     def self.facets(options = {})
-      Rails.cache.fetch "repo_facet:#{options.to_s.gsub(/\W/, '')}", :expires_in => 1.hour, race_condition_ttl: 2.minutes do
+      Rails.cache.fetch "repo_facet:#{options.to_s.gsub(/\W/, '')}", expires_in: 1.hour, race_condition_ttl: 2.minutes do
         search('', options).response.aggregations
       end
     end

--- a/app/models/package_manager/alcatraz.rb
+++ b/app/models/package_manager/alcatraz.rb
@@ -29,9 +29,9 @@ module PackageManager
 
     def self.mapping(project)
       {
-        :name => project["name"],
-        :description => project["description"],
-        :repository_url => project['url']
+        name: project["name"],
+        description: project["description"],
+        repository_url: project['url']
       }
     end
   end

--- a/app/models/package_manager/bower.rb
+++ b/app/models/package_manager/bower.rb
@@ -35,12 +35,12 @@ module PackageManager
     def self.mapping(project)
       bower_json = load_bower_json(project) || project
       {
-        :name => project["name"],
-        :repository_url => project["url"],
-        :licenses => bower_json['license'],
-        :keywords_array => bower_json['keywords'],
-        :homepage => bower_json["homepage"],
-        :description => bower_json["description"]
+        name: project["name"],
+        repository_url: project["url"],
+        licenses: bower_json['license'],
+        keywords_array: bower_json['keywords'],
+        homepage: bower_json["homepage"],
+        description: bower_json["description"]
       }
     end
 

--- a/app/models/package_manager/carthage.rb
+++ b/app/models/package_manager/carthage.rb
@@ -42,12 +42,12 @@ module PackageManager
 
     def self.mapping(project)
       {
-        :name => project[:full_name],
-        :description => project[:description],
-        :homepage => project[:homepage],
-        :keywords_array => project[:topics],
-        :licenses => (project.fetch(:license, {}) || {})[:key],
-        :repository_url => project[:html_url]
+        name: project[:full_name],
+        description: project[:description],
+        homepage: project[:homepage],
+        keywords_array: project[:topics],
+        licenses: (project.fetch(:license, {}) || {})[:key],
+        repository_url: project[:html_url]
       }
     end
   end

--- a/app/models/package_manager/emacs.rb
+++ b/app/models/package_manager/emacs.rb
@@ -28,10 +28,10 @@ module PackageManager
 
     def self.mapping(project)
       {
-        :name => project["name"],
-        :description => project["desc"],
-        :repository_url => project.fetch("props", {}).try(:fetch, 'url', ''),
-        :keywords_array => Array.wrap(project.fetch("props", {}).try(:fetch, 'keywords', []))
+        name: project["name"],
+        description: project["desc"],
+        repository_url: project.fetch("props", {}).try(:fetch, 'url', ''),
+        keywords_array: Array.wrap(project.fetch("props", {}).try(:fetch, 'keywords', []))
       }
     end
   end

--- a/app/models/package_manager/inqlude.rb
+++ b/app/models/package_manager/inqlude.rb
@@ -26,11 +26,11 @@ module PackageManager
 
     def self.mapping(project)
       {
-        :name => project['name'],
-        :description => project["summary"],
-        :homepage => project["urls"]["homepage"],
-        :licenses => project['licenses'].join(','),
-        :repository_url => repo_fallback(project["urls"]["vcs"], '')
+        name: project['name'],
+        description: project["summary"],
+        homepage: project["urls"]["homepage"],
+        licenses: project['licenses'].join(','),
+        repository_url: repo_fallback(project["urls"]["vcs"], '')
       }
     end
   end

--- a/app/models/package_manager/nimble.rb
+++ b/app/models/package_manager/nimble.rb
@@ -31,12 +31,12 @@ module PackageManager
 
     def self.mapping(project)
       {
-        :name => project["name"],
-        :description => project["description"],
-        :repository_url => repo_fallback(project['url'],project['web']),
-        :keywords_array => Array.wrap(project["tags"]),
-        :licenses => project['license'],
-        :homepage => project['web']
+        name: project["name"],
+        description: project["description"],
+        repository_url: repo_fallback(project['url'],project['web']),
+        keywords_array: Array.wrap(project["tags"]),
+        licenses: project['license'],
+        homepage: project['web']
       }
     end
   end

--- a/app/models/package_manager/pure_script.rb
+++ b/app/models/package_manager/pure_script.rb
@@ -19,8 +19,8 @@ module PackageManager
 
     def self.mapping(project)
       {
-        :name => project['name'],
-        :repository_url => project['repo']
+        name: project['name'],
+        repository_url: project['repo']
       }
     end
 

--- a/app/models/package_manager/shards.rb
+++ b/app/models/package_manager/shards.rb
@@ -21,8 +21,8 @@ module PackageManager
 
     def self.mapping(project)
       {
-        :name => project["name"],
-        :repository_url => repo_fallback(project["url"], nil)
+        name: project["name"],
+        repository_url: repo_fallback(project["url"], nil)
       }
     end
   end

--- a/app/models/package_manager/swift_pm.rb
+++ b/app/models/package_manager/swift_pm.rb
@@ -20,8 +20,8 @@ module PackageManager
 
     def self.mapping(project)
       {
-        :name => project[:name],
-        :repository_url => project[:repository_url]
+        name: project[:name],
+        repository_url: project[:repository_url]
       }
     end
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -134,7 +134,7 @@ class Project < ApplicationRecord
   after_create :destroy_deleted_project
 
   def self.total
-    Rails.cache.fetch 'projects:total', :expires_in => 1.day, race_condition_ttl: 2.minutes do
+    Rails.cache.fetch 'projects:total', expires_in: 1.day, race_condition_ttl: 2.minutes do
       self.all.count
     end
   end
@@ -251,7 +251,7 @@ class Project < ApplicationRecord
   end
 
   def mlt_ids
-    Rails.cache.fetch "projects:#{self.id}:mlt_ids", :expires_in => 1.week do
+    Rails.cache.fetch "projects:#{self.id}:mlt_ids", expires_in: 1.week do
       results = Project.__elasticsearch__.client.mlt(id: self.id, index: 'projects', type: 'project', mlt_fields: 'keywords_array,platform,description,repository_url', min_term_freq: 1, min_doc_freq: 2)
       results['hits']['hits'].map{|h| h['_id']}
     end

--- a/app/models/recommendable.rb
+++ b/app/models/recommendable.rb
@@ -8,7 +8,7 @@ module Recommendable
   end
 
   def recommended_project_ids
-    Rails.cache.fetch "recommendations:#{self.id}", :expires_in => 1.day do
+    Rails.cache.fetch "recommendations:#{self.id}", expires_in: 1.day do
       ids = favourite_recommendation_ids + most_depended_on_recommendation_ids + most_watched_recommendation_ids
       sort_array_by_frequency(ids)
     end

--- a/app/models/repository_host/github.rb
+++ b/app/models/repository_host/github.rb
@@ -64,7 +64,7 @@ module RepositoryHost
     end
 
     def get_file_list(token = nil)
-      tree = api_client(token).tree(repository.full_name, repository.default_branch, :recursive => true).tree
+      tree = api_client(token).tree(repository.full_name, repository.default_branch, recursive: true).tree
       tree.select{|item| item.type == 'blob' }.map{|file| file.path }
     rescue *IGNORABLE_EXCEPTIONS
       nil
@@ -87,12 +87,12 @@ module RepositoryHost
         repository.full_name,
         'web',
         {
-          :url => 'https://libraries.io/hooks/github',
-          :content_type => 'json'
+          url: 'https://libraries.io/hooks/github',
+          content_type: 'json'
         },
         {
-          :events => ['push', 'pull_request'],
-          :active => true
+          events: ['push', 'pull_request'],
+          active: true
         }
       )
     rescue Octokit::UnprocessableEntity

--- a/app/models/repository_owner/base.rb
+++ b/app/models/repository_owner/base.rb
@@ -118,13 +118,13 @@ module RepositoryOwner
     private
 
     def top_favourite_project_ids
-      Rails.cache.fetch [owner, "top_favourite_project_ids"], :expires_in => 1.week, race_condition_ttl: 2.minutes do
+      Rails.cache.fetch [owner, "top_favourite_project_ids"], expires_in: 1.week, race_condition_ttl: 2.minutes do
         owner.favourite_projects.limit(10).pluck(:id)
       end
     end
 
     def top_contributor_ids
-      Rails.cache.fetch [owner, "top_contributor_ids"], :expires_in => 1.week, race_condition_ttl: 2.minutes do
+      Rails.cache.fetch [owner, "top_contributor_ids"], expires_in: 1.week, race_condition_ttl: 2.minutes do
         owner.contributors.visible.limit(50).pluck(:id)
       end
     end

--- a/app/models/repository_tree_resolver.rb
+++ b/app/models/repository_tree_resolver.rb
@@ -32,7 +32,7 @@ class RepositoryTreeResolver
   end
 
   def load_dependencies_tree
-    tree_data = Rails.cache.fetch cache_key, :expires_in => 1.day, race_condition_ttl: 2.minutes do
+    tree_data = Rails.cache.fetch cache_key, expires_in: 1.day, race_condition_ttl: 2.minutes do
       generate_dependency_tree
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,8 +36,8 @@ class User < ApplicationRecord
 
   after_commit :update_repo_permissions_async, :download_self, :create_api_key, on: :create
 
-  validates_presence_of :email, :on => :update
-  validates_format_of :email, :with => /\A[^@\s]+@([^@\s]+\.)+[^@\s]+\z/, :on => :update
+  validates_presence_of :email, on: :update
+  validates_format_of :email, with: /\A[^@\s]+@([^@\s]+\.)+[^@\s]+\z/, on: :update
 
   def assign_from_auth_hash(hash)
     return unless new_record?

--- a/app/models/web_hook.rb
+++ b/app/models/web_hook.rb
@@ -2,7 +2,7 @@ class WebHook < ApplicationRecord
   belongs_to :repository
   belongs_to :user
   validates_presence_of :url
-  validates :url, :format => URI::regexp(%w(http https))
+  validates :url, format: URI::regexp(%w(http https))
 
   before_save :clear_timestamps
 

--- a/app/views/dashboard/home.atom.builder
+++ b/app/views/dashboard/home.atom.builder
@@ -6,7 +6,7 @@ atom_feed do |feed|
     feed.entry(version, url: version_url(version.to_param)) do |entry|
       entry.title "#{version.project.name} - #{version.number}"
       entry.published Time.at(version.published_at).rfc822
-      entry.content "", :type => "html"
+      entry.content "", type: "html"
       entry.author do |author|
         author.name('Libraries.io')
       end

--- a/app/views/projects/tags.atom.builder
+++ b/app/views/projects/tags.atom.builder
@@ -6,7 +6,7 @@ atom_feed do |feed|
     feed.entry(tag, url: version_url(@project.to_param.merge(number: tag.name))) do |entry|
       entry.title(tag.number)
       entry.published Time.at(tag.published_at).rfc822
-      entry.content "", :type => "html"
+      entry.content "", type: "html"
       entry.author do |author|
         author.name('Libraries.io')
       end

--- a/app/views/projects/versions.atom.builder
+++ b/app/views/projects/versions.atom.builder
@@ -6,7 +6,7 @@ atom_feed do |feed|
     feed.entry(version, url: version_url(version.to_param)) do |entry|
       entry.title(version.number)
       entry.published Time.at(version.published_at).rfc822
-      entry.content "", :type => "html"
+      entry.content "", type: "html"
       entry.author do |author|
         author.name('Libraries.io')
       end

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,7 +47,7 @@ module Libraries
 
     config.exceptions_app = routes
 
-    Rails::Timeago.default_options :limit => proc { 60.days.ago }, :nojs => true, :format => proc { |time, options| time.strftime('%b %e, %Y') }
+    Rails::Timeago.default_options limit: proc { 60.days.ago }, nojs: true, format: proc { |time, options| time.strftime('%b %e, %Y') }
 
     # GC::Profiler.enable
 
@@ -58,9 +58,9 @@ module Libraries
       allow do
         origins '*'
         resource /^\/api\/.+/,
-          :headers => :any,
-          :methods => [:get, :post, :patch, :put, :delete, :options, :head],
-          :max_age => 86400
+          headers: :any,
+          methods: [:get, :post, :patch, :put, :delete, :options, :head],
+          max_age: 86400
       end
     end
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,7 +56,7 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
 
   # default mail links to https
-  config.action_mailer.default_url_options = { :protocol => 'https' }
+  config.action_mailer.default_url_options = { protocol: 'https' }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
@@ -82,12 +82,12 @@ Rails.application.configure do
 
   config.cache_store = :dalli_store,
                     (ENV["MEMCACHIER_SERVERS"] || "").split(","),
-                    {:username => ENV["MEMCACHIER_USERNAME"],
-                     :password => ENV["MEMCACHIER_PASSWORD"],
-                     :failover => true,
-                     :compress => true,
-                     :socket_timeout => 0.5,
-                     :socket_failure_delay => 0.1
+                    {username: ENV["MEMCACHIER_USERNAME"],
+                     password: ENV["MEMCACHIER_PASSWORD"],
+                     failover: true,
+                     compress: true,
+                     socket_timeout: 0.5,
+                     socket_failure_delay: 0.1
                     }
   config.action_mailer.smtp_settings = {
     address:              'smtp.sendgrid.net',

--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -7,13 +7,13 @@ limit_proc = proc do |req|
   end
 end
 
-Rack::Attack.throttle('api', :limit => limit_proc, :period => 1.minute) do |req|
+Rack::Attack.throttle('api', limit: limit_proc, period: 1.minute) do |req|
   if req.path.match(/^\/api\/.+/) && !req.path.match(/^\/api\/bower-search/)
     req.params['api_key'] || req.ip
   end
 end
 
 # throttle scraping
-Rack::Attack.throttle('scrapers', :limit => 30, :period => 5.minutes) do |req|
+Rack::Attack.throttle('scrapers', limit: 30, period: 5.minutes) do |req|
   req.remote_ip if req.user_agent && req.user_agent.match(/Scrapy.*/)
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,9 +45,9 @@ Rails.application.routes.draw do
       get '/:host_type/:login/repositories', to: 'repository_users#repositories'
       get '/:host_type/:login/projects', to: 'repository_users#projects'
 
-      get '/:host_type/:owner/:name/dependencies', to: 'repositories#dependencies', constraints: { :name => /[^\/]+/ }
-      get '/:host_type/:owner/:name/projects', to: 'repositories#projects', constraints: { :name => /[^\/]+/ }
-      get '/:host_type/:owner/:name', to: 'repositories#show', constraints: { :name => /[^\/]+/ }
+      get '/:host_type/:owner/:name/dependencies', to: 'repositories#dependencies', constraints: { name: /[^\/]+/ }
+      get '/:host_type/:owner/:name/projects', to: 'repositories#projects', constraints: { name: /[^\/]+/ }
+      get '/:host_type/:owner/:name', to: 'repositories#show', constraints: { name: /[^\/]+/ }
 
       get '/:host_type/:login', to: 'repository_users#show'
     end
@@ -56,19 +56,19 @@ Rails.application.routes.draw do
     PROJECT_CONSTRAINT = /[^\/]+/
     VERSION_CONSTRAINT = /[\w\.\-]+/
 
-    put '/maintenance/stats/enqueue/:platform/:name', as: :maintenance_stat_enqueue, to: 'maintenance_stats#enqueue', constraints: { :platform => PLATFORM_CONSTRAINT, :name => PROJECT_CONSTRAINT }
+    put '/maintenance/stats/enqueue/:platform/:name', as: :maintenance_stat_enqueue, to: 'maintenance_stats#enqueue', constraints: { platform: PLATFORM_CONSTRAINT, name: PROJECT_CONSTRAINT }
     post '/maintenance/stats/begin/bulk', to: 'maintenance_stats#begin_watching_bulk'
-    get '/maintenance/stats/begin/:platform/:name', to: 'maintenance_stats#begin_watching', constraints: { :platform => PLATFORM_CONSTRAINT, :name => PROJECT_CONSTRAINT }
+    get '/maintenance/stats/begin/:platform/:name', to: 'maintenance_stats#begin_watching', constraints: { platform: PLATFORM_CONSTRAINT, name: PROJECT_CONSTRAINT }
 
-    get '/:platform/:name/usage', to: 'project_usage#show', as: :project_usage, constraints: { :platform => PLATFORM_CONSTRAINT, :name => PROJECT_CONSTRAINT }
-    get '/:platform/:name/sourcerank', to: 'projects#sourcerank', constraints: { :platform => PLATFORM_CONSTRAINT, :name => PROJECT_CONSTRAINT }
-    get '/:platform/:name/contributors', to: 'projects#contributors', constraints: { :platform => PLATFORM_CONSTRAINT, :name => PROJECT_CONSTRAINT }
-    get '/:platform/:name/:version/tree', to: 'tree#show', constraints: { :platform => /[\w\-]+/, :name => PROJECT_CONSTRAINT, :version => VERSION_CONSTRAINT }, as: :version_tree
-    get '/:platform/:name/:version/dependencies', to: 'projects#dependencies', constraints: { :platform => PLATFORM_CONSTRAINT, :name => PROJECT_CONSTRAINT, :version => VERSION_CONSTRAINT }
-    get '/:platform/:name/dependent_repositories', to: 'projects#dependent_repositories', constraints: { :platform => PLATFORM_CONSTRAINT, :name => PROJECT_CONSTRAINT }
-    get '/:platform/:name/dependents', to: 'projects#dependents', constraints: { :platform => PLATFORM_CONSTRAINT, :name => PROJECT_CONSTRAINT }
-    get '/:platform/:name/tree', to: 'tree#show', constraints: { :platform => PLATFORM_CONSTRAINT, :name => PROJECT_CONSTRAINT }, as: :tree
-    get '/:platform/:name', to: 'projects#show', constraints: { :platform => PLATFORM_CONSTRAINT, :name => PROJECT_CONSTRAINT }
+    get '/:platform/:name/usage', to: 'project_usage#show', as: :project_usage, constraints: { platform: PLATFORM_CONSTRAINT, name: PROJECT_CONSTRAINT }
+    get '/:platform/:name/sourcerank', to: 'projects#sourcerank', constraints: { platform: PLATFORM_CONSTRAINT, name: PROJECT_CONSTRAINT }
+    get '/:platform/:name/contributors', to: 'projects#contributors', constraints: { platform: PLATFORM_CONSTRAINT, name: PROJECT_CONSTRAINT }
+    get '/:platform/:name/:version/tree', to: 'tree#show', constraints: { platform: /[\w\-]+/, name: PROJECT_CONSTRAINT, version: VERSION_CONSTRAINT }, as: :version_tree
+    get '/:platform/:name/:version/dependencies', to: 'projects#dependencies', constraints: { platform: PLATFORM_CONSTRAINT, name: PROJECT_CONSTRAINT, version: VERSION_CONSTRAINT }
+    get '/:platform/:name/dependent_repositories', to: 'projects#dependent_repositories', constraints: { platform: PLATFORM_CONSTRAINT, name: PROJECT_CONSTRAINT }
+    get '/:platform/:name/dependents', to: 'projects#dependents', constraints: { platform: PLATFORM_CONSTRAINT, name: PROJECT_CONSTRAINT }
+    get '/:platform/:name/tree', to: 'tree#show', constraints: { platform: PLATFORM_CONSTRAINT, name: PROJECT_CONSTRAINT }, as: :tree
+    get '/:platform/:name', to: 'projects#show', constraints: { platform: PLATFORM_CONSTRAINT, name: PROJECT_CONSTRAINT }
   end
 
   namespace :admin do
@@ -135,9 +135,9 @@ Rails.application.routes.draw do
   match '/422', to: 'errors#unprocessable', via: :all
   match '/500', to: 'errors#internal', via: :all
 
-  resources :licenses, constraints: { :id => /.*/ }, :defaults => { :format => 'html' }
+  resources :licenses, constraints: { id: /.*/ }, defaults: { format: 'html' }
   resources :languages
-  resources :keywords, constraints: { :id => /.*/ }, :defaults => { :format => 'html' }
+  resources :keywords, constraints: { id: /.*/ }, defaults: { format: 'html' }
   resources :subscriptions
   resources :repository_subscriptions
   get '/subscribe/:project_id', to: 'subscriptions#subscribe', as: :subscribe
@@ -162,22 +162,22 @@ Rails.application.routes.draw do
     post '/:host_type/:login/sync', to: 'repository_users#sync', as: :sync_user
     get '/:host_type/:login', to: 'repository_users#show', as: :user
 
-    get '/:host_type/:owner/:name', to: 'repositories#show', as: :repository, :defaults => { :format => 'html' }, constraints: { :name => /[\w\.\-\%]+/ }
-    get '/:host_type/:owner/:name/contributors', to: 'repositories#contributors', as: :repository_contributors, format: false, constraints: { :name => /[^\/]+/ }
-    post '/:host_type/:owner/:name/sync', to: 'repositories#sync', as: :sync_repository, format: false, constraints: { :name => /[^\/]+/ }
-    get '/:host_type/:owner/:name/sourcerank', to: 'repositories#sourcerank', as: :repository_sourcerank, format: false, constraints: { :name => /[^\/]+/ }
-    get '/:host_type/:owner/:name/forks', to: 'repositories#forks', as: :repository_forks, format: false, constraints: { :name => /[^\/]+/ }
-    get '/:host_type/:owner/:name/tags', to: 'repositories#tags', as: :repository_tags, format: false, constraints: { :name => /[^\/]+/ }
-    get '/:host_type/:owner/:name/dependencies', to: 'repositories#dependencies', format: false, constraints: { :name => /[^\/]+/ }, as: :repository_dependencies
-    get '/:host_type/:owner/:name/tree', to: 'repository_tree#show', as: :repository_tree, format: false, constraints: { :name => /[^\/]+/ }
+    get '/:host_type/:owner/:name', to: 'repositories#show', as: :repository, defaults: { format: 'html' }, constraints: { name: /[\w\.\-\%]+/ }
+    get '/:host_type/:owner/:name/contributors', to: 'repositories#contributors', as: :repository_contributors, format: false, constraints: { name: /[^\/]+/ }
+    post '/:host_type/:owner/:name/sync', to: 'repositories#sync', as: :sync_repository, format: false, constraints: { name: /[^\/]+/ }
+    get '/:host_type/:owner/:name/sourcerank', to: 'repositories#sourcerank', as: :repository_sourcerank, format: false, constraints: { name: /[^\/]+/ }
+    get '/:host_type/:owner/:name/forks', to: 'repositories#forks', as: :repository_forks, format: false, constraints: { name: /[^\/]+/ }
+    get '/:host_type/:owner/:name/tags', to: 'repositories#tags', as: :repository_tags, format: false, constraints: { name: /[^\/]+/ }
+    get '/:host_type/:owner/:name/dependencies', to: 'repositories#dependencies', format: false, constraints: { name: /[^\/]+/ }, as: :repository_dependencies
+    get '/:host_type/:owner/:name/tree', to: 'repository_tree#show', as: :repository_tree, format: false, constraints: { name: /[^\/]+/ }
 
-    get '/:host_type/:owner/:name/web_hooks', to: 'web_hooks#index', as: :repository_web_hooks, format: false, constraints: { :name => /[^\/]+/ }
-    get '/:host_type/:owner/:name/web_hooks/new', to: 'web_hooks#new', as: :new_repository_web_hook, format: false, constraints: { :name => /[^\/]+/ }
-    delete '/:host_type/:owner/:name/web_hooks/:id', to: 'web_hooks#destroy', as: :repository_web_hook, format: false, constraints: { :name => /[^\/]+/ }
-    patch '/:host_type/:owner/:name/web_hooks/:id', to: 'web_hooks#update', format: false, constraints: { :name => /[^\/]+/ }
-    get '/:host_type/:owner/:name/web_hooks/:id/edit', to: 'web_hooks#edit', as: :edit_repository_web_hook, format: false, constraints: { :name => /[^\/]+/ }
-    post '/:host_type/:owner/:name/web_hooks/:id/test', to: 'web_hooks#test', as: :test_repository_web_hook, format: false, constraints: { :name => /[^\/]+/ }
-    post '/:host_type/:owner/:name/web_hooks', to: 'web_hooks#create', format: false, constraints: { :name => /[^\/]+/ }
+    get '/:host_type/:owner/:name/web_hooks', to: 'web_hooks#index', as: :repository_web_hooks, format: false, constraints: { name: /[^\/]+/ }
+    get '/:host_type/:owner/:name/web_hooks/new', to: 'web_hooks#new', as: :new_repository_web_hook, format: false, constraints: { name: /[^\/]+/ }
+    delete '/:host_type/:owner/:name/web_hooks/:id', to: 'web_hooks#destroy', as: :repository_web_hook, format: false, constraints: { name: /[^\/]+/ }
+    patch '/:host_type/:owner/:name/web_hooks/:id', to: 'web_hooks#update', format: false, constraints: { name: /[^\/]+/ }
+    get '/:host_type/:owner/:name/web_hooks/:id/edit', to: 'web_hooks#edit', as: :edit_repository_web_hook, format: false, constraints: { name: /[^\/]+/ }
+    post '/:host_type/:owner/:name/web_hooks/:id/test', to: 'web_hooks#test', as: :test_repository_web_hook, format: false, constraints: { name: /[^\/]+/ }
+    post '/:host_type/:owner/:name/web_hooks', to: 'web_hooks#create', format: false, constraints: { name: /[^\/]+/ }
 
     get '/:host_type', to: 'repositories#index', as: :hosts
   end
@@ -217,35 +217,35 @@ Rails.application.routes.draw do
 
   post '/hooks/package', to: 'hooks#package'
 
-  get '/:platform/:name/suggestions', to: 'project_suggestions#new', as: :project_suggestions, constraints: { :name => /.*/ }
-  post '/:platform/:name/suggestions', to: 'project_suggestions#create', constraints: { :name => /.*/ }
+  get '/:platform/:name/suggestions', to: 'project_suggestions#new', as: :project_suggestions, constraints: { name: /.*/ }
+  post '/:platform/:name/suggestions', to: 'project_suggestions#create', constraints: { name: /.*/ }
 
   # project routes
-  get '/:platform/:name/top_dependent_repos', to: 'projects#top_dependent_repos', as: :top_dependent_repos, constraints: { :name => /.*/ }, :defaults => { :format => 'html' }
-  get '/:platform/:name/top_dependent_projects', to: 'projects#top_dependent_projects', as: :top_dependent_projects, constraints: { :name => /.*/ }, :defaults => { :format => 'html' }
-  get '/:platform/:name/:number/dependencies', to: 'projects#dependencies', constraints: { :number => /.*/, :name => /.*/ }, as: :version_dependencies
+  get '/:platform/:name/top_dependent_repos', to: 'projects#top_dependent_repos', as: :top_dependent_repos, constraints: { name: /.*/ }, defaults: { format: 'html' }
+  get '/:platform/:name/top_dependent_projects', to: 'projects#top_dependent_projects', as: :top_dependent_projects, constraints: { name: /.*/ }, defaults: { format: 'html' }
+  get '/:platform/:name/:number/dependencies', to: 'projects#dependencies', constraints: { number: /.*/, name: /.*/ }, as: :version_dependencies
 
-  post '/:platform/:name/sync', to: 'projects#sync', constraints: { :name => /.*/ }, as: :sync_project
-  post '/:platform/:name/refresh-stats', to: 'projects#refresh_stats', constraints: { :name => /.*/ }, as: :project_refresh_stats
-  get '/:platform/:name/unsubscribe', to: 'projects#unsubscribe', constraints: { :name => /.*/ }, as: :unsubscribe_project
-  get '/:platform/:name/usage', to: 'project_usage#show', as: :project_usage, constraints: { :name => /.*/ }, :defaults => { :format => 'html' }
-  post '/:platform/:name/mute', to: 'projects#mute', as: :mute_project, constraints: { :name => /.*/ }
-  delete '/:platform/:name/unmute', to: 'projects#unmute', as: :unmute_project, constraints: { :name => /.*/ }
-  get '/:platform/:name/tree', to: 'tree#show', constraints: { :name => PROJECT_CONSTRAINT }, as: :tree
-  get '/:platform/:name/score', to: 'projects#score', as: :project_score, constraints: { :name => /.*/ }
-  get '/:platform/:name/sourcerank', to: 'projects#sourcerank', as: :project_sourcerank, constraints: { :name => /.*/ }
-  get '/:platform/:name/versions', to: 'projects#versions', as: :project_versions, constraints: { :name => /.*/ }
-  get '/:platform/:name/tags', to: 'projects#tags', as: :project_tags, constraints: { :name => /.*/ }
-  get '/:platform/:name/dependents', to: 'projects#dependents', as: :project_dependents, constraints: { :name => /.*/ }
-  get '/:platform/:name/dependent_repositories', to: 'projects#dependent_repos', as: :legacy_project_dependent_repos, constraints: { :name => /.*/ }
-  get '/:platform/:name/dependent-repositories', to: 'projects#dependent_repos', as: :project_dependent_repos, constraints: { :name => /.*/ }
-  get '/:platform/:name/dependent-repositories/yours', to: 'projects#your_dependent_repos', as: :your_project_dependent_repos, constraints: { :name => /.*/ }
-  get '/:platform/:name/:number.about', to: 'projects#about', as: :about_version, constraints: { :number => /.*/, :name => /.*/ }
-  get '/:platform/:name/:number.ABOUT', to: 'projects#about', constraints: { :number => /.*/, :name => /.*/ }
-  get '/:platform/:name/:number/tree', to: 'tree#show', constraints: { :number => /[\w\.\-\%]+/, :name => PROJECT_CONSTRAINT }, as: :version_tree
-  get '/:platform/:name/:number', to: 'projects#show', as: :version, constraints: { :number => /.*/, :name => /.*/ }
-  get '/:platform/:name.about', to: 'projects#about', as: :about_project, constraints: { :name => /.*/ }
-  get '/:platform/:name.ABOUT', to: 'projects#about', constraints: { :name => /.*/ }
-  get '/:platform/:name', to: 'projects#show', as: :project, constraints: { :name => /.*/ }, :defaults => { :format => 'html' }
+  post '/:platform/:name/sync', to: 'projects#sync', constraints: { name: /.*/ }, as: :sync_project
+  post '/:platform/:name/refresh-stats', to: 'projects#refresh_stats', constraints: { name: /.*/ }, as: :project_refresh_stats
+  get '/:platform/:name/unsubscribe', to: 'projects#unsubscribe', constraints: { name: /.*/ }, as: :unsubscribe_project
+  get '/:platform/:name/usage', to: 'project_usage#show', as: :project_usage, constraints: { name: /.*/ }, defaults: { format: 'html' }
+  post '/:platform/:name/mute', to: 'projects#mute', as: :mute_project, constraints: { name: /.*/ }
+  delete '/:platform/:name/unmute', to: 'projects#unmute', as: :unmute_project, constraints: { name: /.*/ }
+  get '/:platform/:name/tree', to: 'tree#show', constraints: { name: PROJECT_CONSTRAINT }, as: :tree
+  get '/:platform/:name/score', to: 'projects#score', as: :project_score, constraints: { name: /.*/ }
+  get '/:platform/:name/sourcerank', to: 'projects#sourcerank', as: :project_sourcerank, constraints: { name: /.*/ }
+  get '/:platform/:name/versions', to: 'projects#versions', as: :project_versions, constraints: { name: /.*/ }
+  get '/:platform/:name/tags', to: 'projects#tags', as: :project_tags, constraints: { name: /.*/ }
+  get '/:platform/:name/dependents', to: 'projects#dependents', as: :project_dependents, constraints: { name: /.*/ }
+  get '/:platform/:name/dependent_repositories', to: 'projects#dependent_repos', as: :legacy_project_dependent_repos, constraints: { name: /.*/ }
+  get '/:platform/:name/dependent-repositories', to: 'projects#dependent_repos', as: :project_dependent_repos, constraints: { name: /.*/ }
+  get '/:platform/:name/dependent-repositories/yours', to: 'projects#your_dependent_repos', as: :your_project_dependent_repos, constraints: { name: /.*/ }
+  get '/:platform/:name/:number.about', to: 'projects#about', as: :about_version, constraints: { number: /.*/, name: /.*/ }
+  get '/:platform/:name/:number.ABOUT', to: 'projects#about', constraints: { number: /.*/, name: /.*/ }
+  get '/:platform/:name/:number/tree', to: 'tree#show', constraints: { number: /[\w\.\-\%]+/, name: PROJECT_CONSTRAINT }, as: :version_tree
+  get '/:platform/:name/:number', to: 'projects#show', as: :version, constraints: { number: /.*/, name: /.*/ }
+  get '/:platform/:name.about', to: 'projects#about', as: :about_project, constraints: { name: /.*/ }
+  get '/:platform/:name.ABOUT', to: 'projects#about', constraints: { name: /.*/ }
+  get '/:platform/:name', to: 'projects#show', as: :project, constraints: { name: /.*/ }, defaults: { format: 'html' }
   get '/:id', to: 'platforms#show', as: :platform
 end

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -5,40 +5,40 @@ SitemapGenerator::Sitemap.public_path = 'tmp/'
 SitemapGenerator::Sitemap.sitemaps_path = 'sitemaps/'
 SitemapGenerator::Sitemap.search_engines[:yandex] = 'https://blogs.yandex.ru/pings/?status=success&url=%s'
 
-SitemapGenerator::Sitemap.create(:create_index => true) do
+SitemapGenerator::Sitemap.create(create_index: true) do
   projects = lambda {
-    group = sitemap.group(:filename => :projects, :sitemaps_path => 'sitemaps/projects') do
+    group = sitemap.group(filename: :projects, sitemaps_path: 'sitemaps/projects') do
       Project.not_removed.where("rank > 0").find_each do |project|
-        add project_path(project.to_param), :lastmod => project.updated_at
+        add project_path(project.to_param), lastmod: project.updated_at
       end
     end
     group.sitemap.write unless group.sitemap.written?
   }
 
   misc = lambda {
-    group = sitemap.group(:filename => :misc, :sitemaps_path => 'sitemaps/misc') do
-      add root_path, :priority => 1, :changefreq => 'daily'
+    group = sitemap.group(filename: :misc, sitemaps_path: 'sitemaps/misc') do
+      add root_path, priority: 1, changefreq: 'daily'
 
       add search_path
       add about_path
 
-      add platforms_path, :changefreq => 'daily'
-      add licenses_path, :changefreq => 'daily'
-      add languages_path, :changefreq => 'daily'
+      add platforms_path, changefreq: 'daily'
+      add licenses_path, changefreq: 'daily'
+      add languages_path, changefreq: 'daily'
 
       PackageManager::Base.platforms.each do |platform|
         name = platform.formatted_name
-        add platform_path(name.downcase), :lastmod => Project.platform(name).order('updated_at DESC').first.try(:updated_at)
+        add platform_path(name.downcase), lastmod: Project.platform(name).order('updated_at DESC').first.try(:updated_at)
       end
 
-      Project.popular_licenses(:facet_limit => 300).each do |license|
+      Project.popular_licenses(facet_limit: 300).each do |license|
         name = license['key']
-        add license_path(name), :lastmod => Project.license(name).order('updated_at DESC').first.try(:updated_at)
+        add license_path(name), lastmod: Project.license(name).order('updated_at DESC').first.try(:updated_at)
       end
 
-      Project.popular_languages(:facet_limit => 200).each do |language|
+      Project.popular_languages(facet_limit: 200).each do |language|
         name = language['key']
-        add language_path(name), :lastmod => Project.language(name).order('updated_at DESC').first.try(:updated_at)
+        add language_path(name), lastmod: Project.language(name).order('updated_at DESC').first.try(:updated_at)
       end
     end
     group.sitemap.write unless group.sitemap.written?
@@ -49,7 +49,7 @@ SitemapGenerator::Sitemap.create(:create_index => true) do
   end
 end
 
-SitemapGenerator::Sitemap.create(:create_index => true) do
+SitemapGenerator::Sitemap.create(create_index: true) do
   Dir.chdir(sitemap.public_path.to_s)
   xml_files      = File.join("**", "sitemaps", "**", "*.xml.gz")
   xml_file_paths = Dir.glob(xml_files)

--- a/db/migrate/20150828094144_add_unique_indexes_on_repos.rb
+++ b/db/migrate/20150828094144_add_unique_indexes_on_repos.rb
@@ -2,7 +2,7 @@ class AddUniqueIndexesOnRepos < ActiveRecord::Migration[5.0]
   def up
     remove_index :github_repositories, :full_name
     remove_index :github_repositories, :github_id
-    add_index :github_repositories, :github_id, :unique => true
+    add_index :github_repositories, :github_id, unique: true
     execute "CREATE UNIQUE INDEX index_github_repositories_on_lowercase_full_name
              ON github_repositories USING btree (lower(full_name));"
   end

--- a/db/migrate/20150901165303_unique_indexes_for_users_and_orgs.rb
+++ b/db/migrate/20150901165303_unique_indexes_for_users_and_orgs.rb
@@ -1,9 +1,9 @@
 class UniqueIndexesForUsersAndOrgs < ActiveRecord::Migration[5.0]
   def change
     remove_index :github_users, :github_id
-    add_index :github_users, :github_id, :unique => true
+    add_index :github_users, :github_id, unique: true
     remove_index :github_organisations, :github_id
-    add_index :github_organisations, :github_id, :unique => true
+    add_index :github_organisations, :github_id, unique: true
 
     remove_index :github_organisations, :login
     execute "CREATE UNIQUE INDEX index_github_users_on_lowercase_login

--- a/db/migrate/20150902123941_add_unique_index_to_repository_permissions.rb
+++ b/db/migrate/20150902123941_add_unique_index_to_repository_permissions.rb
@@ -1,5 +1,5 @@
 class AddUniqueIndexToRepositoryPermissions < ActiveRecord::Migration[5.0]
   def change
-    add_index :repository_permissions, [:user_id, :github_repository_id], :unique => true, name: 'user_repo_unique_repository_permissions'
+    add_index :repository_permissions, [:user_id, :github_repository_id], unique: true, name: 'user_repo_unique_repository_permissions'
   end
 end

--- a/db/migrate/20150905165001_uniq_version_index.rb
+++ b/db/migrate/20150905165001_uniq_version_index.rb
@@ -1,6 +1,6 @@
 class UniqVersionIndex < ActiveRecord::Migration[5.0]
   def change
     remove_index :versions, [:project_id, :number]
-    add_index :versions, [:project_id, :number], :unique => true
+    add_index :versions, [:project_id, :number], unique: true
   end
 end

--- a/db/migrate/20150908093255_create_project_mutes.rb
+++ b/db/migrate/20150908093255_create_project_mutes.rb
@@ -3,7 +3,7 @@ class CreateProjectMutes < ActiveRecord::Migration[5.0]
     create_table :project_mutes do |t|
       t.integer :user_id, null: false
       t.integer :project_id, null: false
-      t.index [:project_id, :user_id], :unique => true
+      t.index [:project_id, :user_id], unique: true
       t.timestamps null: false
     end
   end

--- a/db/migrate/20151205004838_change_tax_percent_format_in_payola_subscriptions.rb
+++ b/db/migrate/20151205004838_change_tax_percent_format_in_payola_subscriptions.rb
@@ -1,6 +1,6 @@
 class ChangeTaxPercentFormatInPayolaSubscriptions < ActiveRecord::Migration[5.0]
   def up
-    change_column :payola_subscriptions, :tax_percent, :decimal, :precision => 4, :scale => 2
+    change_column :payola_subscriptions, :tax_percent, :decimal, precision: 4, scale: 2
   end
 
   def down

--- a/spec/models/maintenance_stats/github/commit_count_stats_spec.rb
+++ b/spec/models/maintenance_stats/github/commit_count_stats_spec.rb
@@ -12,7 +12,7 @@ describe MaintenanceStats::Stats::Github::CommitsStat do
   context "with a valid repository" do
     let(:repository) { create(:repository, full_name: 'chalk/chalk') }
     let(:query_results) do
-        VCR.use_cassette('github/chalk_api', :match_requests_on => [:method, :uri, :body, :query]) do
+        VCR.use_cassette('github/chalk_api', match_requests_on: [:method, :uri, :body, :query]) do
            return query_klass.query(params: query_params)
         end
     end
@@ -44,7 +44,7 @@ describe MaintenanceStats::Stats::Github::CommitsStat do
   context "repository with no commits" do
     let(:repository) { create(:repository, full_name: 'buddhamagnet/heidigoodchild') }
     let(:query_results) do
-        VCR.use_cassette('github/empty_repository', :match_requests_on => [:method, :uri, :body, :query]) do
+        VCR.use_cassette('github/empty_repository', match_requests_on: [:method, :uri, :body, :query]) do
             return query_klass.query(params: query_params)
         end
     end
@@ -73,7 +73,7 @@ describe MaintenanceStats::Stats::Github::V3CommitsStat do
     context "with a valid repository" do
         let(:repository) { create(:repository, full_name: 'chalk/chalk') }
         let(:query_results) do
-            VCR.use_cassette('github/chalk_api', :match_requests_on => [:method, :uri, :body, :query]) do
+            VCR.use_cassette('github/chalk_api', match_requests_on: [:method, :uri, :body, :query]) do
                 return query_klass.query(params: query_params)
             end
         end
@@ -96,7 +96,7 @@ describe MaintenanceStats::Stats::Github::V3CommitsStat do
     context "repository with no commits" do
         let(:repository) { create(:repository, full_name: 'buddhamagnet/heidigoodchild') }
         let(:query_results) do
-            VCR.use_cassette('github/empty_repository', :match_requests_on => [:method, :uri, :body, :query]) do
+            VCR.use_cassette('github/empty_repository', match_requests_on: [:method, :uri, :body, :query]) do
                 return query_klass.query(params: query_params)
             end
         end

--- a/spec/models/maintenance_stats/github/release_stats_spec.rb
+++ b/spec/models/maintenance_stats/github/release_stats_spec.rb
@@ -17,7 +17,7 @@ describe MaintenanceStats::Stats::Github::ReleaseStats do
   context "with a valid repository" do
     let(:repository) { create(:repository, full_name: 'chalk/chalk') }
     let(:query_results) do
-        VCR.use_cassette('github/chalk_api', :match_requests_on => [:method, :uri, :body, :query]) do
+        VCR.use_cassette('github/chalk_api', match_requests_on: [:method, :uri, :body, :query]) do
            return query_klass.query(params: query_params)
         end
     end
@@ -50,7 +50,7 @@ describe MaintenanceStats::Stats::Github::ReleaseStats do
   context "repository with no commits" do
     let(:repository) { create(:repository, full_name: 'buddhamagnet/heidigoodchild') }
     let(:query_results) do
-      VCR.use_cassette('github/empty_repository', :match_requests_on => [:method, :uri, :body, :query]) do
+      VCR.use_cassette('github/empty_repository', match_requests_on: [:method, :uri, :body, :query]) do
         return query_klass.query(params: query_params)
       end
     end

--- a/spec/models/project_score_calculator_spec.rb
+++ b/spec/models/project_score_calculator_spec.rb
@@ -439,46 +439,46 @@ describe ProjectScoreCalculator do
       let(:project) { build(:project, repository: repository) }
       it "should be the contain details of each score category" do
         expect(calculator.breakdown).to eq({
-          :overall_score => 38,
-          :popularity => {
-            :score => 0,
-            :dependent_projects => 0,
-            :dependent_repositories => 0,
-            :stars => 0,
-            :forks => 0,
-            :watchers => 0
+          overall_score: 38,
+          popularity: {
+            score: 0,
+            dependent_projects: 0,
+            dependent_repositories: 0,
+            stars: 0,
+            forks: 0,
+            watchers: 0
           },
-          :community => {
-            :score => 0,
-            :contribution_docs => {
-              :code_of_conduct => false,
-              :contributing => false,
-              :changelog => false
+          community: {
+            score: 0,
+            contribution_docs: {
+              code_of_conduct: false,
+              contributing: false,
+              changelog: false
             },
-            :recent_releases => 0,
-            :brand_new => 0,
-            :contributors => 0,
-            :maintainers => 0
+            recent_releases: 0,
+            brand_new: 0,
+            contributors: 0,
+            maintainers: 0
           },
-          :quality => {
-            :score => 53.33333333333333,
-            :basic_info => {
-              :description => true,
-              :homepage => true,
-              :repository_url => true,
-              :keywords => true,
-              :readme => false,
-              :license => false},
-            :status => 100,
-            :multiple_versions => 0,
-            :semver => 100,
-            :stable_release => 0
+          quality: {
+            score: 53.33333333333333,
+            basic_info: {
+              description: true,
+              homepage: true,
+              repository_url: true,
+              keywords: true,
+              readme: false,
+              license: false},
+            status: 100,
+            multiple_versions: 0,
+            semver: 100,
+            stable_release: 0
           },
-          :dependencies => {
-            :score => 100.0,
-            :outdated_dependencies => nil,
-            :dependencies_count => 100,
-            :direct_dependencies => {}
+          dependencies: {
+            score: 100.0,
+            outdated_dependencies: nil,
+            dependencies_count: 100,
+            direct_dependencies: {}
           }
         })
       end
@@ -488,46 +488,46 @@ describe ProjectScoreCalculator do
       let(:project) { build(:project) }
       it "should be the contain details of each score category" do
         expect(calculator.breakdown).to eq({
-          :overall_score => 39,
-          :popularity => {
-            :score => 0.0,
-            :dependent_projects => 0,
-            :dependent_repositories => 0,
-            :stars => nil,
-            :forks => nil,
-            :watchers => nil
+          overall_score: 39,
+          popularity: {
+            score: 0.0,
+            dependent_projects: 0,
+            dependent_repositories: 0,
+            stars: nil,
+            forks: nil,
+            watchers: nil
           },
-          :community => {
-            :score => 0.0,
-            :contribution_docs => {
-              :code_of_conduct => nil,
-              :contributing => nil,
-              :changelog => nil
+          community: {
+            score: 0.0,
+            contribution_docs: {
+              code_of_conduct: nil,
+              contributing: nil,
+              changelog: nil
             },
-            :recent_releases => 0,
-            :brand_new => 0,
-            :contributors => nil,
-            :maintainers => 0
+            recent_releases: 0,
+            brand_new: 0,
+            contributors: nil,
+            maintainers: 0
           },
-          :quality => {
-            :score => 56.0,
-            :basic_info => {
-              :description => true,
-              :homepage => true,
-              :repository_url => true,
-              :keywords => true,
-              :readme => nil,
-              :license => false},
-            :status => 100,
-            :multiple_versions => 0,
-            :semver => 100,
-            :stable_release => 0
+          quality: {
+            score: 56.0,
+            basic_info: {
+              description: true,
+              homepage: true,
+              repository_url: true,
+              keywords: true,
+              readme: nil,
+              license: false},
+            status: 100,
+            multiple_versions: 0,
+            semver: 100,
+            stable_release: 0
           },
-          :dependencies => {
-            :score => 100.0,
-            :outdated_dependencies => nil,
-            :dependencies_count => 100,
-            :direct_dependencies => {}
+          dependencies: {
+            score: 100.0,
+            outdated_dependencies: nil,
+            dependencies_count: 100,
+            direct_dependencies: {}
           }
         })
       end
@@ -537,46 +537,46 @@ describe ProjectScoreCalculator do
       let(:project) { build(:project, platform: 'CocoaPods') }
       it "should be the contain details of each score category" do
         expect(calculator.breakdown).to eq({
-          :overall_score => 19,
-          :popularity => {
-            :score => 0.0,
-            :dependent_projects => nil,
-            :dependent_repositories => 0,
-            :stars => nil,
-            :forks => nil,
-            :watchers => nil
+          overall_score: 19,
+          popularity: {
+            score: 0.0,
+            dependent_projects: nil,
+            dependent_repositories: 0,
+            stars: nil,
+            forks: nil,
+            watchers: nil
           },
-          :community => {
-            :score => 0.0,
-            :contribution_docs => {
-              :code_of_conduct => nil,
-              :contributing => nil,
-              :changelog => nil
+          community: {
+            score: 0.0,
+            contribution_docs: {
+              code_of_conduct: nil,
+              contributing: nil,
+              changelog: nil
             },
-            :recent_releases => 0,
-            :brand_new => 0,
-            :contributors => nil,
-            :maintainers => nil
+            recent_releases: 0,
+            brand_new: 0,
+            contributors: nil,
+            maintainers: nil
           },
-          :quality => {
-            :score => 56.0,
-            :basic_info => {
-              :description => true,
-              :homepage => true,
-              :repository_url => true,
-              :keywords => true,
-              :readme => nil,
-              :license => false},
-            :status => 100,
-            :multiple_versions => 0,
-            :semver => 100,
-            :stable_release => 0
+          quality: {
+            score: 56.0,
+            basic_info: {
+              description: true,
+              homepage: true,
+              repository_url: true,
+              keywords: true,
+              readme: nil,
+              license: false},
+            status: 100,
+            multiple_versions: 0,
+            semver: 100,
+            stable_release: 0
           },
-          :dependencies => {
-            :score => nil,
-            :outdated_dependencies => nil,
-            :dependencies_count => nil,
-            :direct_dependencies => nil
+          dependencies: {
+            score: nil,
+            outdated_dependencies: nil,
+            dependencies_count: nil,
+            direct_dependencies: nil
           }
         })
       end

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -225,7 +225,7 @@ describe Repository, type: :model do
     # GitHub API V4 calls all use the same endpoint, but have unique request bodies with the GraphQL queries. They will need to match on :body.
     context "with a valid repository" do
       before do
-        VCR.use_cassette('github/chalk_api', :match_requests_on => [:method, :uri, :body, :query]) do
+        VCR.use_cassette('github/chalk_api', match_requests_on: [:method, :uri, :body, :query]) do
           repository.gather_maintenance_stats
         end
       end
@@ -244,7 +244,7 @@ describe Repository, type: :model do
         first_updated_at = repository.repository_maintenance_stats.first.updated_at
         category = repository.repository_maintenance_stats.first.category
 
-        VCR.use_cassette('github/chalk_api', :match_requests_on => [:method, :uri, :body, :query]) do
+        VCR.use_cassette('github/chalk_api', match_requests_on: [:method, :uri, :body, :query]) do
           repository.gather_maintenance_stats
         end
 
@@ -258,7 +258,7 @@ describe Repository, type: :model do
       let(:repository) { create(:repository, full_name: 'bad/example-for-testing') }
 
       it "should save metrics for repository" do
-        VCR.use_cassette('github/bad_repository', :match_requests_on => [:method, :uri, :body, :query]) do
+        VCR.use_cassette('github/bad_repository', match_requests_on: [:method, :uri, :body, :query]) do
           repository.gather_maintenance_stats
         end
 
@@ -271,7 +271,7 @@ describe Repository, type: :model do
       let(:repository) { create(:repository, full_name: 'buddhamagnet/heidigoodchild') }
 
       it "should save default values" do
-        VCR.use_cassette('github/empty_repository', :match_requests_on => [:method, :uri, :body, :query]) do
+        VCR.use_cassette('github/empty_repository', match_requests_on: [:method, :uri, :body, :query]) do
           repository.gather_maintenance_stats
         end
 
@@ -295,7 +295,7 @@ describe Repository, type: :model do
       let(:repository) { create(:repository, host_type: "Bitbucket") }
 
       it "should not save any values" do
-        VCR.use_cassette('github/chalk_api', :match_requests_on => [:method, :uri, :body, :query]) do
+        VCR.use_cassette('github/chalk_api', match_requests_on: [:method, :uri, :body, :query]) do
           repository.gather_maintenance_stats
         end
 

--- a/spec/routing/tree_routes_spec.rb
+++ b/spec/routing/tree_routes_spec.rb
@@ -1,42 +1,42 @@
 require "rails_helper"
 
-describe "tree routes", :type => :routing do
+describe "tree routes", type: :routing do
   it 'routes npm modules correctly' do
-    expect(:get => "/npm/webpack/4.4.1/tree").to route_to(
-      :controller => "tree",
-      :action => "show",
-      :platform => "npm",
-      :name => "webpack",
-      :number => "4.4.1"
+    expect(get: "/npm/webpack/4.4.1/tree").to route_to(
+      controller: "tree",
+      action: "show",
+      platform: "npm",
+      name: "webpack",
+      number: "4.4.1"
     )
   end
 
   it 'routes npm modules with slashes correctly' do
-    expect(:get => "/npm/@babel%2Fcore/7.0.0-beta.44/tree").to route_to(
-      :controller => "tree",
-      :action => "show",
-      :platform => "npm",
-      :name => "@babel/core",
-      :number => "7.0.0-beta.44"
+    expect(get: "/npm/@babel%2Fcore/7.0.0-beta.44/tree").to route_to(
+      controller: "tree",
+      action: "show",
+      platform: "npm",
+      name: "@babel/core",
+      number: "7.0.0-beta.44"
     )
   end
 
   describe 'without version' do
     it 'routes npm modules correctly' do
-      expect(:get => "/npm/webpack/tree").to route_to(
-        :controller => "tree",
-        :action => "show",
-        :platform => "npm",
-        :name => "webpack"
+      expect(get: "/npm/webpack/tree").to route_to(
+        controller: "tree",
+        action: "show",
+        platform: "npm",
+        name: "webpack"
       )
     end
 
     it 'routes npm modules with slashes correctly' do
-      expect(:get => "/npm/@babel%2Fcore/tree").to route_to(
-        :controller => "tree",
-        :action => "show",
-        :platform => "npm",
-        :name => "@babel/core"
+      expect(get: "/npm/@babel%2Fcore/tree").to route_to(
+        controller: "tree",
+        action: "show",
+        platform: "npm",
+        name: "@babel/core"
       )
     end
   end


### PR DESCRIPTION
Bumps Rubocop to 1.0.0, and convert all `{ :foo => 'blah' }` hashes to `{ foo: 'blah' }` to modernize our Hash notation.