### PR TITLE
Silence some PackageManagerDownloadWorker noise from long CRAN scraped urls.

### DIFF
--- a/app/models/package_manager/cran.rb
+++ b/app/models/package_manager/cran.rb
@@ -53,7 +53,7 @@ module PackageManager
         homepage: project[:info].fetch("URL:", "").split(",").first,
         description: project[:html].css("h2").text.split(":")[1..-1].join(":").strip,
         licenses: project[:info]["License:"],
-        repository_url: repo_fallback("", (project[:info].fetch("URL:", "").split(",").first.presence || project[:info]["BugReports:"])),
+        repository_url: repo_fallback("", (project[:info].fetch("URL:", "").split(",").first.presence || project[:info]["BugReports:"]))[0, 255],
       }
     end
 

--- a/app/models/package_manager/cran.rb
+++ b/app/models/package_manager/cran.rb
@@ -53,7 +53,7 @@ module PackageManager
         homepage: project[:info].fetch("URL:", "").split(",").first,
         description: project[:html].css("h2").text.split(":")[1..-1].join(":").strip,
         licenses: project[:info]["License:"],
-        repository_url: repo_fallback("", (project[:info].fetch("URL:", "").split(",").first.presence || project[:info]["BugReports:"]))[0, 255],
+        repository_url: repo_fallback("", (project[:info].fetch("URL:", "").split(",").first.presence || project[:info]["BugReports:"])).to_s[0, 255],
       }
     end
 


### PR DESCRIPTION
Projects like [this](https://cran.r-project.org/web/packages/acumos/index.html) are scraped from CRAN, including the URL, which can be pretty long. Seems specific to CRAN so why not just truncate long url fields (or we could make this column bigger too 🤷 )

Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/6035c1add3b47400174b50dc
