### PR TITLE
PackageManager::CocoaPods: don't set 'versions' on project if the project is missing.

### DIFF
--- a/app/models/package_manager/cocoa_pods.rb
+++ b/app/models/package_manager/cocoa_pods.rb
@@ -33,7 +33,9 @@ module PackageManager
     def self.project(name)
       versions = get_json("http://cocoapods.libraries.io/pods/#{name}.json") || {}
       latest_version = versions.keys.max_by { |version| version.split(".").map(&:to_i) }
-      versions.fetch(latest_version, {}).merge("versions" => versions)
+      versions.fetch(latest_version, {}).then do |v|
+        v.merge("versions" => versions) if versions.present?
+      end
     end
 
     def self.mapping(project)


### PR DESCRIPTION
We're getting `{"versions" => {}}` for CocoaPods that don't exist, but we want just a blank `{}` so we can do an early-return because the project doesn't exist.

Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/6036a95d2447bb0018ea48f2

