### PR TITLE
Return nil from mapping() instead of false or nil.

### DIFF
--- a/app/models/package_manager/npm.rb
+++ b/app/models/package_manager/npm.rb
@@ -49,7 +49,7 @@ module PackageManager
     end
 
     def self.mapping(project)
-      return false unless project["versions"].present?
+      return nil unless project["versions"].present?
 
       latest_version = project["versions"].to_a.last[1]
 

--- a/app/models/package_manager/packagist.rb
+++ b/app/models/package_manager/packagist.rb
@@ -40,7 +40,7 @@ module PackageManager
     end
 
     def self.mapping(project)
-      return false unless project["versions"].any?
+      return nil unless project["versions"].any?
 
       # for version comparison of php, we want to reject any dev versions unless
       # there are only dev versions of the project


### PR DESCRIPTION
Followup to https://github.com/librariesio/libraries.io/commit/78cbb976d01c84f859bbc2501f8f02b3a7a52873

IMO better to return `nil` for a project's mapping that we don't care about rather than `nil` **or** `false` (and false seems more appropriate if this method was inquisitive).

Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/6033ea3c71af060018d90a6b
