### PR TITLE
Fix Homebrew project mapping.

### DIFF
--- a/app/models/package_manager/homebrew.rb
+++ b/app/models/package_manager/homebrew.rb
@@ -32,11 +32,11 @@ module PackageManager
 
     def self.mapping(project)
       {
-        name: project["formula"],
-        description: project["description"],
+        name: project["name"],
+        description: project["desc"],
         homepage: project["homepage"],
         repository_url: repo_fallback("", project["homepage"]),
-        version: project["version"],
+        version: project.dig("versions", "stable"),
         dependencies: project["dependencies"],
       }
     end


### PR DESCRIPTION
Another thing that switching to `save!` on package updates has surfaced: I think Homebrew updating might've been broken since [the API endpoint was updated](https://github.com/librariesio/libraries.io/commit/87874db767e1d69a8487d84dd81649596d7ce6c8)?

Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/6036a95d2447bb0018ea48f2

