### PR TITLE
Safe redirects.

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -69,12 +69,13 @@ class SessionsController < ApplicationController
   private
 
   def pre_login_destination
-    destination = session.delete(:pre_login_destination).to_s
+    destination = session.delete(:pre_login_destination)
+    destination_host = URI(destination.to_s).host
 
-    if URI(destination).host != Rails.application.config.host
-      return false
-    else
+    if destination_host.blank? || destination_host == Rails.application.config.host
       return destination
+    else
+      return false
     end
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -49,13 +49,12 @@ class SessionsController < ApplicationController
       flash[:notice] = nil
       session[:user_id] = identity.user.id
     end
-    
+
     identity.user.update_columns(last_login_at: Time.current)
     identity.user.update_repo_permissions_async
     login_destination = pre_login_destination
 
-    redirect_to(root_path) && return unless login_destination
-    redirect_to login_destination
+    redirect_to login_destination || root_path
   end
 
   def destroy
@@ -70,8 +69,12 @@ class SessionsController < ApplicationController
   private
 
   def pre_login_destination
-    destination = session[:pre_login_destination]
-    session.delete :pre_login_destination
-    return destination
+    destination = session.delete(:pre_login_destination).to_s
+
+    if URI(destination).host != Rails.application.config.host
+      return false
+    else
+      return destination
+    end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -53,5 +53,7 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.host = "localhost"
+
+  config.action_mailer.default_url_options = { host: config.host, port: 3000 }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -79,7 +79,9 @@ Rails.application.configure do
   # disable sql logging in production
   config.active_record.logger = nil
 
-  config.action_mailer.default_url_options = { host: 'libraries.io' }
+  config.host = "libraries.io"
+
+  config.action_mailer.default_url_options = { host: config.host }
 
   config.cache_store = :dalli_store,
                     (ENV["MEMCACHIER_SERVERS"] || "").split(","),

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,5 +45,7 @@ Rails.application.configure do
 
   config.cache_store = :null_store
 
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.host = "www.example.com"
+
+  config.action_mailer.default_url_options = { host:  config.host, port: 3000 }
 end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -54,8 +54,16 @@ describe "SessionsController" do
         end
       end
 
-      context "internal" do
+      context "internal (absolute)" do
         let(:return_to) { root_url(foo: "bar") }
+        it "redirects to return_to" do
+          post '/auth/github/callback'
+          expect(response).to redirect_to(return_to)
+        end
+      end
+
+      context "internal (relative)" do
+        let(:return_to) { root_path(foo: "bar") }
         it "redirects to return_to" do
           post '/auth/github/callback'
           expect(response).to redirect_to(return_to)

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -36,4 +36,31 @@ describe "SessionsController" do
       expect(response).to redirect_to(root_path)
     end
   end
+
+  describe "GET /auth/:provider/callback", type: :request do
+    context "with a return_to param" do
+      before do
+        allow(Identity).to receive(:find_with_omniauth).and_return(create(:identity))
+        allow_any_instance_of(Identity).to receive(:update_from_auth_hash).and_return(true)
+        allow_any_instance_of(ActionDispatch::Request::Session).to receive(:delete).and_call_original
+        allow_any_instance_of(ActionDispatch::Request::Session).to receive(:delete).with(:pre_login_destination).and_return(return_to)
+      end
+
+      context "external" do
+        let(:return_to) { "https://an.external.url/bad" }
+        it "redirects to root" do
+          post '/auth/github/callback'
+          expect(response).to redirect_to(root_path)
+        end
+      end
+
+      context "internal" do
+        let(:return_to) { root_url(foo: "bar") }
+        it "redirects to return_to" do
+          post '/auth/github/callback'
+          expect(response).to redirect_to(return_to)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This ensures that Libraries does safe-redirects with its `return_to` parameter, by setting an environment-specific host and checking that before redirecting to the stored `return_to` url.