### PR TITLE
Handle missing POMs 

### DIFF
--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -29,7 +29,7 @@ module PackageManager
       attr_reader :url
       def initialize(url)
         @url = url
-        super("POM not found: #{@url}")
+        super("Missing POM: #{@url}")
       end
     end
 
@@ -64,7 +64,7 @@ module PackageManager
       latest_version_xml = get_pom(project[:group_id], project[:artifact_id], project[:latest_version])
       mapping_from_pom_xml(latest_version_xml, depth).merge({ name: project[:name] })
     rescue POMNotFound => e
-      Rails.logger.info "POM missing: #{e.url}"
+      Rails.logger.info "Missing POM: #{e.url}"
       nil
     end
 

--- a/spec/models/package_manager/maven_spec.rb
+++ b/spec/models/package_manager/maven_spec.rb
@@ -92,7 +92,7 @@ describe PackageManager::Maven do
       it "should return nil" do
         allow(described_class).to receive(:download_pom).and_raise(PackageManager::Maven::POMNotFound.new("https://a-spring-url"))
 
-        expect(described_class.mapping({group_id: "org", artifact_id: "foo", version: "1.0.0"})).to eq(1)
+        expect(described_class.mapping({group_id: "org", artifact_id: "foo", version: "1.0.0"})).to eq(nil)
       end
     end
   end

--- a/spec/models/package_manager/maven_spec.rb
+++ b/spec/models/package_manager/maven_spec.rb
@@ -89,9 +89,9 @@ describe PackageManager::Maven do
 
   describe ".mapping" do
     context "with missing pom" do
-      expect(described_class).to receive(:download_pom).and_raise(POMNotFound.new("https://a-spring-url"))
+      allow(described_class).to receive(:download_pom).and_raise(POMNotFound.new("https://a-spring-url"))
 
-      expect(described_class.mapping({group_id: "org", artifact_id: "foo", version: "1.0.0"})).to eq(nil)
+      expect(described_class.mapping({group_id: "org", artifact_id: "foo", version: "1.0.0"})).to eq(1)
     end
   end
 

--- a/spec/models/package_manager/maven_spec.rb
+++ b/spec/models/package_manager/maven_spec.rb
@@ -90,7 +90,7 @@ describe PackageManager::Maven do
   describe ".mapping" do
     context "with missing pom" do
       it "should return nil" do
-        allow(described_class).to receive(:download_pom).and_raise(POMNotFound.new("https://a-spring-url"))
+        allow(described_class).to receive(:download_pom).and_raise(PackageManager::Maven::POMNotFound.new("https://a-spring-url"))
 
         expect(described_class.mapping({group_id: "org", artifact_id: "foo", version: "1.0.0"})).to eq(1)
       end

--- a/spec/models/package_manager/maven_spec.rb
+++ b/spec/models/package_manager/maven_spec.rb
@@ -87,6 +87,14 @@ describe PackageManager::Maven do
     end
   end
 
+  describe ".mapping" do
+    context "with missing pom" do
+      expect(described_class).to receive(:download_pom).and_raise(POMNotFound.new("https://a-spring-url"))
+
+      expect(described_class.mapping({group_id: "org", artifact_id: "foo", version: "1.0.0"})).to eq(nil)
+    end
+  end
+
   describe "#download_url" do
     let(:project) { create(:project, name: "javax.faces:javax.faces-api", platform: described_class.formatted_name.demodulize) }
 

--- a/spec/models/package_manager/maven_spec.rb
+++ b/spec/models/package_manager/maven_spec.rb
@@ -89,9 +89,11 @@ describe PackageManager::Maven do
 
   describe ".mapping" do
     context "with missing pom" do
-      allow(described_class).to receive(:download_pom).and_raise(POMNotFound.new("https://a-spring-url"))
+      it "should return nil" do
+        allow(described_class).to receive(:download_pom).and_raise(POMNotFound.new("https://a-spring-url"))
 
-      expect(described_class.mapping({group_id: "org", artifact_id: "foo", version: "1.0.0"})).to eq(1)
+        expect(described_class.mapping({group_id: "org", artifact_id: "foo", version: "1.0.0"})).to eq(1)
+      end
     end
   end
 


### PR DESCRIPTION
Some libs in the Spring Artifactory instance (also some Maven libs) do not have POMs, even tho they have zips, pom.asc etc. For example:

https://repo.spring.io/webapp/#/artifacts/browse/tree/General/libs-release-local/org/springframework/cloud/spring-cloud-function-docs/3.1.2

This gracefully moves on during the update if it is missing.

https://app.clubhouse.io/tidelift/story/16019/pom-parsing-error-in-package-manager-download-worker