### PR TITLE
Skip version updates if POM is not found.

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -128,6 +128,8 @@ module PackageManager
     end
 
     def self.add_version(db_project, version_hash)
+      return if version_hash.blank?
+
       # Protect version against stray data
       version_hash = version_hash.symbolize_keys.slice(
         :number,

--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -156,7 +156,7 @@ module PackageManager
             published_at: Time.parse(pom.locate("publishedAt").first.text),
             original_license: license_list,
           }
-      rescue Ox::Error
+      rescue Ox::Error, POMNotFound
         next
         end
         .compact

--- a/spec/models/package_manager/maven_spec.rb
+++ b/spec/models/package_manager/maven_spec.rb
@@ -139,6 +139,16 @@ describe PackageManager::Maven do
     end
   end
 
+  describe ".one_version" do
+    it "retrieves a single version" do
+      allow(described_class)
+        .to receive(:download_pom)
+        .and_raise(PackageManager::Maven::POMNotFound.new("https://a-maven-central-url"))
+
+      expect(PackageManager::Maven::MavenCentral.one_version("org.foo:bar", "1.0.0")). to eq(nil)
+    end
+
+  end
 
   describe ".versions" do
     it "returns the expected version data" do


### PR DESCRIPTION
Followup to https://github.com/librariesio/libraries.io/pull/2779

When pulling specific versions and the POM is missing, skip the update on that version.

Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/606f904b075d7d00079ebe85?event_id=606f904b00770c3cbd710000&i=em&m=nw