### PR TITLE
Sublime: don't follow redirects bc they lead to HTML of other projects.

### DIFF
--- a/app/models/package_manager/sublime.rb
+++ b/app/models/package_manager/sublime.rb
@@ -16,7 +16,9 @@ module PackageManager
     end
 
     def self.project(name)
-      get("https://packagecontrol.io/packages/#{CGI.escape(name)}.json")
+      Faraday.new("https://packagecontrol.io/packages/#{URI.escape(name)}.json")
+        .get
+        .then { |resp| resp.status == 200 ? Oj.load(resp.body) : nil }
     end
 
     def self.mapping(project)


### PR DESCRIPTION
Looks like the `Rust` package, for example, was being redirected to `Rust Enhanced`. This ignores those redirects instead of raising an error.

Things to look into later:
* fix the `project_names` endopint, which broke in v3 of the package manager, and now returns no names.
* add support for redirects, so we can mark a project as "Deleted" and add the new project name (or something)


Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/6036c592aa2da800175dd916?event_id=60735c7d007759f45dc10000&i=em&m=fq