### PR TITLE
Ensure we strip package names in worker.

### DIFF
--- a/app/workers/package_manager_download_worker.rb
+++ b/app/workers/package_manager_download_worker.rb
@@ -64,6 +64,7 @@ class PackageManagerDownloadWorker
           end
 
     platform = PLATFORMS[key]
+    name = name.strip
     version = version.to_s.strip
     raise "Platform '#{platform_name}' not found" unless platform
 


### PR DESCRIPTION
Not positive where this failing `" optimist"` update is getting queued up from yet, but this should squash it.

Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/6036c59c5e2e0700174e0541?event_id=60767b1600770aa4e7f10000&i=em&m=fq
