### PR TITLE
Cast project name arg to string before stripping.

### DIFF
--- a/app/workers/package_manager_download_worker.rb
+++ b/app/workers/package_manager_download_worker.rb
@@ -64,7 +64,7 @@ class PackageManagerDownloadWorker
           end
 
     platform = PLATFORMS[key]
-    name = name.strip
+    name = name.to_s.strip
     version = version.to_s.strip
     raise "Platform '#{platform_name}' not found" unless platform
 


### PR DESCRIPTION
PlatformIO gives us ints back, which we use to lookup the projects when updating them.

Followup to https://github.com/librariesio/libraries.io/pull/2783

Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/607799964ea05c00075280d9?event_id=6077999600777eaaf2850000&i=sk&m=nw
