### PR TITLE
Fix tiny url regression.

### DIFF
--- a/app/models/package_manager/go.rb
+++ b/app/models/package_manager/go.rb
@@ -22,6 +22,7 @@ module PackageManager
     ].freeze
     PROXY_BASE_URL = "https://proxy.golang.org"
     DISCOVER_URL = "https://pkg.go.dev"
+    URL = DISCOVER_URL
 
     VERSION_MODULE_REGEX = /(.+)\/(v\d+)/.freeze
 


### PR DESCRIPTION
Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/607f36c9ad85a200085f2828