### PR TITLE
PlatformIO: add some hook logging to debug, and fix project lookup.

### DIFF
--- a/app/controllers/hooks_controller.rb
+++ b/app/controllers/hooks_controller.rb
@@ -15,6 +15,7 @@ class HooksController < ApplicationController
   end
 
   def package
+    Rails.logger.info "HooksController#package platform=#{params['platform']} name=#{params['name']} param_keys=#{params.keys.join(',')}"
     PackageManagerDownloadWorker.perform_async("PackageManager::#{params['platform']}", params["name"])
 
     render json: nil, status: :ok

--- a/app/models/package_manager/platform_io.rb
+++ b/app/models/package_manager/platform_io.rb
@@ -30,9 +30,12 @@ module PackageManager
       projects.map { |project| project["id"] }.sort.uniq
     end
 
-    def self.project(id)
+    def self.project(name)
       sleep 1
-      get("https://api.platformio.org/lib/info/#{id}")
+      # PlatformIO only takes its ids for project lookups, so we have to find it first.
+      if (db_project = Project.find_by(platform: "PlatformIO", name: name))
+        get("https://api.platformio.org/lib/info/#{db_project.pm_id}")
+      end
     end
 
     def self.mapping(project)


### PR DESCRIPTION
Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/6036c59c5e2e0700174e0541?filters[event.since][0]=30d&filters[error.status][0]=open
