### PR TITLE
NPM: enable single-version updates.

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -118,7 +118,7 @@ module PackageManager
             .each { |v| add_version(db_project, v) }
             .tap { |vs| deprecate_versions(db_project, vs) }
         else
-          add_version(db_project, one_version(db_project.name, sync_version))
+          add_version(db_project, one_version(raw_project, sync_version))
           # TODO: handle deprecation here too
         end
       end

--- a/app/models/package_manager/conda.rb
+++ b/app/models/package_manager/conda.rb
@@ -26,8 +26,8 @@ module PackageManager
       get_json("#{API_URL}/packages")
     end
 
-    def self.one_version(name, version_string)
-      get_json("#{API_URL}/#{self::REPOSITORY_SOURCE_NAME}/#{name}/#{version_string}")&.first
+    def self.one_version(raw_project, version_string)
+      get_json("#{API_URL}/#{self::REPOSITORY_SOURCE_NAME}/#{raw_project["name"]}/#{version_string}")&.first
     end
 
     def self.project(name)

--- a/app/models/package_manager/go.rb
+++ b/app/models/package_manager/go.rb
@@ -55,7 +55,7 @@ module PackageManager
     end
 
     def self.one_version(raw_project, version_string)
-      info = get("#{PROXY_BASE_URL}/#{raw_project["name"]}/@v/#{version_string}.info")
+      info = get("#{PROXY_BASE_URL}/#{raw_project[:name]}/@v/#{version_string}.info")
 
       # Store nil published_at for known Go Modules issue where case-insensitive name collisions break go get
       # e.g. https://proxy.golang.org/github.com/ysweid/aws-sdk-go/@v/v1.12.68.info
@@ -67,7 +67,7 @@ module PackageManager
       }
 
       # Supplement with license info from pkg.go.dev
-      doc_html = get_html("#{DISCOVER_URL}/#{name}")
+      doc_html = get_html("#{DISCOVER_URL}/#{raw_project[:name]}")
       data[:original_license] = doc_html.css('*[data-test-id="UnitHeader-license"]').map(&:text).join(",")
 
       data
@@ -126,7 +126,7 @@ module PackageManager
           if known && known[:original_license].present?
             known.slice(:number, :created_at, :published_at, :original_license)
           else
-            one_version(project[:name], v)
+            one_version(project, v)
           end
       rescue Oj::ParseError
         next

--- a/app/models/package_manager/go.rb
+++ b/app/models/package_manager/go.rb
@@ -54,8 +54,8 @@ module PackageManager
         .map { |line| JSON.parse(line)["Path"] }
     end
 
-    def self.one_version(name, version_string)
-      info = get("#{PROXY_BASE_URL}/#{name}/@v/#{version_string}.info")
+    def self.one_version(raw_project, version_string)
+      info = get("#{PROXY_BASE_URL}/#{raw_project["name"]}/@v/#{version_string}.info")
 
       # Store nil published_at for known Go Modules issue where case-insensitive name collisions break go get
       # e.g. https://proxy.golang.org/github.com/ysweid/aws-sdk-go/@v/v1.12.68.info

--- a/app/models/package_manager/maven/maven_central.rb
+++ b/app/models/package_manager/maven/maven_central.rb
@@ -14,6 +14,6 @@ class PackageManager::Maven::MavenCentral < PackageManager::Maven::Common
   end
 
   def self.one_version(raw_project, version_string)
-    retrieve_versions([version_string], raw_project["name"])&.first
+    retrieve_versions([version_string], raw_project[:name])&.first
   end
 end

--- a/app/models/package_manager/maven/maven_central.rb
+++ b/app/models/package_manager/maven/maven_central.rb
@@ -13,7 +13,7 @@ class PackageManager::Maven::MavenCentral < PackageManager::Maven::Common
     get("https://maven.libraries.io/mavenCentral/recent")
   end
 
-  def self.one_version(name, version_string)
-    retrieve_versions([version_string], name)&.first
+  def self.one_version(raw_project, version_string)
+    retrieve_versions([version_string], raw_project["name"])&.first
   end
 end

--- a/app/models/package_manager/npm.rb
+++ b/app/models/package_manager/npm.rb
@@ -9,6 +9,7 @@ module PackageManager
     URL = "https://www.npmjs.com"
     COLOR = "#f1e05a"
     ENTIRE_PACKAGE_CAN_BE_DEPRECATED = true
+    SUPPORTS_SINGLE_VERSION_UPDATE = true
 
     def self.package_link(project, _version = nil)
       "https://www.npmjs.com/package/#{project.name}"
@@ -100,6 +101,11 @@ module PackageManager
           original_license: license,
         }
       end
+    end
+
+    def self.one_version(raw_project, version_string)
+      versions(raw_project, raw_project["name"])
+        .find { |v| v[:number] == version_string }
     end
 
     def self.dependencies(_name, version, mapped_project)

--- a/spec/models/package_manager/go_spec.rb
+++ b/spec/models/package_manager/go_spec.rb
@@ -88,8 +88,14 @@ describe PackageManager::Go do
 
   describe "#one_version" do
     it "should update an individual version" do
+      raw_project = nil
+
+      VCR.use_cassette("pkg_go_dev") do
+        raw_project = described_class.project(package_name)
+      end
+
       VCR.use_cassette("version_update") do
-        version = described_class.one_version(package_name, "v1.2.0")
+        version = described_class.one_version(raw_project, "v1.2.0")
         expect(version[:number]).to eq "v1.2.0"
         expect(version[:original_license]).to eq "MIT"
         expect(version[:published_at].strftime("%m/%d/%Y")).to eq "05/05/2018"

--- a/spec/models/package_manager/maven_spec.rb
+++ b/spec/models/package_manager/maven_spec.rb
@@ -160,8 +160,9 @@ describe PackageManager::Maven do
       allow(described_class)
         .to receive(:download_pom)
         .and_raise(PackageManager::Maven::POMNotFound.new("https://a-maven-central-url"))
+      raw_project = {name: "org.foo:bar"}
 
-      expect(PackageManager::Maven::MavenCentral.one_version("org.foo:bar", "1.0.0")). to eq(nil)
+      expect(PackageManager::Maven::MavenCentral.one_version(raw_project, "1.0.0")). to eq(nil)
     end
 
   end


### PR DESCRIPTION
Also changes the signature of `one_version()` to avoid fetching the project again needlessly.

https://app.clubhouse.io/tidelift/story/16937/implement-single-version-package-manager-download-worker-updates-for-npm