### PR TITLE
mapping(), versions(): rename project ~> raw_project.

### DIFF
--- a/app/models/package_manager/alcatraz.rb
+++ b/app/models/package_manager/alcatraz.rb
@@ -28,11 +28,11 @@ module PackageManager
       projects[name.downcase]
     end
 
-    def self.mapping(project)
+    def self.mapping(raw_project)
       {
-        name: project["name"],
-        description: project["description"],
-        repository_url: project['url']
+        name: raw_project["name"],
+        description: raw_project["description"],
+        repository_url: raw_project['url']
       }
     end
   end

--- a/app/models/package_manager/atom.rb
+++ b/app/models/package_manager/atom.rb
@@ -44,19 +44,19 @@ module PackageManager
       get("https://atom.io/api/packages/#{CGI.escape(name.strip)}")
     end
 
-    def self.mapping(project)
-      metadata = project["metadata"]
-      metadata = project if metadata.nil?
+    def self.mapping(raw_project)
+      metadata = raw_project["metadata"]
+      metadata = raw_project if metadata.nil?
       repo = metadata["repository"].is_a?(Hash) ? metadata["repository"]["url"] : metadata["repository"]
       {
-        name: project["name"],
+        name: raw_project["name"],
         description: metadata["description"],
         repository_url: repo_fallback(repo, ""),
       }
     end
 
-    def self.versions(project, _name)
-      project["versions"].map do |k, _v|
+    def self.versions(raw_project, _name)
+      raw_project["versions"].map do |k, _v|
         {
           number: k,
           published_at: nil,

--- a/app/models/package_manager/bower.rb
+++ b/app/models/package_manager/bower.rb
@@ -33,11 +33,11 @@ module PackageManager
       projects[name.downcase]
     end
 
-    def self.mapping(project)
-      bower_json = load_bower_json(project) || project
+    def self.mapping(raw_project)
+      bower_json = load_bower_json(project) || raw_project
       {
-        name: project["name"],
-        repository_url: project["url"],
+        name: raw_project["name"],
+        repository_url: raw_project["url"],
         licenses: bower_json['license'],
         keywords_array: bower_json['keywords'],
         homepage: bower_json["homepage"],

--- a/app/models/package_manager/cargo.rb
+++ b/app/models/package_manager/cargo.rb
@@ -69,20 +69,20 @@ module PackageManager
       get("https://crates.io/api/v1/crates/#{name}")
     end
 
-    def self.mapping(project)
+    def self.mapping(raw_project)
       latest_version = versions(project, nil).to_a.first
       {
-        name: project["crate"]["id"],
-        homepage: project["crate"]["homepage"],
-        description: project["crate"]["description"],
-        keywords_array: Array.wrap(project["crate"]["keywords"]),
+        name: raw_project["crate"]["id"],
+        homepage: raw_project["crate"]["homepage"],
+        description: raw_project["crate"]["description"],
+        keywords_array: Array.wrap(raw_project["crate"]["keywords"]),
         licenses: latest_version&.fetch(:original_license),
-        repository_url: repo_fallback(project["crate"]["repository"], project["crate"]["homepage"]),
+        repository_url: repo_fallback(raw_project["crate"]["repository"], raw_project["crate"]["homepage"]),
       }
     end
 
-    def self.versions(project, _name)
-      project["versions"].map do |version|
+    def self.versions(raw_project, _name)
+      raw_project["versions"].map do |version|
         {
           number: version["num"],
           published_at: version["created_at"],

--- a/app/models/package_manager/carthage.rb
+++ b/app/models/package_manager/carthage.rb
@@ -41,14 +41,14 @@ module PackageManager
       end
     end
 
-    def self.mapping(project)
+    def self.mapping(raw_project)
       {
-        name: project[:full_name],
-        description: project[:description],
-        homepage: project[:homepage],
-        keywords_array: project[:topics],
-        licenses: (project.fetch(:license, {}) || {})[:key],
-        repository_url: project[:html_url]
+        name: raw_project[:full_name],
+        description: raw_project[:description],
+        homepage: raw_project[:homepage],
+        keywords_array: raw_project[:topics],
+        licenses: (raw_project.fetch(:license, {}) || {})[:key],
+        repository_url: raw_project[:html_url]
       }
     end
   end

--- a/app/models/package_manager/cocoa_pods.rb
+++ b/app/models/package_manager/cocoa_pods.rb
@@ -38,18 +38,18 @@ module PackageManager
       end
     end
 
-    def self.mapping(project)
+    def self.mapping(raw_project)
       {
-        name: project["name"],
-        description: project["summary"],
-        homepage: project["homepage"],
-        licenses: parse_license(project["license"]),
-        repository_url: repo_fallback(project.dig("source", "git"), ""),
+        name: raw_project["name"],
+        description: raw_project["summary"],
+        homepage: raw_project["homepage"],
+        licenses: parse_license(raw_project["license"]),
+        repository_url: repo_fallback(raw_project.dig("source", "git"), ""),
       }
     end
 
-    def self.versions(project, _name)
-      project.fetch("versions", {}).keys.map do |v|
+    def self.versions(raw_project, _name)
+      raw_project.fetch("versions", {}).keys.map do |v|
         {
           number: v.to_s,
         }

--- a/app/models/package_manager/conda.rb
+++ b/app/models/package_manager/conda.rb
@@ -88,13 +88,13 @@ module PackageManager
       "#{API_URL}/package/#{project.name}"
     end
 
-    def self.mapping(project)
+    def self.mapping(raw_project)
       # TODO: can we make this more explicit?
-      project.deep_symbolize_keys
+      raw_project.deep_symbolize_keys
     end
 
-    def self.versions(project, _name)
-      project["versions"].map { |version| version.deep_symbolize_keys.slice(:number, :original_license, :published_at) }
+    def self.versions(raw_project, _name)
+      raw_project["versions"].map { |version| version.deep_symbolize_keys.slice(:number, :original_license, :published_at) }
     end
 
     def self.dependencies(name, version, _mapped_project)

--- a/app/models/package_manager/cpan.rb
+++ b/app/models/package_manager/cpan.rb
@@ -34,18 +34,18 @@ module PackageManager
       get("https://fastapi.metacpan.org/v1/release/#{name}")
     end
 
-    def self.mapping(project)
+    def self.mapping(raw_project)
       {
-        name: project["distribution"],
-        homepage: project.fetch("resources", {})["homepage"],
-        description: project["abstract"],
-        licenses: project.fetch("license", []).join(","),
-        repository_url: repo_fallback(project.fetch("resources", {}).fetch("repository", {})["web"], project.fetch("resources", {})["homepage"]),
+        name: raw_project["distribution"],
+        homepage: raw_project.fetch("resources", {})["homepage"],
+        description: raw_project["abstract"],
+        licenses: raw_project.fetch("license", []).join(","),
+        repository_url: repo_fallback(raw_project.fetch("resources", {}).fetch("repository", {})["web"], raw_project.fetch("resources", {})["homepage"]),
       }
     end
 
-    def self.versions(project, _name)
-      versions = get("https://fastapi.metacpan.org/v1/release/_search?q=distribution:#{project['distribution']}&size=5000&fields=version,date")["hits"]["hits"]
+    def self.versions(raw_project, _name)
+      versions = get("https://fastapi.metacpan.org/v1/release/_search?q=distribution:#{raw_project['distribution']}&size=5000&fields=version,date")["hits"]["hits"]
       versions.map do |version|
         {
           number: version["fields"]["version"],

--- a/app/models/package_manager/cran.rb
+++ b/app/models/package_manager/cran.rb
@@ -47,21 +47,21 @@ module PackageManager
       { name: name, html: html, info: info }
     end
 
-    def self.mapping(project)
+    def self.mapping(raw_project)
       {
-        name: project[:name],
-        homepage: project[:info].fetch("URL:", "").split(",").first,
-        description: project[:html].css("h2").text.split(":")[1..-1].join(":").strip,
-        licenses: project[:info]["License:"],
-        repository_url: repo_fallback("", (project[:info].fetch("URL:", "").split(",").first.presence || project[:info]["BugReports:"])).to_s[0, 255],
+        name: raw_project[:name],
+        homepage: raw_project[:info].fetch("URL:", "").split(",").first,
+        description: raw_project[:html].css("h2").text.split(":")[1..-1].join(":").strip,
+        licenses: raw_project[:info]["License:"],
+        repository_url: repo_fallback("", (raw_project[:info].fetch("URL:", "").split(",").first.presence || raw_project[:info]["BugReports:"])).to_s[0, 255],
       }
     end
 
-    def self.versions(project, _name)
+    def self.versions(raw_project, _name)
       [{
-        number: project[:info]["Version:"],
-        published_at: project[:info]["Published:"],
-      }] + find_old_versions(project)
+        number: raw_project[:info]["Version:"],
+        published_at: raw_project[:info]["Published:"],
+      }] + find_old_versions(raw_project)
     end
 
     def self.find_old_versions(project)

--- a/app/models/package_manager/dub.rb
+++ b/app/models/package_manager/dub.rb
@@ -24,20 +24,20 @@ module PackageManager
       get("http://code.dlang.org/packages/#{name}.json")
     end
 
-    def self.mapping(project)
-      latest_version = project["versions"].last
+    def self.mapping(raw_project)
+      latest_version = raw_project["versions"].last
       {
-        name: project["name"],
+        name: raw_project["name"],
         description: latest_version["description"],
         homepage: latest_version["homepage"],
-        keywords_array: format_keywords(project["categories"]),
+        keywords_array: format_keywords(raw_project["categories"]),
         licenses: latest_version["license"],
-        repository_url: repo_fallback(repository(project["repository"]), latest_version["homepage"]),
+        repository_url: repo_fallback(repository(raw_project["repository"]), latest_version["homepage"]),
       }
     end
 
-    def self.versions(project, _name)
-      acceptable_versions(project).map do |v|
+    def self.versions(raw_project, _name)
+      acceptable_versions(raw_project).map do |v|
         {
           number: v["version"],
           published_at: v["date"],

--- a/app/models/package_manager/elm.rb
+++ b/app/models/package_manager/elm.rb
@@ -36,15 +36,15 @@ module PackageManager
       get("http://package.elm-lang.org/packages/#{name}/latest/elm.json")
     end
 
-    def self.mapping(project)
+    def self.mapping(raw_project)
       {
-        name: project["name"],
-        description: project["summary"],
-        repository_url: "https://github.com/#{project['name']}",
+        name: raw_project["name"],
+        description: raw_project["summary"],
+        repository_url: "https://github.com/#{raw_project['name']}",
       }
     end
 
-    def self.versions(_project, name)
+    def self.versions(_raw_project, name)
       get("https://package.elm-lang.org/packages/#{name}/releases.json")
         .map do |version, timestamp|
           {

--- a/app/models/package_manager/emacs.rb
+++ b/app/models/package_manager/emacs.rb
@@ -27,12 +27,12 @@ module PackageManager
       projects[name].merge({"name" => name})
     end
 
-    def self.mapping(project)
+    def self.mapping(raw_project)
       {
-        name: project["name"],
-        description: project["desc"],
-        repository_url: project.fetch("props", {}).try(:fetch, 'url', ''),
-        keywords_array: Array.wrap(project.fetch("props", {}).try(:fetch, 'keywords', []))
+        name: raw_project["name"],
+        description: raw_project["desc"],
+        repository_url: raw_project.fetch("props", {}).try(:fetch, 'url', ''),
+        keywords_array: Array.wrap(raw_project.fetch("props", {}).try(:fetch, 'keywords', []))
       }
     end
   end

--- a/app/models/package_manager/go.rb
+++ b/app/models/package_manager/go.rb
@@ -107,16 +107,16 @@ module PackageManager
       end
     end
 
-    def self.versions(project, _name)
-      return [] if project.nil?
-      return project[:versions] if project[:versions]
+    def self.versions(raw_project, _name)
+      return [] if raw_project.nil?
+      return raw_project[:versions] if raw_project[:versions]
 
-      known_versions = Project.find_by(platform: "Go", name: project[:name])&.versions&.select(:number, :created_at, :published_at, :updated_at, :original_license)&.index_by(&:number) || {}
+      known_versions = Project.find_by(platform: "Go", name: raw_project[:name])&.versions&.select(:number, :created_at, :published_at, :updated_at, :original_license)&.index_by(&:number) || {}
 
       # NB fetching versions from the html only gets dates without timestamps, but we could alternatively use the go proxy too:
       #   1) Fetch the list of versions: https://proxy.golang.org/#{module_name}/@v/list
       #   2) And for each version, fetch https://proxy.golang.org/#{module_name}/@v/#{v}.info
-      get_raw("#{PROXY_BASE_URL}/#{project[:name]}/@v/list")
+      get_raw("#{PROXY_BASE_URL}/#{raw_project[:name]}/@v/list")
         &.lines
         &.map(&:strip)
         &.reject(&:blank?)
@@ -126,7 +126,7 @@ module PackageManager
           if known && known[:original_license].present?
             known.slice(:number, :created_at, :published_at, :original_license)
           else
-            one_version(project, v)
+            one_version(raw_project, v)
           end
       rescue Oj::ParseError
         next
@@ -134,19 +134,19 @@ module PackageManager
         &.compact
     end
 
-    def self.mapping(project)
-      if project[:html]
-        url = project[:overview_html]&.css(".UnitMeta-repo a")&.first&.attribute("href")&.value
+    def self.mapping(raw_project)
+      if raw_project[:html]
+        url = raw_project[:overview_html]&.css(".UnitMeta-repo a")&.first&.attribute("href")&.value
 
         {
-          name: project[:name],
-          description: project[:html].css(".Documentation-overview p").map(&:text).join("\n").strip,
-          licenses: project[:html].css('*[data-test-id="UnitHeader-license"]').map(&:text).join(","),
+          name: raw_project[:name],
+          description: raw_project[:html].css(".Documentation-overview p").map(&:text).join("\n").strip,
+          licenses: raw_project[:html].css('*[data-test-id="UnitHeader-license"]').map(&:text).join(","),
           repository_url: url,
           homepage: url,
         }
       else
-        { name: project[:name] }
+        { name: raw_project[:name] }
       end
     end
 

--- a/app/models/package_manager/hackage.rb
+++ b/app/models/package_manager/hackage.rb
@@ -37,20 +37,20 @@ module PackageManager
       }
     end
 
-    def self.mapping(project)
+    def self.mapping(raw_project)
       {
-        name: project[:name],
-        keywords_array: Array(project[:page].css("#content div:first a")[1..-1].map(&:text)),
-        description: description(project[:page]),
-        licenses: find_attribute(project[:page], "License"),
-        homepage: find_attribute(project[:page], "Home page"),
-        repository_url: repo_fallback(repository_url(find_attribute(project[:page], "Source repository")), find_attribute(project[:page], "Home page")),
+        name: raw_project[:name],
+        keywords_array: Array(raw_project[:page].css("#content div:first a")[1..-1].map(&:text)),
+        description: description(raw_project[:page]),
+        licenses: find_attribute(raw_project[:page], "License"),
+        homepage: find_attribute(raw_project[:page], "Home page"),
+        repository_url: repo_fallback(repository_url(find_attribute(raw_project[:page], "Source repository")), find_attribute(raw_project[:page], "Home page")),
       }
     end
 
-    def self.versions(project, _name)
-      versions = find_attribute(project[:page], "Versions")
-      versions = find_attribute(project[:page], "Version") if versions.nil?
+    def self.versions(raw_project, _name)
+      versions = find_attribute(raw_project[:page], "Versions")
+      versions = find_attribute(raw_project[:page], "Version") if versions.nil?
       versions.delete("(info)").split(",").map(&:strip).map do |v|
         {
           number: v,

--- a/app/models/package_manager/haxelib.rb
+++ b/app/models/package_manager/haxelib.rb
@@ -34,18 +34,18 @@ module PackageManager
       get_json("http://haxelib-json.herokuapp.com/package/#{name}")
     end
 
-    def self.mapping(project)
+    def self.mapping(raw_project)
       {
-        name: project["name"],
-        keywords_array: project["info"]["tags"],
-        description: project["info"]["desc"],
-        licenses: project["info"]["license"],
-        repository_url: repo_fallback(project["info"]["website"], ""),
+        name: raw_project["name"],
+        keywords_array: raw_project["info"]["tags"],
+        description: raw_project["info"]["desc"],
+        licenses: raw_project["info"]["license"],
+        repository_url: repo_fallback(raw_project["info"]["website"], ""),
       }
     end
 
-    def self.versions(project, _name)
-      project["info"]["versions"].map do |version|
+    def self.versions(raw_project, _name)
+      raw_project["info"]["versions"].map do |version|
         {
           number: version["name"],
           published_at: version["date"],

--- a/app/models/package_manager/hex.rb
+++ b/app/models/package_manager/hex.rb
@@ -44,21 +44,21 @@ module PackageManager
       get("https://hex.pm/api/packages/#{name}")
     end
 
-    def self.mapping(project)
-      links = project["meta"].fetch("links", {}).each_with_object({}) do |(k, v), h|
+    def self.mapping(raw_project)
+      links = raw_project["meta"].fetch("links", {}).each_with_object({}) do |(k, v), h|
         h[k.downcase] = v
       end
       {
-        name: project["name"],
+        name: raw_project["name"],
         homepage: links.except("github").first.try(:last),
         repository_url: links["github"],
-        description: project["meta"]["description"],
+        description: raw_project["meta"]["description"],
         licenses: repo_fallback(project["meta"].fetch("licenses", []).join(","), links.except("github").first.try(:last)),
       }
     end
 
-    def self.versions(project, _name)
-      project["releases"].map do |version|
+    def self.versions(raw_project, _name)
+      raw_project["releases"].map do |version|
         {
           number: version["version"],
           published_at: version["inserted_at"],

--- a/app/models/package_manager/homebrew.rb
+++ b/app/models/package_manager/homebrew.rb
@@ -30,19 +30,19 @@ module PackageManager
       get("https://formulae.brew.sh/api/formula/#{name}.json")
     end
 
-    def self.mapping(project)
+    def self.mapping(raw_project)
       {
-        name: project["name"],
-        description: project["desc"],
-        homepage: project["homepage"],
-        repository_url: repo_fallback("", project["homepage"]),
-        version: project.dig("versions", "stable"),
-        dependencies: project["dependencies"],
+        name: raw_project["name"],
+        description: raw_project["desc"],
+        homepage: raw_project["homepage"],
+        repository_url: repo_fallback("", raw_project["homepage"]),
+        version: raw_project.dig("versions", "stable"),
+        dependencies: raw_project["dependencies"],
       }
     end
 
-    def self.versions(project, _name)
-      stable = project.dig("versions", "stable")
+    def self.versions(raw_project, _name)
+      stable = raw_project.dig("versions", "stable")
       return [] if stable.blank?
 
       [

--- a/app/models/package_manager/inqlude.rb
+++ b/app/models/package_manager/inqlude.rb
@@ -25,13 +25,13 @@ module PackageManager
       Oj.load `cat inqlude-data/#{name}/#{version}`
     end
 
-    def self.mapping(project)
+    def self.mapping(raw_project)
       {
-        name: project['name'],
-        description: project["summary"],
-        homepage: project["urls"]["homepage"],
-        licenses: project['licenses'].join(','),
-        repository_url: repo_fallback(project["urls"]["vcs"], '')
+        name: raw_project['name'],
+        description: raw_project["summary"],
+        homepage: raw_project["urls"]["homepage"],
+        licenses: raw_project['licenses'].join(','),
+        repository_url: repo_fallback(raw_project["urls"]["vcs"], '')
       }
     end
   end

--- a/app/models/package_manager/julia.rb
+++ b/app/models/package_manager/julia.rb
@@ -26,15 +26,15 @@ module PackageManager
       }
     end
 
-    def self.mapping(project)
+    def self.mapping(raw_project)
       {
-        name: project[:name],
-        repository_url: repo_fallback(project[:repository_url], ""),
+        name: raw_project[:name],
+        repository_url: repo_fallback(raw_project[:repository_url], ""),
       }
     end
 
-    def self.versions(project, _name)
-      project["versions"].map do |v|
+    def self.versions(raw_project, _name)
+      raw_project["versions"].map do |v|
         {
           number: v,
         }

--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -62,9 +62,9 @@ module PackageManager
       {}
     end
 
-    def self.mapping(project, depth = 0)
-      latest_version_xml = get_pom(project[:group_id], project[:artifact_id], project[:latest_version])
-      mapping_from_pom_xml(latest_version_xml, depth).merge({ name: project[:name] })
+    def self.mapping(raw_project, depth = 0)
+      latest_version_xml = get_pom(raw_project[:group_id], raw_project[:artifact_id], raw_project[:latest_version])
+      mapping_from_pom_xml(latest_version_xml, depth).merge({ name: raw_project[:name] })
     rescue POMNotFound => e
       Rails.logger.info "Missing POM: #{e.url}"
       nil
@@ -134,9 +134,9 @@ module PackageManager
       end
     end
 
-    def self.versions(project, name)
-      if project && project[:versions]
-        project[:versions]
+    def self.versions(raw_project, name)
+      if raw_project && raw_project[:versions]
+        raw_project[:versions]
       else
         xml_metadata = maven_metadata(name)
         xml_versions = Nokogiri::XML(xml_metadata).css("version").map(&:text)

--- a/app/models/package_manager/meteor.rb
+++ b/app/models/package_manager/meteor.rb
@@ -39,18 +39,18 @@ module PackageManager
       projects[name.downcase]
     end
 
-    def self.mapping(project)
+    def self.mapping(raw_project)
       {
-        name: project["name"],
-        description: project["description"],
-        repository_url: repo_fallback(project["git"], nil),
+        name: raw_project["name"],
+        description: raw_project["description"],
+        repository_url: repo_fallback(raw_project["git"], nil),
       }
     end
 
-    def self.versions(project, _name)
+    def self.versions(raw_project, _name)
       [{
-        number: project["version"],
-        published_at: Time.at(project["published"]["$date"] / 1000.0),
+        number: raw_project["version"],
+        published_at: Time.at(raw_project["published"]["$date"] / 1000.0),
       }]
     end
   end

--- a/app/models/package_manager/nimble.rb
+++ b/app/models/package_manager/nimble.rb
@@ -30,14 +30,14 @@ module PackageManager
       projects[name.downcase]
     end
 
-    def self.mapping(project)
+    def self.mapping(raw_project)
       {
-        name: project["name"],
-        description: project["description"],
-        repository_url: repo_fallback(project['url'],project['web']),
-        keywords_array: Array.wrap(project["tags"]),
-        licenses: project['license'],
-        homepage: project['web']
+        name: raw_project["name"],
+        description: raw_project["description"],
+        repository_url: repo_fallback(raw_project['url'], raw_project['web']),
+        keywords_array: Array.wrap(raw_project["tags"]),
+        licenses: raw_project['license'],
+        homepage: raw_project['web']
       }
     end
   end

--- a/app/models/package_manager/npm.rb
+++ b/app/models/package_manager/npm.rb
@@ -49,22 +49,22 @@ module PackageManager
       }
     end
 
-    def self.mapping(project)
-      return nil unless project["versions"].present?
+    def self.mapping(raw_project)
+      return nil unless raw_project["versions"].present?
 
-      latest_version = project["versions"].to_a.last[1]
+      latest_version = raw_project["versions"].to_a.last[1]
 
       repo = latest_version.fetch("repository", {})
       repo = repo[0] if repo.is_a?(Array)
       repo_url = repo.try(:fetch, "url", nil)
 
       {
-        name: project["name"],
+        name: raw_project["name"],
         description: latest_version["description"],
-        homepage: project["homepage"],
+        homepage: raw_project["homepage"],
         keywords_array: Array.wrap(latest_version.fetch("keywords", [])),
         licenses: licenses(latest_version),
-        repository_url: repo_fallback(repo_url, project["homepage"]),
+        repository_url: repo_fallback(repo_url, raw_project["homepage"]),
       }
     end
 
@@ -88,16 +88,16 @@ module PackageManager
       end
     end
 
-    def self.versions(project, _name)
+    def self.versions(raw_project, _name)
       # npm license fields are supposed to be SPDX expressions now https://docs.npmjs.com/files/package.json#license
-      return [] if project.nil?
-      project.fetch("versions", {}).map do |k, v|
+      return [] if raw_project.nil?
+      raw_project.fetch("versions", {}).map do |k, v|
         license = v.fetch("license", nil)
         license = licenses(v) unless license.is_a?(String)
         license = "" if license.nil?
         {
           number: k,
-          published_at: project.fetch("time", {}).fetch(k, nil),
+          published_at: raw_project.fetch("time", {}).fetch(k, nil),
           original_license: license,
         }
       end

--- a/app/models/package_manager/nu_get.rb
+++ b/app/models/package_manager/nu_get.rb
@@ -91,16 +91,16 @@ module PackageManager
       []
     end
 
-    def self.mapping(project)
-      item = project[:releases].last["catalogEntry"]
+    def self.mapping(raw_project)
+      item = raw_project[:releases].last["catalogEntry"]
 
       {
-        name: project[:name],
+        name: raw_project[:name],
         description: description(item),
         homepage: item["projectUrl"],
         keywords_array: Array(item["tags"]),
         repository_url: repo_fallback("", item["projectUrl"]),
-        releases: project[:releases],
+        releases: raw_project[:releases],
         licenses: item["licenseExpression"],
       }
     end
@@ -109,8 +109,8 @@ module PackageManager
       item["description"].blank? ? item["summary"] : item["description"]
     end
 
-    def self.versions(project, _name)
-      project[:releases].map do |item|
+    def self.versions(raw_project, _name)
+      raw_project[:releases].map do |item|
         license = [
           item.dig("catalogEntry", "licenseExpression"),
           item.dig("catalogEntry", "licenseUrl"),

--- a/app/models/package_manager/packagist.rb
+++ b/app/models/package_manager/packagist.rb
@@ -40,13 +40,13 @@ module PackageManager
       }
     end
 
-    def self.mapping(project)
-      return nil unless project["versions"].any?
+    def self.mapping(raw_project)
+      return nil unless raw_project["versions"].any?
 
       # for version comparison of php, we want to reject any dev versions unless
       # there are only dev versions of the project
-      versions = project["versions"].values.reject { |v| v["version"].include? "dev" }
-      versions = project["versions"].values if versions.empty?
+      versions = raw_project["versions"].values.reject { |v| v["version"].include? "dev" }
+      versions = raw_project["versions"].values if versions.empty?
       # then we'll use the most recently published as our most recent version
       latest_version = versions.max_by { |v| v["time"] }
       {
@@ -55,11 +55,11 @@ module PackageManager
         homepage: latest_version["home_page"],
         keywords_array: Array.wrap(latest_version["keywords"]),
         licenses: latest_version["license"].join(","),
-        repository_url: repo_fallback(project["repository"], latest_version["home_page"]),
+        repository_url: repo_fallback(raw_project["repository"], latest_version["home_page"]),
       }
     end
 
-    def self.versions(_project, name)
+    def self.versions(_raw_project, name)
       # TODO: Use composer v2 and unminify data https://packagist.org/apidoc
       versions = get("https://repo.packagist.org/p/#{name}.json").dig("packages", name)
 

--- a/app/models/package_manager/platform_io.rb
+++ b/app/models/package_manager/platform_io.rb
@@ -38,19 +38,19 @@ module PackageManager
       end
     end
 
-    def self.mapping(project)
+    def self.mapping(raw_project)
       {
-        name: project["name"],
-        pm_id: project["id"],
-        homepage: project["homepage"],
-        description: project["description"],
-        keywords_array: Array.wrap(project["keywords"]),
-        repository_url: repo_fallback("", project["repository"]),
+        name: raw_project["name"],
+        pm_id: raw_project["id"],
+        homepage: raw_project["homepage"],
+        description: raw_project["description"],
+        keywords_array: Array.wrap(raw_project["keywords"]),
+        repository_url: repo_fallback("", raw_project["repository"]),
       }
     end
 
-    def self.versions(project, _name)
-      version = project["version"]
+    def self.versions(raw_project, _name)
+      version = raw_project["version"]
       return [] if version.nil?
 
       [{

--- a/app/models/package_manager/pub.rb
+++ b/app/models/package_manager/pub.rb
@@ -41,10 +41,10 @@ module PackageManager
       get("https://pub.dartlang.org/api/packages/#{name}")
     end
 
-    def self.mapping(project)
-      latest_version = project["versions"].last
+    def self.mapping(raw_project)
+      latest_version = raw_project["versions"].last
       {
-        name: project["name"],
+        name: raw_project["name"],
         homepage: latest_version["pubspec"]["homepage"],
         description: latest_version["pubspec"]["description"],
         repository_url: repo_fallback("", latest_version["pubspec"]["homepage"]),
@@ -52,7 +52,7 @@ module PackageManager
     end
 
     def self.versions(project, _name)
-      project["versions"].map do |v|
+      raw_project["versions"].map do |v|
         {
           number: v["version"],
         }

--- a/app/models/package_manager/puppet.rb
+++ b/app/models/package_manager/puppet.rb
@@ -26,11 +26,11 @@ module PackageManager
       get_json("https://forgeapi.puppetlabs.com/v3/modules/#{name}")
     end
 
-    def self.mapping(project)
-      current_release = project["current_release"]
+    def self.mapping(raw_project)
+      current_release = raw_project["current_release"]
       metadata = current_release["metadata"]
       {
-        name: project["slug"],
+        name: raw_project["slug"],
         repository_url: metadata["source"],
         description: metadata["description"],
         keywords_array: current_release["tags"],
@@ -38,8 +38,8 @@ module PackageManager
       }
     end
 
-    def self.versions(project, _name)
-      project["releases"].map do |release|
+    def self.versions(raw_project, _name)
+      raw_project["releases"].map do |release|
         {
           number: release["version"],
           published_at: release["created_at"],

--- a/app/models/package_manager/pure_script.rb
+++ b/app/models/package_manager/pure_script.rb
@@ -18,10 +18,10 @@ module PackageManager
       project
     end
 
-    def self.mapping(project)
+    def self.mapping(raw_project)
       {
-        name: project['name'],
-        repository_url: project['repo']
+        name: raw_project['name'],
+        repository_url: raw_project['repo']
       }
     end
 

--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -65,23 +65,23 @@ module PackageManager
       }
     end
 
-    def self.mapping(project)
+    def self.mapping(raw_project)
       {
-        name: project["info"]["name"],
-        description: project["info"]["summary"],
-        homepage: project["info"]["home_page"],
-        keywords_array: Array.wrap(project["info"]["keywords"].try(:split, /[\s.,]+/)),
-        licenses: licenses(project),
+        name: raw_project["info"]["name"],
+        description: raw_project["info"]["summary"],
+        homepage: raw_project["info"]["home_page"],
+        keywords_array: Array.wrap(raw_project["info"]["keywords"].try(:split, /[\s.,]+/)),
+        licenses: licenses(raw_project),
         repository_url: repo_fallback(
-          project.dig("info", "project_urls", "Source").presence || project.dig("info", "project_urls", "Source Code"),
-          project["info"]["home_page"].presence || project.dig("info", "project_urls", "Homepage")
+          raw_project.dig("info", "project_urls", "Source").presence || raw_project.dig("info", "project_urls", "Source Code"),
+          raw_project["info"]["home_page"].presence || raw_project.dig("info", "project_urls", "Homepage")
         ),
       }
     end
 
-    def self.versions(project, name)
-      return [] if project.nil?
-      project["releases"].reject { |_k, v| v == [] }.map do |k, v|
+    def self.versions(raw_project, name)
+      return [] if raw_project.nil?
+      raw_project["releases"].reject { |_k, v| v == [] }.map do |k, v|
         release = get("https://pypi.org/pypi/#{name}/#{k}/json")
         {
           number: k,

--- a/app/models/package_manager/racket.rb
+++ b/app/models/package_manager/racket.rb
@@ -22,13 +22,13 @@ module PackageManager
       }
     end
 
-    def self.mapping(project)
+    def self.mapping(raw_project)
       {
-        name: project[:name],
-        repository_url: project[:page].at('a:contains("Code")')&.attributes.try(:[], "href")&.text,
-        description: project[:page].css('.jumbotron p')&.first&.children&.first&.text,
-        homepage: homepage_link(project[:page]).present? ? homepage_link(project[:page]).attributes['href'].value : '',
-        keywords_array: project[:page].at('th:contains("Tags")').parent.css('a')&.map{|el| el.children.first.try(:text)}
+        name: raw_project[:name],
+        repository_url: raw_project[:page].at('a:contains("Code")')&.attributes.try(:[], "href")&.text,
+        description: raw_project[:page].css('.jumbotron p')&.first&.children&.first&.text,
+        homepage: homepage_link(project[:page]).present? ? homepage_link(raw_project[:page]).attributes['href'].value : '',
+        keywords_array: raw_project[:page].at('th:contains("Tags")').parent.css('a')&.map{|el| el.children.first.try(:text)}
       }
     end
 

--- a/app/models/package_manager/rubygems.rb
+++ b/app/models/package_manager/rubygems.rb
@@ -47,18 +47,18 @@ module PackageManager
       {}
     end
 
-    def self.mapping(project)
+    def self.mapping(raw_project)
       {
-        name: project["name"],
-        description: project["info"],
-        homepage: project["homepage_uri"],
-        licenses: project.fetch("licenses", []).try(:join, ","),
-        repository_url: repo_fallback(project["source_code_uri"], project["homepage_uri"]),
+        name: raw_project["name"],
+        description: raw_project["info"],
+        homepage: raw_project["homepage_uri"],
+        licenses: raw_project.fetch("licenses", []).try(:join, ","),
+        repository_url: repo_fallback(raw_project["source_code_uri"], raw_project["homepage_uri"]),
       }
     end
 
-    def self.versions(project, _name)
-      json = get_json("https://rubygems.org/api/v1/versions/#{project['name']}.json")
+    def self.versions(raw_project, _name)
+      json = get_json("https://rubygems.org/api/v1/versions/#{raw_project['name']}.json")
       json.map do |v|
         license = v.fetch("licenses", "")
         license = "" if license.nil?

--- a/app/models/package_manager/shards.rb
+++ b/app/models/package_manager/shards.rb
@@ -20,10 +20,10 @@ module PackageManager
       get("https://crystal-shards-registry.herokuapp.com/api/v1/shards/#{name}")
     end
 
-    def self.mapping(project)
+    def self.mapping(raw_project)
       {
-        name: project["name"],
-        repository_url: repo_fallback(project["url"], nil)
+        name: raw_project["name"],
+        repository_url: repo_fallback(raw_project["url"], nil)
       }
     end
   end

--- a/app/models/package_manager/sublime.rb
+++ b/app/models/package_manager/sublime.rb
@@ -21,18 +21,18 @@ module PackageManager
         .then { |resp| resp.status == 200 ? Oj.load(resp.body) : nil }
     end
 
-    def self.mapping(project)
+    def self.mapping(raw_project)
       {
-        name: project["name"],
-        description: project["description"],
-        homepage: project["homepage"],
-        repository_url: repo_fallback(parse_repo(project["issues"]), project["homepage"]),
-        keywords_array: Array.wrap(project["labels"]),
+        name: raw_project["name"],
+        description: raw_project["description"],
+        homepage: raw_project["homepage"],
+        repository_url: repo_fallback(parse_repo(raw_project["issues"]), raw_project["homepage"]),
+        keywords_array: Array.wrap(raw_project["labels"]),
       }
     end
 
-    def self.versions(project, _name)
-      project["versions"].map do |v|
+    def self.versions(raw_project, _name)
+      raw_project["versions"].map do |v|
         {
           number: v["version"],
         }

--- a/app/models/package_manager/swift_pm.rb
+++ b/app/models/package_manager/swift_pm.rb
@@ -19,10 +19,10 @@ module PackageManager
       }
     end
 
-    def self.mapping(project)
+    def self.mapping(raw_project)
       {
-        name: project[:name],
-        repository_url: project[:repository_url]
+        name: raw_project[:name],
+        repository_url: raw_project[:repository_url]
       }
     end
   end

--- a/app/models/package_manager/wordpress.rb
+++ b/app/models/package_manager/wordpress.rb
@@ -78,8 +78,8 @@ module PackageManager
       else
         [
           {
-            number: project["version"],
-            published_at: project["last_updated"],
+            number: raw_project["version"],
+            published_at: raw_project["last_updated"],
           }
         ]
       end

--- a/app/models/package_manager/wordpress.rb
+++ b/app/models/package_manager/wordpress.rb
@@ -55,24 +55,24 @@ module PackageManager
       get("https://api.wordpress.org/plugins/info/1.0/#{name}.json")
     end
 
-    def self.mapping(project)
+    def self.mapping(raw_project)
       {
-        name: project["slug"],
-        description: project["short_description"],
-        homepage: project["homepage"],
-        keywords_array: (project["tags"].presence || {}).values,
-        repository_url: repo_fallback("", project["homepage"]),
+        name: raw_project["slug"],
+        description: raw_project["short_description"],
+        homepage: raw_project["homepage"],
+        keywords_array: (raw_project["tags"].presence || {}).values,
+        repository_url: repo_fallback("", raw_project["homepage"]),
       }
     end
 
-    def self.versions(project, _name)
-      if project["versions"].present?
-        project["versions"]
+    def self.versions(raw_project, _name)
+      if raw_project["versions"].present?
+        raw_project["versions"]
           .reject { |k, _v| k == "trunk" }
           .map do |k, _v|
           {
             number: k,
-            published_at: k == project["version"] ? project["last_updated"] : nil
+            published_at: k == raw_project["version"] ? raw_project["last_updated"] : nil
           }
         end
       else

--- a/docs/add-a-package-manager.md
+++ b/docs/add-a-package-manager.md
@@ -98,14 +98,14 @@ After getting the information about a package from the registry, we need to form
 Here's an example from [Cargo](../app/models/package_manager/cargo.rb):
 
 ```ruby
-def self.mapping(project)
+def self.mapping(raw_project)
   {
-    :name => project['crate']['id'],
-    :homepage => project['crate']['homepage'],
-    :description => project['crate']['description'],
-    :keywords_array => Array.wrap(project['crate']['keywords']),
-    :licenses => project['crate']['license'],
-    :repository_url => repo_fallback(project['crate']['repository'], project['crate']['homepage'])
+    :name => raw_project['crate']['id'],
+    :homepage => raw_project['crate']['homepage'],
+    :description => raw_project['crate']['description'],
+    :keywords_array => Array.wrap(raw_project['crate']['keywords']),
+    :licenses => raw_project['crate']['license'],
+    :repository_url => repo_fallback(raw_project['crate']['repository'], raw_project['crate']['homepage'])
   }
 end
 ```
@@ -123,13 +123,31 @@ This method takes the returned data from the `#project` method and should return
 Here's an example from [NuGet](../app/models/package_manager/nu_get.rb):
 
 ```ruby
-def self.versions(project, _name)
-  project[:releases].map do |item|
+def self.versions(raw_project, _name)
+  raw_project[:releases].map do |item|
     {
       number: item['catalogEntry']['version'],
       published_at: item['catalogEntry']['published']
     }
   end
+end
+```
+
+### `#one_version`
+
+For package managers that we can update using a single version instead of all versions.
+
+This method should take the returned data from the `#project` method and should return a single version, with the same data
+that `versions()` returns.
+
+```ruby
+def self.one_version(raw_project, version_string)
+  raw_project["versions"]
+    .find { |v| v["number"] == version_string }
+    .map do |item|
+      number: item["number"],
+      published_at: item["published"]
+    end
 end
 ```
 


### PR DESCRIPTION
These methods in `PackageManager::Base` classes take an argument `project`, which is the result of the `project()` method. Sometimes I forget if it's that or the result of `mapping()` though, so I propose we make the arg names more specific. 