### PR TITLE
bibliothecary 6.9.7 ~> 6.12.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby "2.6.5"
 gem "active_model_serializers"
 gem "api-pagination"
 gem "asciidoctor"
-gem "bibliothecary", "~> 6.12.2"
+gem "bibliothecary"
 gem "bitbucket_rest_api", git: "https://github.com/librariesio/bitbucket"
 gem "bootsnap", require: false
 gem "bootstrap-sass"

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby "2.6.5"
 gem "active_model_serializers"
 gem "api-pagination"
 gem "asciidoctor"
-gem "bibliothecary"
+gem "bibliothecary", "~> 6.12.2"
 gem "bitbucket_rest_api", git: "https://github.com/librariesio/bitbucket"
 gem "bootsnap", require: false
 gem "bootstrap-sass"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,8 +176,8 @@ GEM
       multi_json
     erubi (1.10.0)
     escape_utils (1.2.1)
-    ethon (0.12.0)
-      ffi (>= 1.3.0)
+    ethon (0.14.0)
+      ffi (>= 1.15.0)
     excon (0.72.0)
     execjs (2.7.0)
     factory_bot (5.0.2)
@@ -198,7 +198,7 @@ GEM
       rake
       rake-compiler
     fast_xs (0.8.0)
-    ffi (1.14.2)
+    ffi (1.15.1)
     fog-aws (3.5.0)
       fog-core (~> 2.1)
       fog-json (~> 1.1)
@@ -636,7 +636,7 @@ GEM
     uber (0.1.0)
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (1.6.1)
+    unicode-display_width (1.7.0)
     unicode_utils (1.4.0)
     vcr (4.0.0)
     webmock (3.5.1)
@@ -661,7 +661,7 @@ DEPENDENCIES
   active_model_serializers
   api-pagination
   asciidoctor
-  bibliothecary (~> 6.12.2)
+  bibliothecary
   bitbucket_rest_api!
   bootsnap
   bootstrap-sass

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
     ast (2.4.2)
     autoprefixer-rails (9.5.1.1)
       execjs
-    bibliothecary (6.9.7)
+    bibliothecary (6.12.2)
       commander
       deb_control
       librariesio-gem-parser
@@ -131,7 +131,7 @@ GEM
     citrus (3.0.2)
     cliver (0.3.2)
     coderay (1.1.2)
-    commander (4.5.2)
+    commander (4.6.0)
       highline (~> 2.0.0)
     commonmarker (0.20.1)
       ruby-enum (~> 0.5)
@@ -403,7 +403,7 @@ GEM
     org-ruby (0.9.12)
       rubypants (~> 0.2)
     os (1.1.1)
-    ox (2.14.1)
+    ox (2.14.4)
     parallel (1.17.0)
     parser (3.0.0.0)
       ast (~> 2.4.1)
@@ -611,9 +611,9 @@ GEM
       google-cloud-trace (~> 0.33)
     stackdriver-core (1.4.0)
       google-cloud-core (~> 1.2)
-    strings (0.2.0)
+    strings (0.2.1)
       strings-ansi (~> 0.2)
-      unicode-display_width (~> 1.5)
+      unicode-display_width (>= 1.5, < 3.0)
       unicode_utils (~> 1.4)
     strings-ansi (0.2.0)
     terminal-table (1.8.0)
@@ -661,7 +661,7 @@ DEPENDENCIES
   active_model_serializers
   api-pagination
   asciidoctor
-  bibliothecary
+  bibliothecary (~> 6.12.2)
   bitbucket_rest_api!
   bootsnap
   bootstrap-sass


### PR DESCRIPTION
Looks like we haven't bumped bibliothecary in a few months, so here's a diff:

https://github.com/librariesio/bibliothecary/compare/v6.9.7...v6.12.2