### PR TITLE
Search: exclude platforms removed from code but still exist in db/ES.

### DIFF
--- a/app/models/concerns/project_search.rb
+++ b/app/models/concerns/project_search.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 module ProjectSearch
+  # Whenever a PackageManager::Base platform is removed, it's easier for now to
+  # just add it to this list, until the records/indices are cleared out of that platform.
+  # NB these are the casings from the database, which sometimes don't match the PackageManager::Base
+  # formatted_name casings, e.g. Pypi vs PyPI
+  REMOVED_PLATFORMS = %w(Sublime Wordpress Atom PlatformIO Shards Emacs)
+
   extend ActiveSupport::Concern
 
   included do
@@ -131,7 +137,8 @@ module ProjectSearch
                      must: [],
                      must_not: [
                        { term: { "status" => "Hidden" } },
-                       { term: { "status" => "Removed" } }
+                       { term: { "status" => "Removed" } },
+                       { terms: { "platform" => REMOVED_PLATFORMS } }
                      ]
                   }
                 }


### PR DESCRIPTION
Some records are now throwing 500s in search because they exist in the db/ES but their PackageManager::Base platform was removed. Until we remove those records in a cleanup, this ignores those removed platforms in all project searches explicitly. This should also exclude those removed platforms from faceting too 👍🏻 

Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/60ae50aca940100007305441

