### PR TITLE
Ignore Jam in Project search too.

### DIFF
--- a/app/models/concerns/project_search.rb
+++ b/app/models/concerns/project_search.rb
@@ -4,7 +4,7 @@ module ProjectSearch
   # just add it to this list, until the records/indices are cleared out of that platform.
   # NB these are the casings from the database, which sometimes don't match the PackageManager::Base
   # formatted_name casings, e.g. Pypi vs PyPI
-  REMOVED_PLATFORMS = %w(Sublime Wordpress Atom PlatformIO Shards Emacs)
+  REMOVED_PLATFORMS = %w(Sublime Wordpress Atom PlatformIO Shards Emacs Jam)
 
   extend ActiveSupport::Concern
 


### PR DESCRIPTION
Forgot to add Jam to ignored Project search package managers.

Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/60ae50aca940100007305441

