### PR TITLE
Remove duplicate handling for failed version lookup

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -117,11 +117,7 @@ module PackageManager
           versions(raw_project, db_project.name)
             .each { |v| add_version(db_project, v) }
             .tap { |vs| deprecate_versions(db_project, vs) }
-        else
-          version = one_version(raw_project, sync_version)
-
-          raise "#{db_platform}/#{db_project.name} version #{sync_version} requested but not found" if version.nil?
-
+        elsif (version = one_version(raw_project, sync_version))
           add_version(db_project, version)
           # TODO: handle deprecation here too
         end


### PR DESCRIPTION
This is a duplicate error thrown on a version lookup failure. In https://github.com/librariesio/libraries.io/pull/2829 a custom error was introduced so that we can rely on sidekiq retries but not send to bugsnag. This also doesn't need to get sent to bugsnag, and we can rely on that worker exception.