### PR TITLE
Add byebug and pry-byebug as dev/test dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,7 +101,9 @@ group :development do
 end
 
 group :development, :test do
+  gem 'byebug'
   gem "pry"
+  gem 'pry-byebug'
   gem "rspec-rails"
   gem "rubocop", "~> 1.0.0", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,7 @@ GEM
     bugsnag (6.11.1)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
+    byebug (11.1.3)
     capybara (2.18.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -428,6 +429,9 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-byebug (3.8.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.6)
@@ -669,6 +673,7 @@ DEPENDENCIES
   brotli
   bugsnag
   bundler
+  byebug
   charlock_holmes (>= 0.7.5)
   chartkick (~> 3.4)
   chronic
@@ -729,6 +734,7 @@ DEPENDENCIES
   poltergeist (= 1.17.0)
   premailer-rails (= 1.9.7)
   pry
+  pry-byebug
   pry-rails
   puma
   rack-attack


### PR DESCRIPTION
I thought it would be helpful to have these libraries around to help with debugging in the dev/testing environments, as you would be able to step through/over/continue/etc. from the pry console when you hit a `binding.pry` in the code.