### PR TITLE
Add epl2 url to LICENSE_STRINGS

### DIFF
--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -157,6 +157,12 @@ module PackageManager
           rescue StandardError
             license_list = nil
           end
+
+          if license_list.blank? && pom.respond_to?("project") && pom.project.locate("parent").present?
+            parent_version = extract_pom_value(pom.project, "parent/version")
+            Rails.logger.info("[POM has parent no license] name=#{name} parent_version=#{parent_version} child_version=#{version}")
+          end
+
           {
             number: version,
             published_at: Time.parse(pom.locate("publishedAt").first.text),

--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -13,6 +13,7 @@ module PackageManager
     LICENSE_STRINGS = {
       "http://www.apache.org/licenses/LICENSE-2.0" => "Apache-2.0",
       "http://www.eclipse.org/legal/epl-v10" => "Eclipse Public License (EPL), Version 1.0",
+      "http://www.eclipse.org/legal/epl-2.0" => "Eclipse Public License (EPL), Version 2.0",
       "http://www.eclipse.org/org/documents/edl-v10" => "Eclipse Distribution License (EDL), Version 1.0",
     }.freeze
     NAME_DELIMITER = ":"
@@ -29,6 +30,7 @@ module PackageManager
 
     class POMNotFound < StandardError
       attr_reader :url
+
       def initialize(url)
         @url = url
         super("Missing POM: #{@url}")
@@ -145,6 +147,8 @@ module PackageManager
     end
 
     def self.retrieve_versions(versions, name)
+      # TODO: This should also look for the parent POM and if it exists + the child POM
+      # is missing license data, use the data from the parent POM
       versions
         .map do |version|
           pom = get_pom(*name.split(NAME_DELIMITER, 2), version)
@@ -167,7 +171,7 @@ module PackageManager
     def self.download_pom(group_id, artifact_id, version)
       url = MavenUrl.new(group_id, artifact_id, repository_base).pom(version)
       pom_request = request(url)
-      raise POMNotFound.new(url) if pom_request.status == 404
+      raise POMNotFound, url if pom_request.status == 404
 
       xml = Ox.parse(pom_request.body)
       published_at = pom_request.headers["Last-Modified"]

--- a/spec/fixtures/proto-google-common-protos-0.1.9.pom
+++ b/spec/fixtures/proto-google-common-protos-0.1.9.pom
@@ -53,3 +53,4 @@
     </dependency>
   </dependencies>
 </project>
+<publishedAt>Fri, 11 Oct 2019 20:00:00 GMT</publishedAt>

--- a/spec/models/package_manager/maven_spec.rb
+++ b/spec/models/package_manager/maven_spec.rb
@@ -108,7 +108,7 @@ describe PackageManager::Maven do
       it "should return nil" do
         allow(described_class).to receive(:download_pom).and_raise(PackageManager::Maven::POMNotFound.new("https://a-spring-url"))
 
-        expect(described_class.mapping({group_id: "org", artifact_id: "foo", version: "1.0.0"})).to eq(nil)
+        expect(described_class.mapping({ group_id: "org", artifact_id: "foo", version: "1.0.0" })).to eq(nil)
       end
     end
   end
@@ -160,11 +160,10 @@ describe PackageManager::Maven do
       allow(described_class)
         .to receive(:download_pom)
         .and_raise(PackageManager::Maven::POMNotFound.new("https://a-maven-central-url"))
-      raw_project = {name: "org.foo:bar"}
+      raw_project = { name: "org.foo:bar" }
 
-      expect(PackageManager::Maven::MavenCentral.one_version(raw_project, "1.0.0")). to eq(nil)
+      expect(PackageManager::Maven::MavenCentral.one_version(raw_project, "1.0.0")).to eq(nil)
     end
-
   end
 
   describe ".versions" do
@@ -175,31 +174,61 @@ describe PackageManager::Maven do
 
       project = described_class.project("javax.faces:javax.faces-api")
       expect(described_class.versions(project, "javax.faces:javax.faces-api")).to eq([
-        { number: "2.3", published_at: "2019-06-05T10:50:00Z" }
+        { number: "2.3", published_at: "2019-06-05T10:50:00Z" },
       ])
     end
 
     it "skips versions that can't be parsed" do
       expect(described_class)
         .to receive(:get_raw)
-          .with("https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/maven-metadata.xml")
-          .and_return(File.open("spec/fixtures/proto-google-common-protos-0.1.9.pom").read)
+        .with("https://repo1.maven.org/maven2/com/google/api/grpc/proto-google-common-protos/maven-metadata.xml")
+        .and_return(File.open("spec/fixtures/proto-google-common-protos-0.1.9.pom").read)
       allow(described_class)
         .to receive(:get_pom)
-          .with("com.google.api.grpc", "proto-google-common-protos", "0.1.9")
-          .and_raise(Ox::ParseError.new(""))
+        .with("com.google.api.grpc", "proto-google-common-protos", "0.1.9")
+        .and_raise(Ox::ParseError.new(""))
 
       # TODO: these are probably bugs... it's using the version 3.2.0/etc of a depdendency and looking that up on itself
       allow(described_class)
         .to receive(:get_pom)
-          .with("com.google.api.grpc", "proto-google-common-protos", "3.2.0")
-          .and_raise(Ox::ParseError.new(""))
+        .with("com.google.api.grpc", "proto-google-common-protos", "3.2.0")
+        .and_raise(Ox::ParseError.new(""))
       allow(described_class)
         .to receive(:get_pom)
-          .with("com.google.api.grpc", "proto-google-common-protos", "${api.version}")
-          .and_raise(Ox::ParseError.new(""))
+        .with("com.google.api.grpc", "proto-google-common-protos", "${api.version}")
+        .and_raise(Ox::ParseError.new(""))
 
       expect(described_class.versions(nil, "com.google.api.grpc:proto-google-common-protos")).to eq([])
+    end
+  end
+
+  describe "retrieve_versions" do
+    context "POM has a parent" do
+      let(:pom) { Ox.parse(File.open("spec/fixtures/proto-google-common-protos-0.1.9.pom").read) }
+
+      before do
+        allow(described_class).to receive(:get_pom).and_return(pom)
+      end
+
+      context "POM has a license" do
+        it "does not log a message" do
+          expect(Rails.logger).to_not receive(:info)
+
+          described_class.retrieve_versions(["0.1.9"], "com.google.api.grpc:proto-google-common-protos")
+        end
+      end
+
+      context "POM has no license" do
+        before do
+          allow(described_class).to receive(:licenses).and_return([])
+        end
+
+        it "does logs a message" do
+          expect(Rails.logger).to receive(:info).with("[POM has parent no license] name=com.google.api.grpc:proto-google-common-protos parent_version=0.1.9 child_version=0.1.9")
+
+          described_class.retrieve_versions(["0.1.9"], "com.google.api.grpc:proto-google-common-protos")
+        end
+      end
     end
   end
 
@@ -361,8 +390,8 @@ describe PackageManager::Maven do
       it "returns the latest version" do
         expect(described_class)
           .to receive(:get_raw)
-            .with("https://repo1.maven.org/maven2/com/tidelift/test/maven-metadata.xml")
-            .and_return(File.open("spec/fixtures/tidelift-maven_metadata.xml").read)
+          .with("https://repo1.maven.org/maven2/com/tidelift/test/maven-metadata.xml")
+          .and_return(File.open("spec/fixtures/tidelift-maven_metadata.xml").read)
 
         expect(described_class.latest_version("com.tidelift:test")).to eq("1.0.5")
       end

--- a/spec/models/package_manager/maven_spec.rb
+++ b/spec/models/package_manager/maven_spec.rb
@@ -202,7 +202,7 @@ describe PackageManager::Maven do
     end
   end
 
-  describe "retrieve_versions" do
+  describe ".retrieve_versions" do
     context "POM has a parent" do
       let(:pom) { Ox.parse(File.open("spec/fixtures/proto-google-common-protos-0.1.9.pom").read) }
 


### PR DESCRIPTION
This is a quick fix to resolve the missing license information for the org.jacoco:org.jacoco.* packages. I was able to get the EPL2 license information locally with this change. 

See https://app.clubhouse.io/tidelift/story/18585/license-missing-for-maven-org-jacoco-org-jacoco-packages#activity-18662 for more details. 

