### PR TITLE
Add current commit sha to healthcheck endpoint

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -2,6 +2,6 @@
 
 class HealthcheckController < ApplicationController
   def index
-    render plain: "OK"
+    render plain: "OK\nRevision: #{Rails.application.config.git_revision}"
   end
 end


### PR DESCRIPTION
Adding the current revision commit SHA to the healthcheck endpoint for better internal notifications/monitoring.