### PR TITLE
add special case for Apache License, Version 2.0

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -672,9 +672,15 @@ class Project < ApplicationRecord
       .sub(/\)$/, "")
       .split("or")
       .flat_map { |l| l.split("and") }
+      .map { |l| manual_license_format(l) }
       .flat_map { |l| l.split(/[,\/]/) }
       .map(&Spdx.method(:find))
       .compact
       .map(&:id)
+  end
+
+  def manual_license_format(license)
+    # fixes "Apache License, Version 2.0" being incorrectly split on the comma
+    license.gsub("apache license, version", "apache license version")
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -106,6 +106,13 @@ describe Project, type: :model do
       project.normalize_licenses
       expect(project.normalized_licenses).to eq(["Apache-2.0"])
     end
+
+    it "handles special case Apache License, Version 2.0" do
+      project.licenses = "Apache License, Version 2.0"
+      project.normalize_licenses
+      expect(project.normalized_licenses).to eq(["Apache-2.0"])
+      expect(project.license_normalized).to be_truthy
+    end
   end
 
   describe 'maintenance stats' do


### PR DESCRIPTION
The license "Apache License, Version 2.0" is being incorrectly split on the comma. This results in two licenses: one correct, and one incorrect.  This change will strip the comma for this special case.

I added a new sanitize method, which can be used in case there are other special cases in the future.