### PR TITLE
handle apache licenses that include the word 'software'

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -681,6 +681,8 @@ class Project < ApplicationRecord
 
   def manual_license_format(license)
     # fixes "Apache License, Version 2.0" being incorrectly split on the comma
-    license.gsub("apache license, version", "apache license version")
+    license
+      .gsub("apache license, version", "apache license version")
+      .gsub("apache software license, version", "apache software license version")
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -113,6 +113,13 @@ describe Project, type: :model do
       expect(project.normalized_licenses).to eq(["Apache-2.0"])
       expect(project.license_normalized).to be_truthy
     end
+
+    it "handles special case Apache Software License, Version 2.0" do
+      project.licenses = "The Apache Software License, Version 2.0"
+      project.normalize_licenses
+      expect(project.normalized_licenses).to eq(["Apache-2.0"])
+      expect(project.license_normalized).to be_truthy
+    end
   end
 
   describe 'maintenance stats' do


### PR DESCRIPTION
Similar to #2850 

The license "The Apache Software License, Version 2.0" (as well as other similar variants) is being incorrectly split on the comma. This results in two licenses: one correct, and one incorrect. This change will strip the comma for this special case.

I realize we're playing wack-a-mole here with license spelling differences, but this is a particularly large "mole" with 70,240 affected packages.