### PR TITLE
Packagist repo sources: include "Main" here, since we're saving the repo source as this for now

### DIFF
--- a/app/models/package_manager/packagist.rb
+++ b/app/models/package_manager/packagist.rb
@@ -14,6 +14,7 @@ module PackageManager
     PROVIDER_MAP = {
       "default" => Main,
       "Drupal" => Drupal,
+      "Main" => Drupal,
       "Packagist" => Main,
     }.freeze
 


### PR DESCRIPTION
Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/612eba4cd9053000070f37e0