### PR TITLE
Implement download_url() for Packagist 

### DIFF
--- a/app/models/package_manager/packagist.rb
+++ b/app/models/package_manager/packagist.rb
@@ -26,6 +26,10 @@ module PackageManager
       "Packagist"
     end
 
+    def self.download_url(_name, _version = nil)
+      nil
+    end
+
     def self.project_names
       get("https://packagist.org/packages/list.json")["packageNames"]
     end


### PR DESCRIPTION
We need this now that it's a multiple source package manager.

Fixes Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/612eae3d8904d30007653a10