### PR TITLE
Use GPL-2.0+ for Drupal modules.

### DIFF
--- a/app/models/package_manager/packagist/drupal.rb
+++ b/app/models/package_manager/packagist/drupal.rb
@@ -3,7 +3,7 @@
 class PackageManager::Packagist::Drupal < PackageManager::Packagist
   REPOSITORY_SOURCE_NAME = "Drupal"
   HIDDEN = true
-  DRUPAL_MODULE_LICENSE = "GPL-2.0-or-later" # Drupal plugins all use the same license
+  DRUPAL_MODULE_LICENSE = "GPL-2.0+" # Drupal plugins all use the same license
 
   def self.package_link(project, version = nil)
     if version


### PR DESCRIPTION
This one works with our license fuzzy matching, whereas the previous one broke and got interpreted into a totally diff license.