### PR TITLE
Clean out null bytes from any strings we get from package managers.

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -96,7 +96,10 @@ module PackageManager
       raw_project = project(name)
       return false unless raw_project.present?
 
-      mapped_project = mapping(raw_project).try(&:compact)
+      mapped_project = mapping(raw_project)
+        .try do |p|
+          p.compact.transform_values { |v| v.is_a?(String) ? v.gsub("\u0000", "") : v }
+        end
       return false unless mapped_project.present?
 
       db_project = Project.find_or_initialize_by({ name: mapped_project[:name], platform: db_platform })


### PR DESCRIPTION
This should fix many of the `string contains null byte` errors that Libraries gets from package manager data.

https://app.bugsnag.com/tidelift/libraries-dot-io/errors/6036b670266ec50019a37a09?event_id=6152fd6b00826e026c5d0000&i=em&m=fq