### PR TITLE
OptimizedProjectSerializer optimization.

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -59,7 +59,7 @@ module PackageManager
       nil
     end
 
-    def self.download_url(_name, _version = nil)
+    def self.download_url(_db_project, _version = nil)
       nil
     end
 

--- a/app/models/package_manager/cargo.rb
+++ b/app/models/package_manager/cargo.rb
@@ -16,8 +16,8 @@ module PackageManager
       "https://crates.io/crates/#{project.name}/#{version}"
     end
 
-    def self.download_url(name, version = nil)
-      "https://crates.io/api/v1/crates/#{name}/#{version}/download"
+    def self.download_url(db_project, version = nil)
+      "https://crates.io/api/v1/crates/#{db_project.name}/#{version}/download"
     end
 
     def self.documentation_url(name, version = nil)

--- a/app/models/package_manager/clojars.rb
+++ b/app/models/package_manager/clojars.rb
@@ -26,8 +26,8 @@ module PackageManager
     end
 
     # Clojars download urls require a version
-    def self.download_url(name, version = nil)
-      group_id, artifact_id = name.split("/", 2)
+    def self.download_url(db_project, version = nil)
+      group_id, artifact_id = db_project.name.split("/", 2)
       artifact_id = group_id if artifact_id.nil?
       MavenUrl.new(group_id, artifact_id, repository_base).jar(version)
     end

--- a/app/models/package_manager/conda.rb
+++ b/app/models/package_manager/conda.rb
@@ -45,14 +45,13 @@ module PackageManager
       end
     end
 
-    def self.download_url(name, version = nil)
-      project = Project.find_by(name: name, platform: db_platform)
-      db_version = project.versions.find_by(number: version)
+    def self.download_url(db_project, version = nil)
+      db_version = db_project.versions.find_by(number: version)
       repository_source = db_version&.repository_sources&.first.presence || "default"
       if version.present?
-        get_json("#{API_URL}/#{repository_source}/#{name}/#{version}")&.first&.dig("download_url")
+        get_json("#{API_URL}/#{repository_source}/#{db_project.name}/#{version}")&.first&.dig("download_url")
       else
-        get_json("#{API_URL}/#{repository_source}/#{name}")&.first&.dig("download_url")
+        get_json("#{API_URL}/#{repository_source}/#{db_project.name}")&.first&.dig("download_url")
       end
     end
 

--- a/app/models/package_manager/cran.rb
+++ b/app/models/package_manager/cran.rb
@@ -12,8 +12,8 @@ module PackageManager
       "https://cran.r-project.org/package=#{project.name}"
     end
 
-    def self.download_url(name, version = nil)
-      "https://cran.r-project.org/src/contrib/#{name}_#{version}.tar.gz"
+    def self.download_url(db_project, version = nil)
+      "https://cran.r-project.org/src/contrib/#{db_project.name}_#{version}.tar.gz"
     end
 
     def self.documentation_url(name, _version = nil)

--- a/app/models/package_manager/elm.rb
+++ b/app/models/package_manager/elm.rb
@@ -12,8 +12,8 @@ module PackageManager
       "http://package.elm-lang.org/packages/#{project.name}/#{version || 'latest'}"
     end
 
-    def self.download_url(name, version = "master")
-      "https://github.com/#{name}/archive/#{version}.zip"
+    def self.download_url(db_project, version = "master")
+      "https://github.com/#{db_project.name}/archive/#{version}.zip"
     end
 
     def self.install_instructions(project, version = nil)

--- a/app/models/package_manager/hackage.rb
+++ b/app/models/package_manager/hackage.rb
@@ -12,8 +12,8 @@ module PackageManager
       "http://hackage.haskell.org/package/#{project.name}" + (version ? "-#{version}" : "")
     end
 
-    def self.download_url(name, version = nil)
-      "http://hackage.haskell.org/package/#{name}-#{version}/#{name}-#{version}.tar.gz"
+    def self.download_url(db_project, version = nil)
+      "http://hackage.haskell.org/package/#{db_project.name}-#{version}/#{db_project.name}-#{version}.tar.gz"
     end
 
     def self.install_instructions(project, version = nil)

--- a/app/models/package_manager/haxelib.rb
+++ b/app/models/package_manager/haxelib.rb
@@ -12,8 +12,8 @@ module PackageManager
       "https://lib.haxe.org/p/#{project.name}/#{version}"
     end
 
-    def self.download_url(name, version = nil)
-      "https://lib.haxe.org/p/#{name}/#{version}/download/"
+    def self.download_url(db_project, version = nil)
+      "https://lib.haxe.org/p/#{db_project.name}/#{version}/download/"
     end
 
     def self.install_instructions(project, version = nil)

--- a/app/models/package_manager/hex.rb
+++ b/app/models/package_manager/hex.rb
@@ -13,8 +13,8 @@ module PackageManager
       "https://hex.pm/packages/#{project.name}/#{version}"
     end
 
-    def self.download_url(name, version = nil)
-      "https://repo.hex.pm/tarballs/#{name}-#{version}.tar"
+    def self.download_url(db_project, version = nil)
+      "https://repo.hex.pm/tarballs/#{db_project.name}-#{version}.tar"
     end
 
     def self.documentation_url(name, version = nil)

--- a/app/models/package_manager/maven/common.rb
+++ b/app/models/package_manager/maven/common.rb
@@ -5,11 +5,11 @@ class PackageManager::Maven::Common < PackageManager::Maven
     download_url(project.name, version)
   end
 
-  def self.download_url(name, version = nil)
+  def self.download_url(db_project, version = nil)
     if version
-      MavenUrl.from_name(name, repository_base).jar(version)
+      MavenUrl.from_name(db_project.name, repository_base).jar(version)
     else
-      MavenUrl.from_name(name, repository_base).base
+      MavenUrl.from_name(db_project.name, repository_base).base
     end
   end
 

--- a/app/models/package_manager/maven/common.rb
+++ b/app/models/package_manager/maven/common.rb
@@ -2,7 +2,7 @@
 
 class PackageManager::Maven::Common < PackageManager::Maven
   def self.package_link(project, version = nil)
-    download_url(project.name, version)
+    download_url(project, version)
   end
 
   def self.download_url(db_project, version = nil)

--- a/app/models/package_manager/multiple_sources_base.rb
+++ b/app/models/package_manager/multiple_sources_base.rb
@@ -41,7 +41,7 @@ module PackageManager
     private_class_method def self.get_repository_source(db_project, version = nil)
       db_version = if version.nil?
         db_project.versions.first
-      elsif db_project.association(:versions).loaded?
+      elsif db_project.association(:versions).loaded? && db_project.versions.size > 0
         db_project.versions.find { |v| v.number == version }
       else
         db_project.versions.find_by(number: version)

--- a/app/models/package_manager/multiple_sources_base.rb
+++ b/app/models/package_manager/multiple_sources_base.rb
@@ -25,7 +25,7 @@ module PackageManager
       db_version = if version.nil?
           db_project.versions.first
         elsif db_project.association(:versions).loaded?
-          db_project.versions.select { |v| v.number == version }
+          db_project.versions.find { |v| v.number == version }
         else
           db_project.versions.find_by(number: version)
         end

--- a/app/models/package_manager/multiple_sources_base.rb
+++ b/app/models/package_manager/multiple_sources_base.rb
@@ -15,21 +15,13 @@ module PackageManager
         .map { |source| self::PROVIDER_MAP[source] } || [self::PROVIDER_MAP["default"]]
     end
 
-    def self.package_link(project, version = nil)
-      db_version = project.versions.find_by(number: version)
-      repository_source = db_version&.repository_sources&.first.presence || "default"
-      self::PROVIDER_MAP[repository_source].package_link(project, version)
+    def self.package_link(db_project, version = nil)
+      repository_source = get_repository_source(db_project, version)
+      self::PROVIDER_MAP[repository_source].package_link(db_project, version)
     end
 
     def self.download_url(db_project, version = nil)
-      db_version = if version.nil?
-          db_project.versions.first
-        elsif db_project.association(:versions).loaded?
-          db_project.versions.find { |v| v.number == version }
-        else
-          db_project.versions.find_by(number: version)
-        end
-      repository_source = db_version&.repository_sources&.first.presence || "default"
+      repository_source = get_repository_source(db_project, version)
       self::PROVIDER_MAP[repository_source].download_url(db_project, version)
     end
 
@@ -44,6 +36,17 @@ module PackageManager
 
     def self.recent_names
       self::PROVIDER_MAP["default"].recent_names
+    end
+
+    private_class_method def self.get_repository_source(db_project, version = nil)
+      db_version = if version.nil?
+        db_project.versions.first
+      elsif db_project.association(:versions).loaded?
+        db_project.versions.find { |v| v.number == version }
+      else
+        db_project.versions.find_by(number: version)
+      end
+      repository_source = db_version&.repository_sources&.first.presence || "default"
     end
   end
 end

--- a/app/models/package_manager/npm.rb
+++ b/app/models/package_manager/npm.rb
@@ -15,8 +15,8 @@ module PackageManager
       "https://www.npmjs.com/package/#{project.name}"
     end
 
-    def self.download_url(name, version = nil)
-      "https://registry.npmjs.org/#{name}/-/#{name}-#{version}.tgz"
+    def self.download_url(db_project, version = nil)
+      "https://registry.npmjs.org/#{db_project.name}/-/#{db_project.name}-#{version}.tgz"
     end
 
     def self.install_instructions(project, version = nil)

--- a/app/models/package_manager/nu_get.rb
+++ b/app/models/package_manager/nu_get.rb
@@ -13,8 +13,8 @@ module PackageManager
       "https://www.nuget.org/packages/#{project.name}/#{version}"
     end
 
-    def self.download_url(name, version = nil)
-      "https://www.nuget.org/api/v2/package/#{name}/#{version}"
+    def self.download_url(db_project, version = nil)
+      "https://www.nuget.org/api/v2/package/#{db_project.name}/#{version}"
     end
 
     def self.install_instructions(project, version = nil)

--- a/app/models/package_manager/packagist.rb
+++ b/app/models/package_manager/packagist.rb
@@ -26,7 +26,7 @@ module PackageManager
       "Packagist"
     end
 
-    def self.download_url(_name, _version = nil)
+    def self.download_url(_db_project, _version = nil)
       nil
     end
 

--- a/app/models/package_manager/pub.rb
+++ b/app/models/package_manager/pub.rb
@@ -12,8 +12,8 @@ module PackageManager
       "https://pub.dartlang.org/packages/#{project.name}"
     end
 
-    def self.download_url(name, version = nil)
-      "https://storage.googleapis.com/pub.dartlang.org/packages/#{name}-#{version}.tar.gz"
+    def self.download_url(db_project, version = nil)
+      "https://storage.googleapis.com/pub.dartlang.org/packages/#{db_project.name}-#{version}.tar.gz"
     end
 
     def self.documentation_url(name, version = nil)

--- a/app/models/package_manager/puppet.rb
+++ b/app/models/package_manager/puppet.rb
@@ -72,8 +72,8 @@ module PackageManager
       "https://forge.puppet.com/#{project.name.sub('-', '/')}" + (version ? "/#{version}" : "")
     end
 
-    def self.download_url(name, version = nil)
-      "https://forge.puppet.com/v3/files/#{name}-#{version}.tar.gz"
+    def self.download_url(db_project, version = nil)
+      "https://forge.puppet.com/v3/files/#{db_project.name}-#{version}.tar.gz"
     end
   end
 end

--- a/app/models/package_manager/rubygems.rb
+++ b/app/models/package_manager/rubygems.rb
@@ -14,8 +14,8 @@ module PackageManager
       "https://rubygems.org/gems/#{project.name}" + (version ? "/versions/#{version}" : "")
     end
 
-    def self.download_url(name, version = nil)
-      "https://rubygems.org/downloads/#{name}-#{version}.gem"
+    def self.download_url(db_project, version = nil)
+      "https://rubygems.org/downloads/#{db_project.name}-#{version}.gem"
     end
 
     def self.documentation_url(name, version = nil)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -215,7 +215,7 @@ class Project < ApplicationRecord
   end
 
   def download_url(version = nil)
-    platform_class.download_url(name, version) if version
+    platform_class.download_url(self, version) if version
   end
 
   def latest_download_url

--- a/app/queries/project_status_query.rb
+++ b/app/queries/project_status_query.rb
@@ -17,7 +17,7 @@ class ProjectStatusQuery
       .visible
       .platform(@platform)
       .where(name: @requested_project_names)
-      .includes(:repository)
+      .includes(:repository, :versions)
       .find_each
       .index_by(&:name)
   end
@@ -26,18 +26,14 @@ class ProjectStatusQuery
     @missing_projects ||= Project
       .visible
       .lower_platform(@platform)
-      .where("lower(name) in (?)", project_find_names.keys)
-      .includes(:repository)
+      .where("lower(name) in (?)", missing_project_find_names.keys)
+      .includes(:repository, :versions)
       .find_each
-      .index_by { |project| project_find_names[project.name.downcase] }
+      .index_by { |project| missing_project_find_names[project.name.downcase] }
   end
 
-  def missing_project_names
-    @missing_project_names ||= @requested_project_names - exact_projects.keys
-  end
-
-  def project_find_names
-    @project_find_names ||= missing_project_names
+  def missing_project_find_names
+    @missing_project_find_names ||= (@requested_project_names - exact_projects.keys)
       .each_with_object({}) do |requested_name, hash|
       platform_class
         .project_find_names(requested_name)

--- a/app/serializers/optimized_project_serializer.rb
+++ b/app/serializers/optimized_project_serializer.rb
@@ -48,19 +48,20 @@ class OptimizedProjectSerializer
 
   def serialize_project(project)
     Google::Cloud::Trace.in_span "optimized_project_serializer#serialize_project" do |_span|
+      name = @requested_name_map[[project.platform, project.name]]
       project
         .attributes
         .slice(*PROJECT_ATTRIBUTES)
         .merge!(
           canonical_name: project.name,
-          name: @requested_name_map[[project.platform, project.name]],
-          download_url: project.download_url,
+          name:  project.name,
+          download_url:  project.download_url,
           forks: project.forks,
-          latest_download_url: project.latest_download_url,
-          package_manager_url: project.package_manager_url,
-          repository_license: project.repository_license,
-          stars: project.stars,
-          versions: versions[project.id]
+          latest_download_url:  project.latest_download_url,
+          package_manager_url:  project.package_manager_url,
+          repository_license:  project.repository_license,
+          stars:  project.stars,
+          versions: project.versions
         ).tap do |result|
           if @internal_key
             result[:updated_at] = project.updated_at

--- a/app/serializers/optimized_project_serializer.rb
+++ b/app/serializers/optimized_project_serializer.rb
@@ -54,13 +54,13 @@ class OptimizedProjectSerializer
         .slice(*PROJECT_ATTRIBUTES)
         .merge!(
           canonical_name: project.name,
-          name:  project.name,
-          download_url:  project.download_url,
+          name: project.name,
+          download_url: project.download_url,
           forks: project.forks,
-          latest_download_url:  project.latest_download_url,
-          package_manager_url:  project.package_manager_url,
-          repository_license:  project.repository_license,
-          stars:  project.stars,
+          latest_download_url: project.latest_download_url,
+          package_manager_url: project.package_manager_url,
+          repository_license: project.repository_license,
+          stars: project.stars,
           versions: project.versions
         ).tap do |result|
           if @internal_key

--- a/app/serializers/optimized_project_serializer.rb
+++ b/app/serializers/optimized_project_serializer.rb
@@ -26,15 +26,6 @@ class OptimizedProjectSerializer
     status
   ].freeze
 
-  VERSION_ATTRIBUTES = %w[
-    number
-    published_at
-    spdx_expression
-    original_license
-    researched_at
-    repository_sources
-  ].freeze
-
   MAINTENANCE_STAT_ATTRIBUTES = %w[
     category
     value
@@ -75,21 +66,6 @@ class OptimizedProjectSerializer
             result[:updated_at] = project.updated_at
             result[:repository_maintenance_stats] = maintenance_stats[project.repository_id]
           end
-        end
-    end
-  end
-
-  def versions
-    @versions ||= Google::Cloud::Trace.in_span "optimized_project_serializer#versions" do |_span|
-      Version
-        .where(project_id: @projects.map(&:id))
-        .pluck(*VERSION_ATTRIBUTES, :created_at, :project_id)
-        .each_with_object(Hash.new { |h, k| h[k] = [] }) do |row, versions|
-          # Use created_at if no published date
-          version = VERSION_ATTRIBUTES.zip(row).to_h
-          version["published_at"] ||= row[-2]
-
-          versions[row[-1]] << version
         end
     end
   end

--- a/app/serializers/optimized_project_serializer.rb
+++ b/app/serializers/optimized_project_serializer.rb
@@ -54,7 +54,7 @@ class OptimizedProjectSerializer
         .slice(*PROJECT_ATTRIBUTES)
         .merge!(
           canonical_name: project.name,
-          name: project.name,
+          name: @requested_name_map[[project.platform, project.name]],
           download_url: project.download_url,
           forks: project.forks,
           latest_download_url: project.latest_download_url,

--- a/docs/add-a-package-manager.md
+++ b/docs/add-a-package-manager.md
@@ -251,8 +251,8 @@ If the package manager provides predictable urls to the tar ball or zip archive 
 It takes a package `name` and an optional `version` number, for example:
 
 ```ruby
-def self.download_url(name, version = nil)
-  "https://rubygems.org/downloads/#{name}-#{version}.gem"
+def self.download_url(db_project, version = nil)
+  "https://rubygems.org/downloads/#{db_project.name}-#{version}.gem"
 end
 ```
 

--- a/spec/models/package_manager/cargo_spec.rb
+++ b/spec/models/package_manager/cargo_spec.rb
@@ -2,6 +2,8 @@
 require 'rails_helper'
 
 describe PackageManager::Cargo do
+  let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
+
   it 'has formatted name of "Cargo"' do
     expect(described_class.formatted_name).to eq('Cargo')
   end
@@ -20,7 +22,7 @@ describe PackageManager::Cargo do
 
   describe '#download_url' do
     it 'returns a link to project tarball' do
-      expect(described_class.download_url('foo', '1.0.0')).to eq("https://crates.io/api/v1/crates/foo/1.0.0/download")
+      expect(described_class.download_url(project, '1.0.0')).to eq("https://crates.io/api/v1/crates/foo/1.0.0/download")
     end
   end
 

--- a/spec/models/package_manager/cran_spec.rb
+++ b/spec/models/package_manager/cran_spec.rb
@@ -2,6 +2,8 @@
 require 'rails_helper'
 
 describe PackageManager::CRAN do
+  let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
+
   it 'has formatted name of "CRAN"' do
     expect(described_class.formatted_name).to eq('CRAN')
   end
@@ -20,7 +22,7 @@ describe PackageManager::CRAN do
 
   describe 'download_url' do
     it 'returns a link to project tarball' do
-      expect(described_class.download_url('foo', '1.0.0')).to eq("https://cran.r-project.org/src/contrib/foo_1.0.0.tar.gz")
+      expect(described_class.download_url(project, '1.0.0')).to eq("https://cran.r-project.org/src/contrib/foo_1.0.0.tar.gz")
     end
   end
 

--- a/spec/models/package_manager/elm_spec.rb
+++ b/spec/models/package_manager/elm_spec.rb
@@ -20,7 +20,7 @@ describe PackageManager::Elm do
 
   describe 'download_url' do
     it 'returns a link to project tarball' do
-      expect(described_class.download_url('foo/bar', '1.0.0')).to eq("https://github.com/foo/bar/archive/1.0.0.zip")
+      expect(described_class.download_url(project, '1.0.0')).to eq("https://github.com/foo/bar/archive/1.0.0.zip")
     end
   end
 

--- a/spec/models/package_manager/elm_spec.rb
+++ b/spec/models/package_manager/elm_spec.rb
@@ -20,7 +20,7 @@ describe PackageManager::Elm do
 
   describe 'download_url' do
     it 'returns a link to project tarball' do
-      expect(described_class.download_url(project, '1.0.0')).to eq("https://github.com/foo/bar/archive/1.0.0.zip")
+      expect(described_class.download_url(project, '1.0.0')).to eq("https://github.com/foo/archive/1.0.0.zip")
     end
   end
 

--- a/spec/models/package_manager/hackage_spec.rb
+++ b/spec/models/package_manager/hackage_spec.rb
@@ -20,7 +20,7 @@ describe PackageManager::Hackage do
 
   describe 'download_url' do
     it 'returns a link to project tarball' do
-      expect(described_class.download_url('foo', '1.0.0')).to eq("http://hackage.haskell.org/package/foo-1.0.0/foo-1.0.0.tar.gz")
+      expect(described_class.download_url(project, '1.0.0')).to eq("http://hackage.haskell.org/package/foo-1.0.0/foo-1.0.0.tar.gz")
     end
   end
 

--- a/spec/models/package_manager/haxelib_spec.rb
+++ b/spec/models/package_manager/haxelib_spec.rb
@@ -20,7 +20,7 @@ describe PackageManager::Haxelib do
 
   describe 'download_url' do
     it 'returns a link to project tarball' do
-      expect(described_class.download_url('foo', '1.0.0')).to eq("https://lib.haxe.org/p/foo/1.0.0/download/")
+      expect(described_class.download_url(project, '1.0.0')).to eq("https://lib.haxe.org/p/foo/1.0.0/download/")
     end
   end
 

--- a/spec/models/package_manager/hex_spec.rb
+++ b/spec/models/package_manager/hex_spec.rb
@@ -2,13 +2,13 @@
 require 'rails_helper'
 
 describe PackageManager::Hex do
+  let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
+
   it 'has formatted name of "Hex"' do
     expect(described_class.formatted_name).to eq('Hex')
   end
 
   describe '#package_link' do
-    let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
-
     it 'returns a link to project website' do
       expect(described_class.package_link(project)).to eq("https://hex.pm/packages/foo/")
     end
@@ -20,7 +20,7 @@ describe PackageManager::Hex do
 
   describe 'download_url' do
     it 'returns a link to project tarball' do
-      expect(described_class.download_url('foo', '1.0.0')).to eq("https://repo.hex.pm/tarballs/foo-1.0.0.tar")
+      expect(described_class.download_url(project, '1.0.0')).to eq("https://repo.hex.pm/tarballs/foo-1.0.0.tar")
     end
   end
 

--- a/spec/models/package_manager/maven_spec.rb
+++ b/spec/models/package_manager/maven_spec.rb
@@ -117,14 +117,14 @@ describe PackageManager::Maven do
     let(:project) { create(:project, name: "javax.faces:javax.faces-api", platform: described_class.formatted_name.demodulize) }
 
     it "returns link to maven central jar file" do
-      expect(described_class.download_url(project.name, "2.3")).to eq("https://repo1.maven.org/maven2/javax/faces/javax.faces-api/2.3/javax.faces-api-2.3.jar")
+      expect(described_class.download_url(project, "2.3")).to eq("https://repo1.maven.org/maven2/javax/faces/javax.faces-api/2.3/javax.faces-api-2.3.jar")
     end
 
     context "with atlassian provider" do
       let!(:version) { create(:version, project: project, repository_sources: [PackageManager::Maven::Atlassian::REPOSITORY_SOURCE_NAME], number: "2.0.0") }
 
       it "returns link to atlassian folder" do
-        expect(described_class.download_url(project.name, "2.0.0")).to eq("https://packages.atlassian.com/maven-central-local/javax/faces/javax.faces-api/2.0.0/javax.faces-api-2.0.0.jar")
+        expect(described_class.download_url(project, "2.0.0")).to eq("https://packages.atlassian.com/maven-central-local/javax/faces/javax.faces-api/2.0.0/javax.faces-api-2.0.0.jar")
       end
     end
 
@@ -132,7 +132,7 @@ describe PackageManager::Maven do
       let!(:version) { create(:version, project: project, repository_sources: [PackageManager::Maven::Hortonworks::REPOSITORY_SOURCE_NAME], number: "2.0.0") }
 
       it "returns link to atlassian folder" do
-        expect(described_class.download_url(project.name, "2.0.0")).to eq("https://repo.hortonworks.com/content/groups/releases/javax/faces/javax.faces-api/2.0.0/javax.faces-api-2.0.0.jar")
+        expect(described_class.download_url(project, "2.0.0")).to eq("https://repo.hortonworks.com/content/groups/releases/javax/faces/javax.faces-api/2.0.0/javax.faces-api-2.0.0.jar")
       end
     end
   end

--- a/spec/models/package_manager/npm_spec.rb
+++ b/spec/models/package_manager/npm_spec.rb
@@ -20,7 +20,7 @@ describe PackageManager::NPM do
 
   describe 'download_url' do
     it 'returns a link to project tarball' do
-      expect(described_class.download_url('foo', '1.0.0')).to eq("https://registry.npmjs.org/foo/-/foo-1.0.0.tgz")
+      expect(described_class.download_url(project '1.0.0')).to eq("https://registry.npmjs.org/foo/-/foo-1.0.0.tgz")
     end
   end
 

--- a/spec/models/package_manager/npm_spec.rb
+++ b/spec/models/package_manager/npm_spec.rb
@@ -20,7 +20,7 @@ describe PackageManager::NPM do
 
   describe 'download_url' do
     it 'returns a link to project tarball' do
-      expect(described_class.download_url(project '1.0.0')).to eq("https://registry.npmjs.org/foo/-/foo-1.0.0.tgz")
+      expect(described_class.download_url(project, '1.0.0')).to eq("https://registry.npmjs.org/foo/-/foo-1.0.0.tgz")
     end
   end
 

--- a/spec/models/package_manager/nu_get_spec.rb
+++ b/spec/models/package_manager/nu_get_spec.rb
@@ -21,7 +21,7 @@ describe PackageManager::NuGet do
 
   describe "download_url" do
     it "returns a link to project tarball" do
-      expect(described_class.download_url("foo", "1.0.0")).to eq("https://www.nuget.org/api/v2/package/foo/1.0.0")
+      expect(described_class.download_url(project, "1.0.0")).to eq("https://www.nuget.org/api/v2/package/foo/1.0.0")
     end
   end
 

--- a/spec/models/package_manager/pub_spec.rb
+++ b/spec/models/package_manager/pub_spec.rb
@@ -20,17 +20,17 @@ describe PackageManager::Pub do
 
   describe 'download_url' do
     it 'returns a link to project tarball' do
-      expect(described_class.download_url('foo', '1.0.0')).to eq("https://storage.googleapis.com/pub.dartlang.org/packages/foo-1.0.0.tar.gz")
+      expect(described_class.download_url(project, '1.0.0')).to eq("https://storage.googleapis.com/pub.dartlang.org/packages/foo-1.0.0.tar.gz")
     end
   end
 
   describe '#documentation_url' do
     it 'returns a link to project website' do
-      expect(described_class.documentation_url('foo')).to eq("http://www.dartdocs.org/documentation/foo/")
+      expect(described_class.documentation_url(project)).to eq("http://www.dartdocs.org/documentation/foo/")
     end
 
     it 'handles version' do
-      expect(described_class.documentation_url('foo', '2.0.0')).to eq("http://www.dartdocs.org/documentation/foo/2.0.0")
+      expect(described_class.documentation_url(project, '2.0.0')).to eq("http://www.dartdocs.org/documentation/foo/2.0.0")
     end
   end
 end

--- a/spec/models/package_manager/pub_spec.rb
+++ b/spec/models/package_manager/pub_spec.rb
@@ -2,6 +2,8 @@
 require 'rails_helper'
 
 describe PackageManager::Pub do
+  let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
+
   it 'has formatted name of "Pub"' do
     expect(described_class.formatted_name).to eq('Pub')
   end

--- a/spec/models/package_manager/puppet_spec.rb
+++ b/spec/models/package_manager/puppet_spec.rb
@@ -20,7 +20,7 @@ describe PackageManager::Puppet do
 
   describe 'download_url' do
     it 'returns a link to project tarball' do
-      expect(described_class.download_url('foo-bar', '1.0.0')).to eq("https://forge.puppet.com/v3/files/foo-bar-1.0.0.tar.gz")
+      expect(described_class.download_url(project, '1.0.0')).to eq("https://forge.puppet.com/v3/files/foo-bar-1.0.0.tar.gz")
     end
   end
 

--- a/spec/models/package_manager/rubygems_spec.rb
+++ b/spec/models/package_manager/rubygems_spec.rb
@@ -20,17 +20,17 @@ describe PackageManager::Rubygems do
 
   describe 'download_url' do
     it 'returns a link to project tarball' do
-      expect(described_class.download_url('foo', '1.0.0')).to eq("https://rubygems.org/downloads/foo-1.0.0.gem")
+      expect(described_class.download_url(project, '1.0.0')).to eq("https://rubygems.org/downloads/foo-1.0.0.gem")
     end
   end
 
   describe '#documentation_url' do
     it 'returns a link to project website' do
-      expect(described_class.documentation_url('foo')).to eq("http://www.rubydoc.info/gems/foo/")
+      expect(described_class.documentation_url(project)).to eq("http://www.rubydoc.info/gems/foo/")
     end
 
     it 'handles version' do
-      expect(described_class.documentation_url('foo', '2.0.0')).to eq("http://www.rubydoc.info/gems/foo/2.0.0")
+      expect(described_class.documentation_url(project, '2.0.0')).to eq("http://www.rubydoc.info/gems/foo/2.0.0")
     end
   end
 


### PR DESCRIPTION
Currently package managers that inherit from `PackageManager::MultipleSourcesBase` are doing extraneous N+1 queries from the `/api/check` endpoint: they're re-fetching the project and their versions for each project requested.

The main change is to change `download_url(name, version)` methods to `download_url(db_project, version)` so that we don't have to re-pull the project. Also, if the versions are preloaded (as I'm doing in ProjectStatusQuery here), `download_url` will now use those instead of re-fetching the versions.