### PR TITLE
Re-check Pypi packages for deprecated/removed status regularly.

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -109,6 +109,7 @@ class Project < ApplicationRecord
   scope :removed, -> { where('projects."status" = ?', "Removed") }
   scope :unmaintained, -> { where('projects."status" = ?', "Unmaintained") }
   scope :hidden, -> { where('projects."status" = ?', "Hidden") }
+  scope :removed_or_deprecated, -> { where('projects."status" in (?)', %w[Removed Deprecated]) }
 
   scope :indexable, -> { not_removed.includes(:repository) }
 
@@ -169,7 +170,7 @@ class Project < ApplicationRecord
     return unless platform_class_exists?
 
     sync_classes.each { |sync_class| PackageManagerDownloadWorker.perform_async(sync_class.name, name) }
-    CheckStatusWorker.perform_async(id, status == "Removed")
+    CheckStatusWorker.perform_async(id)
   end
 
   def sync_classes
@@ -550,6 +551,7 @@ class Project < ApplicationRecord
     ProjectDependentRepository.where(project_id: id).count
   end
 
+  # TODO: it's safe to remove deprecated 'removed' arg now
   def check_status(removed = false)
     url = platform_class.check_status_url(self)
     return if url.blank?
@@ -570,7 +572,7 @@ class Project < ApplicationRecord
         update_attribute(:status, "Deprecated")
         update_attribute(:deprecation_reason, result[:message])
       end
-    elsif removed
+    elsif status == "Deprecated" || status == "Removed"
       update_attribute(:status, nil)
     end
   end

--- a/app/workers/check_repo_status_worker.rb
+++ b/app/workers/check_repo_status_worker.rb
@@ -3,7 +3,8 @@ class CheckRepoStatusWorker
   include Sidekiq::Worker
   sidekiq_options queue: :status, unique: :until_executed
 
+  # TODO: it's safe to remove deprecated "removed" arg
   def perform(host_type, repo_full_name, removed = false)
-    Repository.check_status(host_type, repo_full_name, removed)
+    Repository.check_status(host_type, repo_full_name)
   end
 end

--- a/app/workers/check_status_worker.rb
+++ b/app/workers/check_status_worker.rb
@@ -3,7 +3,8 @@ class CheckStatusWorker
   include Sidekiq::Worker
   sidekiq_options queue: :status, unique: :until_executed
 
+  # TODO: it's now safe to remove deprecated 'removed' arg
   def perform(project_id, removed = false)
-    Project.find_by_id(project_id).try(:check_status, removed)
+    Project.find_by_id(project_id).try(:check_status)
   end
 end

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -53,18 +53,19 @@ namespace :projects do
     end
   end
 
-  desc 'Check to see if projects have been removed'
+  desc 'Check to see if projects are still removed/deprecated'
   task check_removed_status: :environment do
     exit if ENV['READ_ONLY'].present?
-    ['npm', 'rubygems', 'packagist', 'cpan', 'clojars', 'cocoapods',
+    # Check if removed/deprecated projects are still deprecated/removed
+    ['pypi', 'npm', 'rubygems', 'packagist', 'cpan', 'clojars', 'cocoapods',
     'hackage', 'cran', 'atom', 'sublime', 'pub', 'elm', 'dub'].each do |platform|
-      Project.platform(platform).removed.select('id').find_each do |project|
-        CheckStatusWorker.perform_async(project.id, true)
+      Project.platform(platform).removed_or_deprecated.select('id').find_each do |project|
+        CheckStatusWorker.perform_async(project.id)
       end
     end
 
     ['bower', 'go', 'elm', 'alcatraz', 'julia', 'nimble'].each do |platform|
-      projects = Project.platform(platform).removed.with_repo.limit(500)
+      projects = Project.platform(platform).removed_or_deprecated.with_repo.limit(500)
       repos = projects.map(&:repository)
       repos.each do |repo|
         CheckRepoStatusWorker.perform_async(repo.host_type, repo.full_name)

--- a/spec/workers/check_repo_status_worker_spec.rb
+++ b/spec/workers/check_repo_status_worker_spec.rb
@@ -8,9 +8,8 @@ describe CheckRepoStatusWorker do
 
   it "should check repo status" do
     repo_full_name = 'rails/rails'
-    removed = true
     host_type = 'GitHub'
-    expect(Repository).to receive(:check_status).with(host_type, repo_full_name, removed)
-    subject.perform(host_type, repo_full_name, removed)
+    expect(Repository).to receive(:check_status).with(host_type, repo_full_name)
+    subject.perform(host_type, repo_full_name)
   end
 end

--- a/spec/workers/check_status_worker_spec.rb
+++ b/spec/workers/check_status_worker_spec.rb
@@ -10,7 +10,7 @@ describe CheckStatusWorker do
     project = create(:project)
     removed = false
     expect(Project).to receive(:find_by_id).with(project.id).and_return(project)
-    expect(project).to receive(:check_status).with(removed)
-    subject.perform(project.id, removed)
+    expect(project).to receive(:check_status)
+    subject.perform(project.id)
   end
 end


### PR DESCRIPTION
* Removes the `removed` arg in CheckStatusWorker and CheckRepoStatusWorker (I don't see a reason why they're necessary, based on the orignial commit https://github.com/librariesio/libraries.io/commit/926f18c56ac8499a980dbbbb1bb64c5808db7113#diff-2bba7f75aa1e0fe9dac0d85c3619999931b5fe2a93918e2bdb0abdb2e1f951fdL8)
* Resets `status: 'Deprecated'` to `status: nil` if a project no longer deprecated
* Check pypi when rechecking removed/deprecated packages too

This should prevent cases like https://github.com/librariesio/libraries.io/issues/2865 where Pypi packages weren't considered deprecated anymore but didn't get reset back to `status: nil`.