### PR TITLE
Not all Drupal projects have a description

### DIFF
--- a/app/models/package_manager/packagist/drupal.rb
+++ b/app/models/package_manager/packagist/drupal.rb
@@ -25,7 +25,7 @@ class PackageManager::Packagist::Drupal < PackageManager::Packagist
 
     {
       name: "drupal/#{homepage.split("/project/", 2)[1]}",
-      description: raw_project.css("meta[name=description]").first.attr('content'),
+      description: raw_project.css("meta[name=description]").first&.attr('content'),
       homepage: homepage,
       licenses: DRUPAL_MODULE_LICENSE,
       repository_url: raw_project.css('#block-drupalorg-project-development .links a').find { |l| l.text =~ /code repository/ }.attr('href'),


### PR DESCRIPTION
Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/614e2ddd4bbd3200075b6ae9?event_id=615dcdcd0083c89d6afe0000&i=em&m=fq