### PR TITLE
PackageManager::MultipleSourcesBase bugfix

### DIFF
--- a/app/models/package_manager/multiple_sources_base.rb
+++ b/app/models/package_manager/multiple_sources_base.rb
@@ -12,7 +12,7 @@ module PackageManager
         .flat_map(&:repository_sources)
         .compact
         .uniq
-        .map { |source| self::PROVIDER_MAP[source] } || [self::PROVIDER_MAP["default"]]
+        .map { |source| self::PROVIDER_MAP[source] }.presence || [self::PROVIDER_MAP["default"]]
     end
 
     def self.package_link(db_project, version = nil)


### PR DESCRIPTION
Fixes a bug where projects that have no versions with a repository_source will have `Project#sync_classes` of `[]`, when we should really return at least the default provider. 