### PR TITLE
Remove the removed routes for fetching all packages for Maven

### DIFF
--- a/app/models/package_manager/clojars.rb
+++ b/app/models/package_manager/clojars.rb
@@ -18,7 +18,7 @@ module PackageManager
     end
 
     def self.project_names
-      get("https://maven.libraries.io/clojars/all")
+      []
     end
 
     def self.recent_names

--- a/app/models/package_manager/maven/atlassian.rb
+++ b/app/models/package_manager/maven/atlassian.rb
@@ -8,7 +8,7 @@ class PackageManager::Maven::Atlassian < PackageManager::Maven::Common
   end
 
   def self.project_names
-    get("https://maven.libraries.io/atlassian/all")
+    []
   end
 
   def self.recent_names

--- a/app/models/package_manager/maven/hortonworks.rb
+++ b/app/models/package_manager/maven/hortonworks.rb
@@ -8,7 +8,7 @@ class PackageManager::Maven::Hortonworks < PackageManager::Maven::Common
   end
 
   def self.project_names
-    get("https://maven.libraries.io/hortonworks/all")
+    []
   end
 
   def self.recent_names

--- a/app/models/package_manager/maven/jboss.rb
+++ b/app/models/package_manager/maven/jboss.rb
@@ -9,7 +9,7 @@ class PackageManager::Maven::Jboss < PackageManager::Maven::Common
   end
 
   def self.project_names
-    get("https://maven.libraries.io/jBoss/all")
+    []
   end
 
   def self.recent_names

--- a/app/models/package_manager/maven/jboss_ea.rb
+++ b/app/models/package_manager/maven/jboss_ea.rb
@@ -9,7 +9,7 @@ class PackageManager::Maven::JbossEa < PackageManager::Maven::Common
   end
 
   def self.project_names
-    get("https://maven.libraries.io/jBossEa/all")
+    []
   end
 
   def self.recent_names

--- a/app/models/package_manager/maven/spring_libs.rb
+++ b/app/models/package_manager/maven/spring_libs.rb
@@ -9,10 +9,10 @@ class PackageManager::Maven::SpringLibs < PackageManager::Maven::Common
   end
 
   def self.project_names
-    get("https://maven.libraries.io/springLibsRelease/all")
+    []
   end
 
   def self.recent_names
-    get("https://maven.libraries.io/springLibsRelease/all")
+    []
   end
 end


### PR DESCRIPTION
Indexing for "All packages" for Maven packages was removed [earlier this year](https://github.com/librariesio/maven-updater/pull/10), so this removes those routes from Libraries.

Fixes https://github.com/librariesio/libraries.io/issues/2847