### PR TITLE
Still allow for workers that kick off with "PackageManager::Packagist" platform

### DIFF
--- a/app/workers/package_manager_download_worker.rb
+++ b/app/workers/package_manager_download_worker.rb
@@ -39,6 +39,7 @@ class PackageManagerDownloadWorker
     nimble: PackageManager::Nimble,
     npm: PackageManager::NPM,
     nuget: PackageManager::NuGet,
+    packagist: PackageManager::Packagist,
     packagist_drupal: PackageManager::Packagist::Drupal,
     packagist_main: PackageManager::Packagist::Main,
     pub: PackageManager::Pub,


### PR DESCRIPTION
I think HooksController is still kicking off these jobs with a platform of "PackageManager::Packagist" instead of PackageManager::Packagist::{Main,Drupal}, and I just noticed maven/conda still allow their base platform as a name in this worker too (eg PackageManager::Maven), so should be fine for Packagist after all.

https://app.bugsnag.com/tidelift/libraries-dot-io/errors/614884220ba5f500073841ac?event_id=617002d70085d0c5a28a0000&i=sk&m=ps