### PR TITLE
Add a missing REPOSITORY_SOURCE_NAME to Packagist::Main

### DIFF
--- a/app/models/package_manager/packagist.rb
+++ b/app/models/package_manager/packagist.rb
@@ -2,6 +2,7 @@
 
 module PackageManager
   class Packagist < MultipleSourcesBase
+    REPOSITORY_SOURCE_NAME = "Main"
     HAS_VERSIONS = true
     HAS_DEPENDENCIES = true
     BIBLIOTHECARY_SUPPORT = true


### PR DESCRIPTION
Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/6170cf1e75898a0008fb0655?event_id=6170cf1e0085cb049c2f0000&i=sk&m=nw