### PR TITLE
Skip any package hooks that have blank platforms.

### DIFF
--- a/app/controllers/hooks_controller.rb
+++ b/app/controllers/hooks_controller.rb
@@ -15,8 +15,12 @@ class HooksController < ApplicationController
   end
 
   def package
-    Rails.logger.info "HooksController#package platform=#{params['platform']} name=#{params['name']} param_keys=#{params.keys.join(',')}"
-    PackageManagerDownloadWorker.perform_async("PackageManager::#{params['platform']}", params["name"])
+    if params['platform'].blank?
+      Rails.logger.info "HooksController#package invalid=true platform=#{params['platform']} name=#{params['name']} param_keys=#{params.keys.join(',')}"
+    else
+      Rails.logger.info "HooksController#package platform=#{params['platform']} name=#{params['name']} param_keys=#{params.keys.join(',')}"
+      PackageManagerDownloadWorker.perform_async("PackageManager::#{params['platform']}", params["name"])
+    end
 
     render json: nil, status: :ok
   end


### PR DESCRIPTION
We're getting some PackageManagerDownloadWorker jobs with blank platforms, and the hooks endpoint seems like the most likely candidate for the source of these. Skip any hooks that have blank platforms and just log them instead.