### PR TITLE
Don't show large project usage pages

### DIFF
--- a/app/controllers/project_usage_controller.rb
+++ b/app/controllers/project_usage_controller.rb
@@ -2,10 +2,16 @@
 class ProjectUsageController < ApplicationController
   before_action :find_project
   def show
-    @all_counts = @project.repository_dependencies.joins(:repository).group('repository_dependencies.requirements').count.select{|k,v| k.present? }
+    # looking at repository dependencies is inefficient, let's not DoS ourself
+    if @project.dependent_repos_count > 10000
+      @too_big = true
+      @total = @project.dependent_repos_count
+      return
+    end
+    @all_counts = @project.repository_dependencies.group('repository_dependencies.requirements').count.select{|k,v| k.present? }
     @total = @all_counts.sum{|k,v| v }
     if @all_counts.any?
-      @kinds = @project.repository_dependencies.joins(:repository).group('repository_dependencies.kind').count
+      @kinds = @project.repository_dependencies.group('repository_dependencies.kind').count
       @counts = sort_by_semver_range(@all_counts.length > 18 ? 17 : 18)
       @highest_percentage = @counts.map{|_k,v| v.to_f/@total*100 }.max
     end

--- a/app/views/project_usage/show.html.erb
+++ b/app/views/project_usage/show.html.erb
@@ -11,7 +11,9 @@
 <p>
   Required version breakdown across <strong><%= number_to_human(@total) %></strong> open source repositories
 </p>
-<% if @all_counts.any? %>
+<% if @too_big %>
+  Too many dependendent repositories to provide breakdown stats
+<% elsif @all_counts.any? %>
     <table id="q-graph">
         <tbody>
         <% max_height = 400 %>


### PR DESCRIPTION
These are inefficient to load so let's just pop a message vs doing
very expensive queries that break the site
