### PR TITLE
Drupal: modify regexp for repo url, and use safe navigation

### DIFF
--- a/app/models/package_manager/packagist/drupal.rb
+++ b/app/models/package_manager/packagist/drupal.rb
@@ -28,7 +28,10 @@ class PackageManager::Packagist::Drupal < PackageManager::Packagist
       description: raw_project.css("meta[name=description]").first&.attr('content'),
       homepage: homepage,
       licenses: DRUPAL_MODULE_LICENSE,
-      repository_url: raw_project.css('#block-drupalorg-project-development .links a').find { |l| l.text =~ /code repository/ }.attr('href'),
+      repository_url: raw_project
+        .css('#block-drupalorg-project-development .links a')
+        .find { |l| l.text =~ /code repository|source code/i }
+        &.attr('href'),
     }
   end
 


### PR DESCRIPTION
Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/618bd78384a4da0008c55296
