### PR TITLE
Fix API tree endpoint by changin params[:version] to params[:number]

### DIFF
--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -70,7 +70,7 @@ class Api::ProjectsController < Api::ApplicationController
     @subset = params.fetch(:subset, "default")
 
     @project = Project.find_best!(params[:platform], params[:name], [:repository, :versions])
-    @version = @project.find_version!(params[:version])
+    @version = @project.find_version!(params[:number])
     # render app/views/api/projects/dependencies.json.jb
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -243,7 +243,7 @@ class ApplicationController < ActionController::Base
 
   def load_tree_resolver
     @date = Date.parse(params[:date]) rescue Date.today
-    number = params[:number].presence || params[:version].presence # Web route || API route
+    number = params[:number].presence
 
     if number
       @version = @project.versions.find_by_number(number)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -243,9 +243,10 @@ class ApplicationController < ActionController::Base
 
   def load_tree_resolver
     @date = Date.parse(params[:date]) rescue Date.today
+    number = params[:number].presence || params[:version].presence # Web route || API route
 
-    if params[:number].present?
-      @version = @project.versions.find_by_number(params[:number])
+    if number
+      @version = @project.versions.find_by_number(number)
     else
       @version = @project.versions.where('versions.published_at <= ?', @date).select(&:stable?).sort.first
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,8 +67,8 @@ Rails.application.routes.draw do
     get "/:platform/:name/usage", to: "project_usage#show", as: :project_usage, constraints: { platform: PLATFORM_CONSTRAINT, name: PROJECT_CONSTRAINT }
     get "/:platform/:name/sourcerank", to: "projects#sourcerank", constraints: { platform: PLATFORM_CONSTRAINT, name: PROJECT_CONSTRAINT }
     get "/:platform/:name/contributors", to: "projects#contributors", constraints: { platform: PLATFORM_CONSTRAINT, name: PROJECT_CONSTRAINT }
-    get "/:platform/:name/:version/tree", to: "tree#show", constraints: { platform: /[\w\-]+/, name: PROJECT_CONSTRAINT, version: VERSION_CONSTRAINT }, as: :version_tree
-    get "/:platform/:name/:version/dependencies", to: "projects#dependencies", constraints: { platform: PLATFORM_CONSTRAINT, name: PROJECT_CONSTRAINT, version: VERSION_CONSTRAINT }
+    get "/:platform/:name/:number/tree", to: "tree#show", constraints: { platform: /[\w\-]+/, name: PROJECT_CONSTRAINT, number: VERSION_CONSTRAINT }, as: :version_tree
+    get "/:platform/:name/:number/dependencies", to: "projects#dependencies", constraints: { platform: PLATFORM_CONSTRAINT, name: PROJECT_CONSTRAINT, number: VERSION_CONSTRAINT }
     get "/:platform/:name/dependent_repositories", to: "projects#dependent_repositories", constraints: { platform: PLATFORM_CONSTRAINT, name: PROJECT_CONSTRAINT }
     get "/:platform/:name/dependents", to: "projects#dependents", constraints: { platform: PLATFORM_CONSTRAINT, name: PROJECT_CONSTRAINT }
     get "/:platform/:name/tree", to: "tree#show", constraints: { platform: PLATFORM_CONSTRAINT, name: PROJECT_CONSTRAINT }, as: :tree

--- a/spec/requests/api/tree_spec.rb
+++ b/spec/requests/api/tree_spec.rb
@@ -15,7 +15,7 @@ describe "Api::TreesController" do
     end
   end
 
-  describe "GET /api/:platform/:name/:version/tree", type: :request do
+  describe "GET /api/:platform/:name/:number/tree", type: :request do
     it "renders successfully" do
       get "/api/#{old_version.project.platform}/#{old_version.project.name}/#{old_version.number}/tree?api_key=#{user.api_key}"
       expect(response).to have_http_status(:success)

--- a/spec/requests/api/tree_spec.rb
+++ b/spec/requests/api/tree_spec.rb
@@ -2,15 +2,25 @@
 require "rails_helper"
 
 describe "Api::TreesController" do
-  let(:version) { create(:version) }
+  let!(:old_version) { create(:version, number: "1.0.0", published_at: 1.month.ago) }
+  let!(:new_version) { create(:version, number: "2.0.0", project: old_version.project, published_at: 1.day.ago) }
   let(:user) { create(:user) }
 
   describe "GET /api/:platform/:name/tree", type: :request do
     it "renders successfully" do
-      get "/api/#{version.project.platform}/#{version.project.name}/tree?api_key=#{user.api_key}"
+      get "/api/#{new_version.project.platform}/#{new_version.project.name}/tree?api_key=#{user.api_key}"
       expect(response).to have_http_status(:success)
       expect(response.content_type).to eq('application/json')
-      expect(response.body).to be_json_eql TreeResolver.new(version, 'runtime', Date.today).tree.to_json
+      expect(response.body).to be_json_eql TreeResolver.new(new_version, 'runtime', Date.today).tree.to_json
+    end
+  end
+
+  describe "GET /api/:platform/:name/:version/tree", type: :request do
+    it "renders successfully" do
+      get "/api/#{old_version.project.platform}/#{old_version.project.name}/#{old_version.number}/tree?api_key=#{user.api_key}"
+      expect(response).to have_http_status(:success)
+      expect(response.content_type).to eq('application/json')
+      expect(response.body).to be_json_eql TreeResolver.new(old_version, 'runtime', Date.today).tree.to_json
     end
   end
 end

--- a/spec/requests/tree_spec.rb
+++ b/spec/requests/tree_spec.rb
@@ -12,7 +12,7 @@ describe "TreeController" do
     end
   end
 
-  describe "GET /:platform/:project/:version/tree", type: :request do
+  describe "GET /:platform/:project/:number/tree", type: :request do
     it "renders successfully when logged out" do
       visit version_tree_path(version.to_param)
       expect(page).to have_content 'Dependency Tree'


### PR DESCRIPTION
The two endpoints to get a dep tree use different params for version:

```
                api_version_tree GET      /api/:platform/:name/:version/tree(.:format)              api/tree#show {:format=>:json, :platform=>/[\w\-]+/, :name=>/[^\/]+/, :version=>/[\w.\-]+/}
                    version_tree GET      /:platform/:name/:number/tree(.:format)                   tree#show {:number=>/[\w.\-%]+/, :name=>/[^\/]+/}
```

~~This adds the `params[:version]` to the tree-resolver-initialization logic so the first route can fetch the specific version instead of "latest stable" version.~~

This changes `params[:version]` to `params[:number]` to fix the API tree endpoint and make API routes consistent with Web routes.
