### PR TITLE
Undeprecate a previously-deprecated package if it is no longer deprecated.

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -570,6 +570,9 @@ class Project < ApplicationRecord
       if result[:is_deprecated]
         update_attribute(:status, "Deprecated")
         update_attribute(:deprecation_reason, result[:message])
+      else # in case package was accidentally marked as deprecated (their logic or ours), mark it as not deprecated
+        update_attribute(:status, '')
+        update_attribute(:deprecation_reason, nil)
       end
     elsif deprecated_or_removed
       update_attribute(:status, nil)

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -273,6 +273,21 @@ describe Project, type: :model do
         end
       end
     end
+
+    context 'deprecated project no longer deprecated' do
+      let!(:project) { Project.create(platform: 'NPM', name: 'react', status: 'Deprecated') }
+
+      it 'should mark the project no longer deprecated' do
+        VCR.use_cassette('project/check_status/react') do
+          project.check_status
+
+          project.reload
+
+          expect(project.status).to eq('')
+          expect(project.deprecation_reason).to eq(nil)
+        end
+      end
+    end
   end
 
   describe 'DeletedProject management' do


### PR DESCRIPTION
Libraries' deprecation logic may be imperfect sometimes and is evolving (or a package repo could allow undeprecation of a package), so if a package on a platform that allows package-deprecation was deprecated in the past and is no longer deprecated, then mark it as not deprecated.

Followup to https://github.com/librariesio/libraries.io/pull/2907

- [ ] Have you followed the guidelines for [contributors](http://docs.libraries.io/contributorshandbook)?
- [ ] Have you checked to ensure there aren't other open pull requests on the repository for a similar change?
- [ ] Is there a corresponding ticket for your pull request?
- [x] Have you written new tests for your changes?
- [ ] Have you successfully run the project with your changes locally?

If so then please replace this section with a link to the ticket(s) it addressed, an explanation of your change and why you think we should include it. Thanks again! 
