### PR TITLE
Use pkg.go.dev For Go Package Names

### DIFF
--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -204,7 +204,7 @@ namespace :projects do
     start_id = REDIS.get("go:update:latest_updated_id").presence || 0
     puts "Start id: #{start_id}, limit: #{args[:count]}."
     projects = Project
-      .where(platform: "Go")
+      .where(platform: "Go", repository_url: nil) # no repository_url is a common sign the package does not exist on pkg.go.dev
       .where("id > ?", start_id)
       .order(:id)
       .limit(args[:count])

--- a/spec/models/package_manager/go_spec.rb
+++ b/spec/models/package_manager/go_spec.rb
@@ -215,4 +215,16 @@ describe PackageManager::Go do
       end
     end
   end
+
+  describe "#encode_for_proxy" do
+    [
+      %w[test test],
+      %w[BigTest !big!test],
+      %w[BIGBIGTEST !b!i!g!b!i!g!t!e!s!t],
+    ].each do |(test, expected)|
+      it "should replace capital letters" do
+        expect(PackageManager::Go.encode_for_proxy(test)).to eql(expected)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Use `pkg.go.dev` to verify if a package name is correct for Go and don't return partial info if the name is not found. This also fixes up an encoding issue when querying the proxy for version info.