### PR TITLE
Update Go Project Verification To Deal With Non Module Names

### DIFF
--- a/app/models/package_manager/go.rb
+++ b/app/models/package_manager/go.rb
@@ -79,7 +79,7 @@ module PackageManager
       # call update on base module name if the name is appended with major version
       # example: github.com/myexample/modulename/v2
       # use the returned project name in case it finds a Project via repository_url
-      update_base_module(project.name) if project.name.match(VERSION_MODULE_REGEX)
+      update_base_module(project.name) if project.present? && project.name.match(VERSION_MODULE_REGEX)
 
       project
     end

--- a/app/workers/go_project_verification_worker.rb
+++ b/app/workers/go_project_verification_worker.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# This worker is meant to verify if this package name is correct and found on the resources used as the
+# Go platform's source of truth. If a project name is not found, then go ahead and delete the Project from libraries.
+# If it is found, but is not the canonical name that should be used, then attempt to find the correct name and
+# use that Project only without creating any new Projects with similar but incorrect names.
 class GoProjectVerificationWorker
   include Sidekiq::Worker
   sidekiq_options queue: :small
@@ -7,20 +11,36 @@ class GoProjectVerificationWorker
   def perform(name)
     project = Project.find_by(platform: "Go", name: name)
 
-    # checks if the project name returns version results from Go Proxy
-    # if the result comes back with a "gone" HTTP status, then remove the project from Libraries
-    if PackageManager::Go.valid_project?(project.name)
-      # valid project page
-      unless PackageManager::Go.module?(project.name)
-        # not a module
-        # figure out what the correct module name is and if it exists already than this one can go
-        # if it doesn't exist then call update for it to get it added
-        module_name = PackageManager::Go.canonical_module_name(project.name)
+    # check to see if the module is found on pkg.go.dev and if it isn't then go ahead and delete this name
+    return project.destroy unless PackageManager::Go.valid_project?(project.name)
+
+    # if this name is found and is considered a module then that should be considered canonical
+    unless PackageManager::Go.module?(project.name)
+      # not a module
+      # figure out what the correct module name is
+      module_name = non_module_name(name)
+
+      # If we have a different name come back then run an update on the new name if we don't already have a Project for it
+      # and delete the Project with the name that was passed in.
+      #
+      # The goal is to have only one remaining Project for the name passed in here to avoid having multiple projects
+      # with different cased names for the same package.
+      if name != module_name
         PackageManager::Go.update(module_name) unless Project.where(platform: "Go", name: module_name).exists?
         project.destroy
       end
-    else
-      project.destroy
     end
+  end
+
+  private
+
+  # attempt to figure out the correct module name by querying the Go proxy server and reading the generated mod file
+  # if the proxy sends back the same cased name that we sent, then it will likely do that for all the different casings
+  # in that case downcase the name and use that as the canonical name for this package
+  def non_module_name(name)
+    proxy_name = PackageManager::Go.canonical_module_name(name)
+
+    proxy_name = proxy_name.downcase if proxy_name == name
+    proxy_name
   end
 end


### PR DESCRIPTION
When verifying a project name and ending up with a non Go module package downcase the name and use that as the canonical name for that package.