### PR TITLE
Set a reasonable timeout when looking up canonical name of go module

### DIFF
--- a/spec/models/package_manager/go_spec.rb
+++ b/spec/models/package_manager/go_spec.rb
@@ -226,7 +226,7 @@ describe PackageManager::Go do
 
           allow(described_class)
             .to receive(:get_html)
-            .with("https://go.uber.org/multierr?go-get=1")
+            .with("https://go.uber.org/multierr?go-get=1", {request: {timeout: 2}})
             .and_return(Nokogiri::HTML(html))
 
           expect(described_class.project_find_names("go.uber.org/multierr"))
@@ -238,7 +238,7 @@ describe PackageManager::Go do
         it "returns the original name" do
           allow(described_class)
             .to receive(:get_html)
-            .with("https://go.example.org/user/foo?go-get=1")
+            .with("https://go.example.org/user/foo?go-get=1", {request: {timeout: 2}})
             .and_return(Nokogiri::HTML("<html><body>Hello, world!</body></html>"))
 
           expect(described_class.project_find_names("go.example.org/user/foo"))


### PR DESCRIPTION
This adds a 2-second timeout to `PackageManager::Go.project_find_names()`, which is currently timing out (60 sec?) on a module that has been moved (`vbom.ml/util` -> `github.com/fvbommel/util`). 