### PR TITLE
puma 5.3.2 ~> 5.6.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -434,7 +434,7 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.6)
-    puma (5.3.2)
+    puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3)


### PR DESCRIPTION
To avoid CVE-2022-24790 request smuggling vuln.

[Diff](https://github.com/puma/puma/compare/v5.3.2...v5.6.4)