### PR TITLE
Adapt Packagist's deprecation_info to new v2 api too.

### DIFF
--- a/app/models/package_manager/packagist.rb
+++ b/app/models/package_manager/packagist.rb
@@ -52,14 +52,14 @@ module PackageManager
     end
 
     def self.project(name)
-      # The main v2 endpoint excludes dev versions, so if that list
-      # of versions is empty, fallback to the dev list of versions.
+      # The main v2 endpoint only returns a list of versions (no single source-of-truth for the project)
+      # and excludes dev versions, so if that list of versions is empty, fallback to the dev list of versions.
       get("https://repo.packagist.org/p2/#{name}.json")&.dig("packages", name).presence || 
         get("https://repo.packagist.org/p2/#{name}~dev.json")&.dig("packages", name)
     end
 
     def self.deprecation_info(name)
-      is_deprecated = project(name).dig("abandoned") || ""
+      is_deprecated = project(name)&.first&.dig("abandoned") || ""
 
       {
         is_deprecated: is_deprecated != "",

--- a/spec/models/package_manager/packagist_spec.rb
+++ b/spec/models/package_manager/packagist_spec.rb
@@ -72,25 +72,25 @@ describe PackageManager::Packagist do
 
   describe "#deprecation_info" do
     it "return not-deprecated if 'abandoned' is false'" do
-      expect(PackageManager::Packagist).to receive(:project).with("foo").and_return({
+      expect(PackageManager::Packagist).to receive(:project).with("foo").and_return([{
                                                                                       "abandoned" => false,
-                                                                                    })
+                                                                                    }])
 
       expect(described_class.deprecation_info("foo")).to eq({ is_deprecated: false, message: "" })
     end
 
     it "return deprecated if 'abandoned' is true'" do
-      expect(PackageManager::Packagist).to receive(:project).with("foo").and_return({
+      expect(PackageManager::Packagist).to receive(:project).with("foo").and_return([{
                                                                                       "abandoned" => true,
-                                                                                    })
+                                                                                    }])
 
       expect(described_class.deprecation_info("foo")).to eq({ is_deprecated: true, message: "" })
     end
 
     it "return deprecated if 'abandoned' is set to a replacement package'" do
-      expect(PackageManager::Packagist).to receive(:project).with("foo").and_return({
+      expect(PackageManager::Packagist).to receive(:project).with("foo").and_return([{
                                                                                       "abandoned" => "use-this/package-instead",
-                                                                                    })
+                                                                                    }])
 
       expect(described_class.deprecation_info("foo")).to eq({ is_deprecated: true, message: "Replacement: use-this/package-instead" })
     end


### PR DESCRIPTION
Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/6296bb1dfa287a00093c83ea