### PR TITLE
Packagist updates: use the first version returned to get metadata.

### DIFF
--- a/app/models/package_manager/packagist.rb
+++ b/app/models/package_manager/packagist.rb
@@ -70,8 +70,9 @@ module PackageManager
     def self.mapping(raw_project)
       return nil unless raw_project.any?
 
-      latest_version = raw_project
-        .max_by { |v| v["time"].to_s } # then we'll use the most recently published as our most recent version
+      # In V2 API, it looks like the first version is the one with all the metadata (name, etc)
+      # (This might not necessarily be the version with the highest "time" value)
+      latest_version = raw_project.first
 
       return if latest_version.nil?
 


### PR DESCRIPTION
The old logic of Packagist V1 API was to use the version with the highest "time" value to fetch the metadata. Now, in V2, that might not necessarily be the "highest" version, and only the "highest" version will have the metadata. This uses the first one returned, which (based on my sample of 20 projects) should always have the metadata.

Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/629694b6d12c280008c2f4e7