### PR TITLE
update pg_query to 1.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -408,7 +408,7 @@ GEM
     parser (3.0.0.0)
       ast (~> 2.4.1)
     pg (1.1.4)
-    pg_query (1.1.0)
+    pg_query (1.3.0)
     pghero (2.7.0)
       activerecord (>= 5)
     pictogram (2.0.12)


### PR DESCRIPTION
Update to support M1 chips. 1.3.0 is the first 1.x version that supports M1 chip installs.

https://github.com/pganalyze/pg_query/issues/210