### PR TITLE
Remove trailing slash to accomodate recent pypi route changes.

### DIFF
--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -17,7 +17,7 @@ module PackageManager
     end
 
     def self.check_status_url(db_project)
-      "https://pypi.org/pypi/#{db_project.name}/json/"
+      "https://pypi.org/pypi/#{db_project.name}/json"
     end
 
     def self.install_instructions(db_project, version = nil)


### PR DESCRIPTION
Pypa is doing some refactoring to their routes and CDN so it looks like we'll need to use the no-slash route for JSON pypi urls (we don't follow redirects so we're using the wrong response in Project#check_status):

https://github.com/python/pypi-infra/pull/74#issuecomment-1149830495

Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/6279b21e084724000936ed63