### PR TITLE
Mark pypi packages as Removed when we get a 404.

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -565,6 +565,8 @@ class Project < ApplicationRecord
       update_attribute(:status, "Removed")
     elsif platform.downcase == "clojars" && response.response_code == 404
       update_attribute(:status, "Removed")
+    elsif platform.downcase == "pypi" && response.response_code = 404
+      update_attribute(:status, "Removed")
     elsif can_have_entire_package_deprecated?
       result = platform_class.deprecation_info(name)
       if result[:is_deprecated]


### PR DESCRIPTION
I'm not positive if 404s on JSON endpoints for missing projects is a new response on Pypi, but we're getting them now, so we can just use them as a signal that the package is deleted. e.g. `astoptimizer` and `cocolangapi` are ones that we're currently blowing up on bc they 404.

Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/6279b21e084724000936ed63
