### PR TITLE
Always publish pypi project urls with a trailing slash.

### DIFF
--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -13,10 +13,13 @@ module PackageManager
     PYPI_PRERELEASE = /(a|b|rc|dev)[0-9]+$/.freeze
 
     def self.package_link(db_project, version = nil)
-      "https://pypi.org/project/#{db_project.name}/#{version}"
+      # NB PEP 503: "All URLs which respond with an HTML5 page MUST end with a / and the repository SHOULD redirect the URLs without a / to add a / to the end."
+      "https://pypi.org/project/#{db_project.name}/"
+        .then { |url| version.present? ? url + "#{version}/" : url }
     end
 
     def self.check_status_url(db_project)
+      # NB Pypa has maintained the original JSON API behavior of allowing no trailing slash in python/pypi-infra/pull/74
       "https://pypi.org/pypi/#{db_project.name}/json"
     end
 

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -14,7 +14,7 @@ describe PackageManager::Pypi do
     end
 
     it 'handles version' do
-      expect(described_class.package_link(project, '2.0.0')).to eq("https://pypi.org/project/foo/2.0.0")
+      expect(described_class.package_link(project, '2.0.0')).to eq("https://pypi.org/project/foo/2.0.0/")
     end
   end
 


### PR DESCRIPTION
Not very consequential, but PEP 503 says "All URLs which respond with an HTML5 page MUST end with a / and the repository SHOULD redirect the URLs without a / to add a / to the end.", so we can save them a redirect by publishing the project-with-version url with a trailing slash.