### PR TITLE
Worker to Check Out Duplicate pypi Names

### DIFF
--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -152,5 +152,14 @@ module PackageManager
         project_name.gsub("_", "-"),
       ]
     end
+
+    # checks to see if the package exists on PyPI and the name matches the canonical name
+    def self.valid_project?(name)
+      raw_project = project(name)
+      mapped_project = mapping(raw_project)
+
+      # did we get a response from PyPI and does the name it respond with match the name passed in
+      raw_project.present? && mapped_project[:name] == name
+    end
   end
 end

--- a/app/workers/pypi_project_verification_worker.rb
+++ b/app/workers/pypi_project_verification_worker.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# This worker is meant to verify if this package name is correct and found on the resources used as the
+# Pypi platform's source of truth. If a project name is not found, then go ahead and delete the Project from libraries.
+class PypiProjectVerificationWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :small
+
+  def perform(name)
+    project = Project.find_by(platform: "Pypi", name: name)
+
+    return unless project.present?
+
+    # check to see if the module is found on pkg.go.dev and if it isn't then go ahead and delete this name
+    return project.destroy unless PackageManager::Pypi.valid_project?(project.name)
+  end
+end


### PR DESCRIPTION
I don't think there is a rush to run this right away, but wanted to put together something that could determine which Project is the correct canonical named Pypi project and remove duplicates.