### PR TITLE
Silence some errors from removed platform projects.

### DIFF
--- a/app/models/concerns/project_search.rb
+++ b/app/models/concerns/project_search.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 module ProjectSearch
-  # Whenever a PackageManager::Base platform is removed, it's easier for now to
-  # just add it to this list, until the records/indices are cleared out of that platform.
-  # NB these are the casings from the database, which sometimes don't match the PackageManager::Base
-  # formatted_name casings, e.g. Pypi vs PyPI
-  REMOVED_PLATFORMS = %w(Sublime Wordpress Atom PlatformIO Shards Emacs Jam)
-
   extend ActiveSupport::Concern
 
   included do
@@ -138,7 +132,7 @@ module ProjectSearch
                      must_not: [
                        { term: { "status" => "Hidden" } },
                        { term: { "status" => "Removed" } },
-                       { terms: { "platform" => REMOVED_PLATFORMS } }
+                       { terms: { "platform" => Project::REMOVED_PLATFORMS } }
                      ]
                   }
                 }


### PR DESCRIPTION
We still do a few things with projects where the platform has been removed (e.g. version notification mailers), but they're currently blowing up because `Project#platform_name` is busted. This fix returns the platform name directly if we know it has been removed.

Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/615b59f7cb008b00075ec41a