### PR TITLE
self.dependencies requires versions in mapped_project for some package managers

### DIFF
--- a/app/models/package_manager/cpan.rb
+++ b/app/models/package_manager/cpan.rb
@@ -41,6 +41,7 @@ module PackageManager
         description: raw_project["abstract"],
         licenses: raw_project.fetch("license", []).join(","),
         repository_url: repo_fallback(raw_project.fetch("resources", {}).fetch("repository", {})["web"], raw_project.fetch("resources", {})["homepage"]),
+        versions: versions(raw_project, raw_project["distribution"]),
       }
     end
 

--- a/app/models/package_manager/dub.rb
+++ b/app/models/package_manager/dub.rb
@@ -33,6 +33,7 @@ module PackageManager
         keywords_array: format_keywords(raw_project["categories"]),
         licenses: latest_version["license"],
         repository_url: repo_fallback(repository(raw_project["repository"]), latest_version["homepage"]),
+        versions: raw_project["versions"],
       }
     end
 

--- a/app/models/package_manager/npm.rb
+++ b/app/models/package_manager/npm.rb
@@ -65,6 +65,7 @@ module PackageManager
         keywords_array: Array.wrap(latest_version.fetch("keywords", [])),
         licenses: licenses(latest_version),
         repository_url: repo_fallback(repo_url, raw_project["homepage"]),
+        versions: raw_project["versions"]
       }
     end
 

--- a/app/models/package_manager/packagist.rb
+++ b/app/models/package_manager/packagist.rb
@@ -83,6 +83,7 @@ module PackageManager
         keywords_array: Array.wrap(latest_version["keywords"]),
         licenses: latest_version["license"]&.join(","),
         repository_url: repo_fallback(latest_version["source"]&.fetch("url"), latest_version["homepage"]),
+        versions: raw_project, # packagist has the list of versions as raw_project and this then lets us pull dependencies in self.dependencies
       }
     end
 

--- a/app/models/package_manager/pub.rb
+++ b/app/models/package_manager/pub.rb
@@ -48,6 +48,7 @@ module PackageManager
         homepage: latest_version["pubspec"]["homepage"],
         description: latest_version["pubspec"]["description"],
         repository_url: repo_fallback("", latest_version["pubspec"]["homepage"]),
+        versions: raw_project["versions"],
       }
     end
 


### PR DESCRIPTION
We need versions in mapped_project for some package managers for
dependencies to work. Bring it back for those specific ones.
