### PR TITLE
Adds and implements Project#repository_url_set_by_admin

### DIFF
--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -8,8 +8,9 @@ class Admin::ProjectsController < Admin::ApplicationController
     @project = Project.find(params[:id])
     # set the flag saying this license was set by admins if there is a value in the form and it is different than what is currently saved
     update_params = project_params
-    update_params[:normalized_licenses] = Array(update_params[:normalized_licenses]) # convert selected license to an array for normalized_licenses
+    update_params = update_params.merge(normalized_licenses: Array(update_params[:normalized_licenses])) # convert selected license to an array for normalized_licenses
     update_params = update_params.merge(license_set_by_admin: true) if project_params[:normalized_licenses].present? && project_params[:normalized_licenses] != @project.normalized_licenses
+    update_params = update_params.merge(repository_url_set_by_admin: true) if project_params[:repository_url_set_by_admin].present? && project_params[:repository_url] != @project.repository_url
     if @project.update(update_params)
       @project.update_repository_async
       @project.async_sync

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -104,7 +104,9 @@ module PackageManager
 
       db_project = Project.find_or_initialize_by({ name: mapped_project[:name], platform: db_platform })
       db_project.reformat_repository_url if sync_version == :all && !db_project.new_record?
-      mapped_project[:repository_url] = db_project.repository_url if mapped_project[:repository_url].blank?
+      if mapped_project[:repository_url].blank? || db_project.repository_url_set_by_admin?
+        mapped_project[:repository_url] = db_project.repository_url 
+      end
       db_project.attributes = mapped_project.except(:name, :releases, :versions, :version, :dependencies, :properties)
 
       begin

--- a/db/migrate/20220712203600_add_repository_url_set_by_admin_to_project.rb
+++ b/db/migrate/20220712203600_add_repository_url_set_by_admin_to_project.rb
@@ -1,0 +1,5 @@
+class AddRepositoryUrlSetByAdminToProject < ActiveRecord::Migration[5.2]
+  def change
+    add_column :projects, :repository_url_set_by_admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_24_133104) do
+ActiveRecord::Schema.define(version: 2022_07_12_203600) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -168,6 +168,7 @@ ActiveRecord::Schema.define(version: 2021_03_24_133104) do
     t.boolean "license_set_by_admin", default: false
     t.boolean "license_normalized", default: false
     t.text "deprecation_reason"
+    t.boolean "repository_url_set_by_admin", default: false
     t.index "lower((language)::text)", name: "index_projects_on_lower_language"
     t.index "lower((platform)::text), lower((name)::text)", name: "index_projects_on_platform_and_name_lower"
     t.index ["created_at"], name: "index_projects_on_created_at"

--- a/spec/models/package_manager/conda_spec.rb
+++ b/spec/models/package_manager/conda_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 describe PackageManager::Conda do
-  let(:project) { create(:project, name: 'foo', platform: described_class.formatted_name) }
+  let(:project) { create(:project, name: 'foo', platform: described_class.db_platform) }
 
   it 'has formatted name of "conda"' do
     expect(described_class.formatted_name).to eq('conda')
@@ -21,6 +21,36 @@ describe PackageManager::Conda do
   describe '#install_instructions' do
     it 'returns a command to install the project' do
       expect(described_class.install_instructions(project)).to eq("conda install -c anaconda foo")
+    end
+  end
+
+
+  describe 'finds repository urls' do
+    it 'updates repository_url' do
+      allow(described_class)
+        .to receive(:project)
+        .and_return({
+          "name" => project.name, 
+          "versions" => [],
+          "repository_url" => "https://this-is-my-repo-url"
+        })
+      described_class.update(project.name)
+      expect(project.reload.repository_url).to eq("https://this-is-my-repo-url")
+    end
+
+    it 'updating doesnt ovewrite repository_url if previously set by admin' do
+      original_repository_url = project.repository_url
+      project.update_column(:repository_url_set_by_admin, true)
+      allow(described_class)
+        .to receive(:project)
+        .and_return({
+          "name" => project.name, 
+          "versions" => [],
+          "repository_url" => "https://this-is-the-wrong-url"
+        })
+      described_class.update(project.name)
+      
+      expect(project.reload.repository_url).to eq(original_repository_url)
     end
   end
 end


### PR DESCRIPTION
This adds `Project#repository_url_set_by_admin?` to denote that the repository_url was explicitly set by an admin, and to prevent it from being overwritten by PackageManagerDownloadWorker. 

It's similar to the `Project#license_set_by_admin?` that was added in https://github.com/librariesio/libraries.io/pull/2448.

(the one thing I'm not doing is adding this to the API, bc I'm not sure if we need it?)