### PR TITLE
Make repository_url non-editable in admin

### DIFF
--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -45,7 +45,7 @@ class Admin::ProjectsController < Admin::ApplicationController
   private
 
   def project_params
-    params.require(:project).permit(:repository_url, :normalized_licenses, :status)
+    params.require(:project).permit(:normalized_licenses, :status)
   end
 
   def search(query)

--- a/app/views/admin/projects/show.html.erb
+++ b/app/views/admin/projects/show.html.erb
@@ -24,7 +24,6 @@
       <strong>Subscribers:</strong> <%= @project.subscriptions.count %>
     </p>
 
-    <%= form.input :repository_url %>
     <%= form.input :normalized_licenses, include_blank: true, selected: @project.normalized_licenses, label: 'License', collection: Project.popular_licenses(:facet_limit => 300).map{|l| format_license(l['key']) } %>
     <%= form.input :status, include_blank: true, collection: Project::STATUSES %>
 


### PR DESCRIPTION
This removes the `repository_url` field from the Admin Project form for 2 reasons:
1) the value gets overridden by PackageManagerDownloadWorker anyway when the project gets rescraped after save
2) and we want libraries to be the canonical source of repo data, not curated data