### PR TITLE
Try to rescue RecordNotFound in one spot and explicitly return 404

### DIFF
--- a/app/controllers/platforms_controller.rb
+++ b/app/controllers/platforms_controller.rb
@@ -19,7 +19,7 @@ class PlatformsController < ApplicationController
     @languages = facets[:languages].language.buckets
     @licenses = facets[:licenses].normalized_licenses.buckets.reject{ |t| t['key'].downcase == 'other' }
     @keywords = facets[:keywords].keywords_array.buckets
-  rescue_from ActiveRecord::RecordNotFound do
-    render status: :not_found
+  rescue ActiveRecord::RecordNotFound
+    head :not_found
   end
 end

--- a/app/controllers/platforms_controller.rb
+++ b/app/controllers/platforms_controller.rb
@@ -19,5 +19,7 @@ class PlatformsController < ApplicationController
     @languages = facets[:languages].language.buckets
     @licenses = facets[:licenses].normalized_licenses.buckets.reject{ |t| t['key'].downcase == 'other' }
     @keywords = facets[:keywords].keywords_array.buckets
+  rescue_from ActiveRecord::RecordNotFound do
+    render status: :not_found
   end
 end


### PR DESCRIPTION
ActiveRecord::RecordNotFounds seem to be rendered as uncaught errors/500s in production instead of 404. This results in false-positive 500 metrics. Going to try rescuing them explicitly and return 404s and if that works then possibly introduce some `rescue_from`.
