### PR TITLE
Fix flaky sidekiq specs

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -16,3 +16,7 @@ end
 Sidekiq.default_worker_options = {
   backtrace: true,
 }
+
+SidekiqUniqueJobs.configure do |config|
+  config.enabled = !Rails.env.test?
+end

--- a/spec/support/sidekiq_testing_helpers.rb
+++ b/spec/support/sidekiq_testing_helpers.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  # Ensure sidekiq is cleared out between examples.
+  config.before(:each) do
+    Sidekiq::Worker.clear_all
+  end
+end

--- a/spec/workers/repository_maintenance_stat_worker_spec.rb
+++ b/spec/workers/repository_maintenance_stat_worker_spec.rb
@@ -19,29 +19,23 @@ describe RepositoryMaintenanceStatWorker do
   end
 
   it "should queue jobs in high priority" do
-    # need to disable the queue locking for tests to work with Sidekiq mocking
-    SidekiqUniqueJobs.use_config(enabled: false) do
-      expect(Sidekiq::Queues["repo_maintenance_stat_high"].size).to eql 0
-      expect(RepositoryMaintenanceStatWorker.jobs.size).to eql 0
+    expect(Sidekiq::Queues["repo_maintenance_stat_high"].size).to eql 0
+    expect(RepositoryMaintenanceStatWorker.jobs.size).to eql 0
 
-      RepositoryMaintenanceStatWorker.enqueue(repository.id, priority: :high)
-    
-      expect(RepositoryMaintenanceStatWorker.jobs.size).to eql 1
-      expect(Sidekiq::Queues["repo_maintenance_stat_high"].size).to eql 1
-    end
+    RepositoryMaintenanceStatWorker.enqueue(repository.id, priority: :high)
+
+    expect(RepositoryMaintenanceStatWorker.jobs.size).to eql 1
+    expect(Sidekiq::Queues["repo_maintenance_stat_high"].size).to eql 1
   end
 
   it "should queue jobs in low priority" do
-    # need to disable the queue locking for tests to work with Sidekiq mocking
-    SidekiqUniqueJobs.use_config(enabled: false) do
-      expect(Sidekiq::Queues["repo_maintenance_stat_low"].size).to eql 0
-      expect(RepositoryMaintenanceStatWorker.jobs.size).to eql 0
+    expect(Sidekiq::Queues["repo_maintenance_stat_low"].size).to eql 0
+    expect(RepositoryMaintenanceStatWorker.jobs.size).to eql 0
 
-      RepositoryMaintenanceStatWorker.enqueue(repository.id, priority: :low)
-    
-      expect(RepositoryMaintenanceStatWorker.jobs.size).to eql 1
-      expect(Sidekiq::Queues["repo_maintenance_stat_low"].size).to eql 1
-    end
+    RepositoryMaintenanceStatWorker.enqueue(repository.id, priority: :low)
+
+    expect(RepositoryMaintenanceStatWorker.jobs.size).to eql 1
+    expect(Sidekiq::Queues["repo_maintenance_stat_low"].size).to eql 1
   end
 
   context "with unsupported repository host_type" do


### PR DESCRIPTION
Some specs are flaky because we don't clear Sidekiq between specs, and don't disable SidekiqUnique for specs.