### PR TITLE
Perf: PackageManager update

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -146,6 +146,7 @@ module PackageManager
       )
 
       existing = db_project.versions.find_or_initialize_by(number: version_hash[:number])
+      existing.skip_save_project = true
       existing.assign_attributes(version_hash)
 
       existing.repository_sources = Set.new(existing.repository_sources).add(self::REPOSITORY_SOURCE_NAME).to_a if self::HAS_MULTIPLE_REPO_SOURCES
@@ -170,6 +171,7 @@ module PackageManager
       db_project.reload
       db_project.download_registry_users
       db_project.update!(last_synced_at: Time.now)
+      db_project.try(:update_repository_async)
       db_project
     end
 

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -31,6 +31,13 @@ class Version < ApplicationRecord
 
   scope :newest_first, -> { order("versions.published_at DESC") }
 
+  # saving the project can be expensive, so allow the ability to skip it for
+  # bulk operations or when the caller is aware a subsequent save will be
+  # coming anyway
+  attr_accessor :skip_save_project
+
+  skip_callback :commit, :after, :save_project, if: :skip_save_project
+
   def save_project
     project.try(:forced_save)
     project.try(:update_repository_async)


### PR DESCRIPTION
Saving a project can be expensive, because of the [set_dependents_count callback](https://github.com/librariesio/libraries.io/blob/90c862489207925e5f9b713d1cb340e806740241/app/models/project.rb#L317-L317). We can call this less often by not saving the project on every upsert of a version.