### PR TITLE
Perf: tree

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -242,14 +242,17 @@ class ApplicationController < ActionController::Base
   end
 
   def load_tree_resolver
-    @date = Date.parse(params[:date]) rescue Date.current
+    @date = Date.parse(params[:date]) rescue nil
     number = params[:number].presence
 
-    if number
-      @version = @project.versions.find_by_number(number)
-    else
-      @version = @project.versions.where('versions.published_at <= ?', @date).select(&:stable?).sort.first
-    end
+    @version =
+      if number
+        @project.versions.find_by_number(number)
+      elsif @date.present?
+        @project.versions.where('versions.published_at <= ?', @date).select(&:stable?).sort.first
+      else
+        @project.versions.select(&:stable?).sort.first
+      end
     raise ActiveRecord::RecordNotFound if @version.nil?
 
     @kind = params[:kind] || 'runtime'

--- a/app/views/tree/show.html.erb
+++ b/app/views/tree/show.html.erb
@@ -4,7 +4,7 @@
   <%= @kind if @kind != 'runtime' %>
   Dependency Tree for <%= link_to "#{@project} #{@version}", version_path(@version.to_param) %> on <%= link_to @project.platform, platform_path(@project.platform) %>
 </h1>
-<% if @date != Date.today %>
+<% if @date != nil %>
 <p>
   <small>
       As if it was resolved on <%= @date.to_formatted_s(:long_ordinal)  %>


### PR DESCRIPTION
If a date is present, [this code](https://github.com/librariesio/libraries.io/blob/02626e29606d48c8fe5e01471997ff9dcc833204/app/models/concerns/dependency_checks.rb#L35-L37) won't use the preloaded versions, instead it performs another sql query because we're adding a `.where()` clause to the preloaded versions. This happens many times over the course of building a tree.

`date` is frequently nil coming in from the API, so let's keep that nil value so we can leverage the included versions. For my sample package, this reduces the tree computation to 51 seconds, instead of crashing the pod with OOM in 2m14s. (I think we can do better, but this is a step in the right direction).