### PR TITLE
Require an internal api key for the search endpoint

### DIFF
--- a/app/controllers/api/search_controller.rb
+++ b/app/controllers/api/search_controller.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 class Api::SearchController < Api::ApplicationController
+  # this is expensive, so let's restrict to internal api keys to avoid breaking hte site
+  before_action :require_internal_api_key
+
   def index
+    raise ActionController::BadRequest unless internal_api_key?
+
     @search = paginate search_projects(params[:q])
     @projects = @search.records.includes(:repository, :versions)
 


### PR DESCRIPTION
We're falling over due to excessive requests to this so let's block that for the moment
