### PR TITLE
Require api key on search endpoint

### DIFF
--- a/app/controllers/api/search_controller.rb
+++ b/app/controllers/api/search_controller.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
+
 class Api::SearchController < Api::ApplicationController
-  # this is expensive, so let's restrict to internal api keys to avoid breaking the site
-  before_action :require_internal_api_key
+  before_action :require_api_key
 
   def index
-    raise ActionController::BadRequest unless internal_api_key?
-
     @search = paginate search_projects(params[:q])
     @projects = @search.records.includes(:repository, :versions)
 

--- a/spec/requests/api/search_spec.rb
+++ b/spec/requests/api/search_spec.rb
@@ -14,11 +14,7 @@ describe "API::SearchController" do
       end
     end
 
-    context "with internal api key" do
-      before :each do
-        user.current_api_key.update_attribute(:is_internal, true)
-      end
-
+    context "with valid api key" do
       it "renders successfully" do
         get "/api/search?api_key=#{user.api_key}"
 

--- a/spec/requests/api/search_spec.rb
+++ b/spec/requests/api/search_spec.rb
@@ -6,13 +6,9 @@ describe "API::SearchController" do
   describe "GET /api/search", type: :request do
     let!(:user) { create(:user) }
 
-    context "with normal api key" do
-      before :each do
-        user.current_api_key.update_attribute(:is_internal, false)
-      end
-
-      it "errors if api_key is not internal" do
-        get "/api/search?api_key=#{user.api_key}"
+    context "with missing api key" do
+      it "returns an error" do
+        get "/api/search"
 
         expect(response).to have_http_status(:forbidden)
       end


### PR DESCRIPTION
- the project search endpoint was previously able to be queried without an API key, which is likely too permissive
- marking it as internal-only seems too restrictive since this is a publicly documented endpoint
- this aims to find a middle ground, ensuring users can still reach the endpoint, while keeping away unregistered usage

Opening this in hopes of providing an option for legitimate usage of the project search endpoint. With bad keys blocked and anonymous keys throttled in #2975, I would think that would catch most API misuse, and rate limits (at the individual or default level) could then be adjusted as needed.