### PR TITLE
Respond with forbidden when invalid api key

### DIFF
--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -1,10 +1,18 @@
 # frozen_string_literal: true
+
+class Rack::Attack::Request < ::Rack::Request
+  def valid_key
+    return unless params["api_key"].present?
+
+    @valid_key ||= ApiKey.active.find_by_access_token(params["api_key"])
+  end
+end
+
+Rack::Attack.blocklist("invalid key") { |req| !req.valid_key }
+
 limit_proc = proc do |req|
-  if req.params['api_key'].present?
-    key = ApiKey.active.find_by_access_token(req.params['api_key'])
-    # an invalid key should get rate limited to zero so that those
-    # requests aren't allowed
-    key ? key.rate_limit : 0
+  if req.valid_key
+    req.valid_key.rate_limit
   else
     10 # req/min for anonymous users
   end

--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -2,16 +2,16 @@
 
 class Rack::Attack::Request < ::Rack::Request
   def valid_key
-    return unless params["api_key"].present?
-
     @valid_key ||= ApiKey.active.find_by_access_token(params["api_key"])
   end
 end
 
-Rack::Attack.blocklist("invalid key") { |req| !req.valid_key }
+Rack::Attack.blocklist("invalid api key") do |req|
+  !req.valid_key if req.params["api_key"].present?
+end
 
 limit_proc = proc do |req|
-  if req.valid_key
+  if req.params["api_key"].present?
     req.valid_key.rate_limit
   else
     10 # req/min for anonymous users

--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -2,7 +2,9 @@
 
 class Rack::Attack::Request < ::Rack::Request
   def valid_key
-    @valid_key ||= ApiKey.active.find_by_access_token(params["api_key"])
+    return @valid_key if defined? @valid_key
+
+    @valid_key = ApiKey.active.find_by_access_token(params["api_key"])
   end
 end
 

--- a/spec/requests/api/search_spec.rb
+++ b/spec/requests/api/search_spec.rb
@@ -7,8 +7,16 @@ describe "API::SearchController" do
     let!(:user) { create(:user) }
 
     context "with missing api key" do
-      it "returns an error" do
+      it "returns forbidden" do
         get "/api/search"
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "with an invalid api key" do
+      it "returns forbidden" do
+        get "/api/search?api_key=abc123"
 
         expect(response).to have_http_status(:forbidden)
       end


### PR DESCRIPTION
- missing or invalid API keys were being handled with Rack::Attack's
  "throttle" method, which automatically returns "429 Too many requests"
- this adds a helper method to check the validity of the API key and use
  a blocklist or throttle as needed

## Why
- recent work to stop API abuse throttles requests with invalid API keys to zero
- this is somewhat confusing, as someone who mistakenly enters their API key incorrectly will get a "too many requests" error message
- a "forbidden" response body would be more clear and semantically correct

## How
- use [Rack::Attack's blocklist method](https://github.com/rack/rack-attack#blocklistname-block) for requests with invalid API keys, which [returns "forbidden" by default](https://github.com/rack/rack-attack#customizing-responses)
- add a memoized [request helper](https://github.com/rack/rack-attack/blob/main/docs/advanced_configuration.md#rackattackrequest-helpers) to allow us to check the validity of the API key once per request