### PR TITLE
Perf: project maintained scope

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -103,7 +103,7 @@ class Project < ApplicationRecord
   scope :most_dependent_repos, -> { with_dependent_repos.order(Arel.sql("dependent_repos_count DESC")) }
 
   scope :visible, -> { where('projects."status" != ? OR projects."status" IS NULL', "Hidden") }
-  scope :maintained, -> { where('projects."status" not in (?) OR projects."status" IS NULL', %w[Deprecated Removed Unmaintained Hidden]) }
+  scope :maintained, -> { where('projects."status" in (?) OR projects."status" IS NULL', ["Active", "Help Wanted"]) }
   scope :deprecated, -> { where('projects."status" = ?', "Deprecated") }
   scope :not_removed, -> { where('projects."status" not in (?) OR projects."status" IS NULL', %w[Removed Hidden]) }
   scope :removed, -> { where('projects."status" = ?', "Removed") }

--- a/db/migrate/20220908024404_add_project_maintained_index.rb
+++ b/db/migrate/20220908024404_add_project_maintained_index.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddProjectMaintainedIndex < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :projects,
+              %i[platform language id],
+              name: "index_projects_on_maintained",
+              where: "status in ('Active','Help Wanted') or status is null",
+              algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_24_133104) do
+ActiveRecord::Schema.define(version: 2022_09_08_024404) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -175,6 +175,7 @@ ActiveRecord::Schema.define(version: 2021_03_24_133104) do
     t.index ["keywords_array"], name: "index_projects_on_keywords_array", using: :gin
     t.index ["normalized_licenses"], name: "index_projects_on_normalized_licenses", using: :gin
     t.index ["platform", "dependents_count"], name: "index_projects_on_platform_and_dependents_count"
+    t.index ["platform", "language", "id"], name: "index_projects_on_maintained", where: "(((status)::text = ANY ((ARRAY['Active'::character varying, 'Help Wanted'::character varying])::text[])) OR (status IS NULL))"
     t.index ["platform", "name"], name: "index_projects_on_platform_and_name", unique: true
     t.index ["repository_id"], name: "index_projects_on_repository_id"
     t.index ["status"], name: "index_projects_on_status"


### PR DESCRIPTION
The Project#maintained scope is a bit of a hot path, and is not using indexed queries. These queries are often 3+ seconds. This change will use an index only scan for many of the queries, bringing them down to under 1 second.

* Change the `Project#maintained` scope to use inclusive matching rather than exclusive matching
* Add an index to support the Project#maintained scope. Unfortunately since this includes querying on NULL, this index is a bit tricky. It would be better if Project#status disallowed null and used a proper value for the initial state, but that would cause other things to break. I'm going for the lowest impact performance change here.