### PR TITLE
Perf: tree

### DIFF
--- a/app/controllers/tree_controller.rb
+++ b/app/controllers/tree_controller.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
+
 class TreeController < ApplicationController
   before_action :find_project
   before_action :load_tree_resolver
 
   def show
-    if @tree_resolver.cached?
+    # if cache is disabled (such as in dev), just do this synchronously
+    if cache_disabled? || @tree_resolver.cached?
       @tree = @tree_resolver.tree
       @project_names = @tree_resolver.project_names
       @license_names = @tree_resolver.license_names
@@ -17,5 +19,11 @@ class TreeController < ApplicationController
         @tree_resolver.enqueue_tree_resolution
       end
     end
+  end
+
+  private
+
+  def cache_disabled?
+    Rails.application.config.cache_store == :null_store
   end
 end

--- a/app/models/tree_resolver.rb
+++ b/app/models/tree_resolver.rb
@@ -81,7 +81,7 @@ class TreeResolver
   end
 
   def cache_key
-    ["tree", @version, @kind, @date].compact
+    ["tree", @version, @kind, @date, "v2"].compact
   end
 
   def append_project_name(dependency)

--- a/app/models/tree_resolver.rb
+++ b/app/models/tree_resolver.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class TreeResolver
   MAX_TREE_DEPTH = 15
 
@@ -46,12 +47,14 @@ class TreeResolver
 
   def generate_dependency_tree(_key)
     {
-      tree: load_dependencies_for(@version, nil, @kind, 0),
+      tree: load_dependencies_for(@version, @version.project, @kind, 0),
       project_names: @project_names,
       license_names: @license_names,
     }
   end
 
+  # @param dependency [Project, Dependency]
+  #   This is a Project for the first node, Dependency for all other nodes
   def load_dependencies_for(version, dependency, kind, index)
     return unless version
 
@@ -67,9 +70,9 @@ class TreeResolver
     dependencies = should_fetch ? fetch_dependencies(version, kind) : []
 
     {
-      version: version,
-      requirements: dependency&.requirements,
-      dependency: dependency,
+      version: version.then { |x| { number: x[:number] } },
+      requirements: dependency&.try(:requirements),
+      dependency: dependency&.then { |x| { platform: x[:platform], project_name: x[:name], kind: x[:kind] } },
       normalized_licenses: version.project.normalized_licenses,
       dependencies: dependencies
         .map { |dep| load_dependencies_for(dep.latest_resolvable_version(@date), dep, "runtime", index + 1) }
@@ -83,7 +86,8 @@ class TreeResolver
 
   def append_project_name(dependency)
     return true unless dependency
-    @project_names.add?(dependency.project_name).present?
+
+    @project_names.add?(dependency.name).present?
   end
 
   def append_license_names(version)

--- a/app/views/tree/_dep.html.erb
+++ b/app/views/tree/_dep.html.erb
@@ -1,24 +1,22 @@
 <% version = dep[:version] %>
-<% project = version.project %>
+<% dependency = dep[:dependency] %>
 <% requirements = dep[:requirements] %>
+<% version_path_value = version_path({platform: dependency[:platform], name: dependency[:project_name], number: version[:number]}) %>
 <li>
-  <%= link_to project, version_path(version.to_param) %>
+  <%= link_to dependency[:project_name], version_path_value %>
   -
-  <%= link_to version.number, version_path(version.to_param), class: 'tip', title: 'Resolved version' %>
+  <%= link_to version[:number], version_path_value, class: 'tip', title: 'Resolved version' %>
   -
   <em class='text-muted'>
     <span class="tip" title="Specified version range"><%= requirements %></span>
     <%= '-' if requirements.present? %>
-    <%= Array.wrap(project.normalize_licenses).join(', ') %>
+    <%= Array.wrap(dep[:normalized_licenses]).join(', ') %>
   </em>
-  <% if dep[:dependency] %>
-    <%#= render 'dependencies/flags', dependency: dep[:dependency] %>
-  <% end %>
   <% if dep[:dependencies] && dep[:dependencies].any? %>
     <ul>
       <% dep[:dependencies].each do |dependency| %>
         <li>
-          <% if dependency.is_a?(Hash) && dependency[:version].is_a?(Version) %>
+          <% if dependency.is_a?(Hash) %>
             <%= render 'dep', dep: dependency %>
           <% end %>
         </li>

--- a/app/views/tree/_dep.html.erb
+++ b/app/views/tree/_dep.html.erb
@@ -1,11 +1,16 @@
 <% version = dep[:version] %>
 <% dependency = dep[:dependency] %>
 <% requirements = dep[:requirements] %>
-<% version_path_value = version_path({platform: dependency[:platform], name: dependency[:project_name], number: version[:number]}) %>
 <li>
-  <%= link_to dependency[:project_name], version_path_value %>
+  <%= link_to dependency[:project_name],
+    project_path(platform: dependency[:platform], name: dependency[:project_name])
+  %>
   -
-  <%= link_to version[:number], version_path_value, class: 'tip', title: 'Resolved version' %>
+  <%= link_to version[:number],
+    version_path(platform: dependency[:platform], name: dependency[:project_name], number: version[:number]),
+    class: 'tip',
+    title: 'Resolved version'
+  %>
   -
   <em class='text-muted'>
     <span class="tip" title="Specified version range"><%= requirements %></span>


### PR DESCRIPTION
* Don't store entire models in cache, instead only store the necessary data as lightweight hashes
* Change the tree API to return only the necessary data in lightweight hashes
* Change the erb views to work with this lightweight hash
* Fix the tree controller not working with cache disabled. It's still broken in dev with cache enabled, because Rails and Sidekiq's memory caches aren't shared. But at least now it works with the default dev mode of cache disabled.