### PR TITLE
Change VersionUpdateFailure behavior to be less exceptional.

### DIFF
--- a/app/workers/package_manager_download_worker.rb
+++ b/app/workers/package_manager_download_worker.rb
@@ -67,10 +67,10 @@ class PackageManagerDownloadWorker
     project = platform.update(name, sync_version: sync_version)
 
     # Raise/log if version was requested but not found
-    if version.present? && true # !Version.exists?(project: project, number: version)
+    if version.present? && !Version.exists?(project: project, number: version)
       Rails.logger.info("[Version Update Failure] platform=#{key} name=#{name} version=#{version}")
       if requeue_count < MAX_ATTEMPTS_TO_UPDATE_FRESH_VERSION_DATA
-        PackageManagerDownloadWorker.perform_in(2.seconds, platform_name, name, version, source, requeue_count + 1)
+        PackageManagerDownloadWorker.perform_in(5.seconds, platform_name, name, version, source, requeue_count + 1)
       else
         raise VersionUpdateFailure
       end

--- a/app/workers/package_manager_download_worker.rb
+++ b/app/workers/package_manager_download_worker.rb
@@ -1,10 +1,16 @@
 # frozen_string_literal: true
 
 class PackageManagerDownloadWorker
+  include Sidekiq::Worker
+  
+  # For stale repo pages without fresh versions, we have a manual retry mechanism 
+  # below. All other errors retry 3 times. 
+  sidekiq_options queue: :critical, retry: 3
+
+  # We were unable to fetch version, even after waiting for repo caches to refresh.
   class VersionUpdateFailure < StandardError; end
 
-  include Sidekiq::Worker
-  sidekiq_options queue: :critical
+  MAX_ATTEMPTS_TO_UPDATE_FRESH_VERSION_DATA = 30
 
   PLATFORMS = {
     alcatraz: PackageManager::Alcatraz,
@@ -51,7 +57,7 @@ class PackageManagerDownloadWorker
     swiftpm: PackageManager::SwiftPM,
   }.freeze
 
-  def perform(platform_name, name, version = nil, source = "unknown")
+  def perform(platform_name, name, version = nil, source = "unknown", requeue_count = 0)
     key, platform = get_platform(platform_name)
     name = name.to_s.strip
     version = version.to_s.strip
@@ -61,9 +67,13 @@ class PackageManagerDownloadWorker
     project = platform.update(name, sync_version: sync_version)
 
     # Raise/log if version was requested but not found
-    if version.present? && !Version.exists?(project: project, number: version)
+    if version.present? && true # !Version.exists?(project: project, number: version)
       Rails.logger.info("[Version Update Failure] platform=#{key} name=#{name} version=#{version}")
-      raise VersionUpdateFailure
+      if requeue_count < MAX_ATTEMPTS_TO_UPDATE_FRESH_VERSION_DATA
+        PackageManagerDownloadWorker.perform_in(2.seconds, platform_name, name, version, source, requeue_count + 1)
+      else
+        raise VersionUpdateFailure
+      end
     end
   end
 

--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -4,7 +4,6 @@ if Rails.env.production?
   Bugsnag.configure do |config|
     config.api_key = ENV["BUGSNAG_API_KEY"]
     config.ignore_classes << ActiveRecord::RecordNotFound
-    config.ignore_classes << PackageManagerDownloadWorker::VersionUpdateFailure
 
     if File.exist?("#{Rails.root}/REVISION")
       config.app_version = File.read("#{Rails.root}/REVISION").strip

--- a/spec/workers/package_manager_download_worker_spec.rb
+++ b/spec/workers/package_manager_download_worker_spec.rb
@@ -16,10 +16,19 @@ describe PackageManagerDownloadWorker do
     expect { subject.perform("what", "isthis") }.to raise_exception(StandardError, "Platform 'what' not found")
   end
 
-  it "should raise an error if version requested didn't get created" do
+  it "should delay version requested if version didn't get created" do
+    expect(PackageManagerDownloadWorker).to receive(:perform_in).with(2.seconds, "go", "github.com/hi/ima.package", "1.2.3", "unknown", 1)
     expect(PackageManager::Go).to receive(:update).with("github.com/hi/ima.package", sync_version: "1.2.3")
     expect(Rails.logger).to receive(:info).with("[Version Update Failure] platform=go name=github.com/hi/ima.package version=1.2.3")
 
-    expect { subject.perform("go", "github.com/hi/ima.package", "1.2.3") }.to raise_exception(PackageManagerDownloadWorker::VersionUpdateFailure)
+    subject.perform("go", "github.com/hi/ima.package", "1.2.3")
+  end
+
+  it "should raise an error if version didn't get created after 30 attempts" do
+    expect(PackageManagerDownloadWorker).to_not receive(:perforperform_inm_async)
+    expect(PackageManager::Go).to receive(:update).with("github.com/hi/ima.package", sync_version: "1.2.3")
+    expect(Rails.logger).to receive(:info).with("[Version Update Failure] platform=go name=github.com/hi/ima.package version=1.2.3")
+
+    expect { subject.perform("go", "github.com/hi/ima.package", "1.2.3", nil, 21) }.to raise_exception(PackageManagerDownloadWorker::VersionUpdateFailure)
   end
 end

--- a/spec/workers/package_manager_download_worker_spec.rb
+++ b/spec/workers/package_manager_download_worker_spec.rb
@@ -25,7 +25,7 @@ describe PackageManagerDownloadWorker do
   end
 
   it "should raise an error if version didn't get created after 30 attempts" do
-    expect(PackageManagerDownloadWorker).to_not receive(:perforperform_inm_async)
+    expect(PackageManagerDownloadWorker).to_not receive(:perform_in)
     expect(PackageManager::Go).to receive(:update).with("github.com/hi/ima.package", sync_version: "1.2.3")
     expect(Rails.logger).to receive(:info).with("[Version Update Failure] platform=go name=github.com/hi/ima.package version=1.2.3")
 

--- a/spec/workers/package_manager_download_worker_spec.rb
+++ b/spec/workers/package_manager_download_worker_spec.rb
@@ -17,7 +17,7 @@ describe PackageManagerDownloadWorker do
   end
 
   it "should delay version requested if version didn't get created" do
-    expect(PackageManagerDownloadWorker).to receive(:perform_in).with(2.seconds, "go", "github.com/hi/ima.package", "1.2.3", "unknown", 1)
+    expect(PackageManagerDownloadWorker).to receive(:perform_in).with(5.seconds, "go", "github.com/hi/ima.package", "1.2.3", "unknown", 1)
     expect(PackageManager::Go).to receive(:update).with("github.com/hi/ima.package", sync_version: "1.2.3")
     expect(Rails.logger).to receive(:info).with("[Version Update Failure] platform=go name=github.com/hi/ima.package version=1.2.3")
 

--- a/spec/workers/package_manager_download_worker_spec.rb
+++ b/spec/workers/package_manager_download_worker_spec.rb
@@ -29,6 +29,6 @@ describe PackageManagerDownloadWorker do
     expect(PackageManager::Go).to receive(:update).with("github.com/hi/ima.package", sync_version: "1.2.3")
     expect(Rails.logger).to receive(:info).with("[Version Update Failure] platform=go name=github.com/hi/ima.package version=1.2.3")
 
-    expect { subject.perform("go", "github.com/hi/ima.package", "1.2.3", nil, 21) }.to raise_exception(PackageManagerDownloadWorker::VersionUpdateFailure)
+    expect { subject.perform("go", "github.com/hi/ima.package", "1.2.3", nil, 31) }.to raise_exception(PackageManagerDownloadWorker::VersionUpdateFailure)
   end
 end


### PR DESCRIPTION
Currently, when we get a newly published version and sync a `PackageManagerDownloadWorker` job, we'll raise a `VersionUpdateFailure` (and ignore that error in bugsnag) if we can't find the version. This is most likely because the package repo has a stale cache, so we let the job try again and it is usually a long enough delay for the new version to exist on the repo.

There are some problems with this:
* since we know this is because of repo staleness, this doesn't really count as "exceptional" enough to raise an error
* this leads us to thousands of regular jobs in the "retries" queue normally, which conceals real errors.
* we're also logging the backtraces and passing around the backtraces for these thousands of errors, which is a lot of strings.
* regarding ☝🏻 , I've noticed the sidekiq workers that OOM have a ton of these errors in their logs, so they might be relieved to stop handling this error all the time.

I propose this strategy instead:
* if `PackageManagerDownloadWorker` can't find the version, *requeue* the job in 2 seconds, so that it goes into the "scheduled" queue 
* if, after 30 attempts (at least 60 seconds later), we still can't fetch the version, assume something else is wrong and raise VersionUpdateFailure
* allow the VersionUpdateFailure to surface in bugsnag again so we can be aware of things like repo outages, etc.
