### PR TITLE
Temporarily silence VerisonUpdateFailure again

### DIFF
--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -4,6 +4,8 @@ if Rails.env.production?
   Bugsnag.configure do |config|
     config.api_key = ENV["BUGSNAG_API_KEY"]
     config.ignore_classes << ActiveRecord::RecordNotFound
+    # Temporarily silence these until we can squash the majority of them, and then remove later.
+    config.ignore_classes << PackageManagerDownloadWorker::VersionUpdateFailure
 
     if File.exist?("#{Rails.root}/REVISION")
       config.app_version = File.read("#{Rails.root}/REVISION").strip


### PR DESCRIPTION
Followup to https://github.com/librariesio/libraries.io/pull/2997

Now that we're sending real VersionUpdateFailure exceptions to Bugsnag (instead of transient ones), the amount is much higher than expected. Since we have the error on hand now, silence them in Bugsnag until we can fix.