### PR TITLE
Decrease VersionUpdateFailure attempts to 15 and skip them for go.

### DIFF
--- a/app/workers/package_manager_download_worker.rb
+++ b/app/workers/package_manager_download_worker.rb
@@ -71,7 +71,7 @@ class PackageManagerDownloadWorker
       Rails.logger.info("[Version Update Failure] platform=#{key} name=#{name} version=#{version}")
       if requeue_count < MAX_ATTEMPTS_TO_UPDATE_FRESH_VERSION_DATA
         PackageManagerDownloadWorker.perform_in(5.seconds, platform_name, name, version, source, requeue_count + 1)
-      elsif platform != "go"
+      elsif platform != PackageManager::Go
         # It's common for go modules, e.g. forks, to not exist on pkg.go.dev, so wait until someone
         # manually requests it from pkg.go.dev before we index it, and only raise this error for non-go packages.
         raise VersionUpdateFailure

--- a/app/workers/package_manager_download_worker.rb
+++ b/app/workers/package_manager_download_worker.rb
@@ -10,7 +10,7 @@ class PackageManagerDownloadWorker
   # We were unable to fetch version, even after waiting for repo caches to refresh.
   class VersionUpdateFailure < StandardError; end
 
-  MAX_ATTEMPTS_TO_UPDATE_FRESH_VERSION_DATA = 30
+  MAX_ATTEMPTS_TO_UPDATE_FRESH_VERSION_DATA = 15
 
   PLATFORMS = {
     alcatraz: PackageManager::Alcatraz,
@@ -71,7 +71,9 @@ class PackageManagerDownloadWorker
       Rails.logger.info("[Version Update Failure] platform=#{key} name=#{name} version=#{version}")
       if requeue_count < MAX_ATTEMPTS_TO_UPDATE_FRESH_VERSION_DATA
         PackageManagerDownloadWorker.perform_in(5.seconds, platform_name, name, version, source, requeue_count + 1)
-      else
+      elsif platform != "go"
+        # It's common for go modules, e.g. forks, to not exist on pkg.go.dev, so wait until someone
+        # manually requests it from pkg.go.dev before we index it, and only raise this error for non-go packages.
         raise VersionUpdateFailure
       end
     end

--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -4,8 +4,8 @@ if Rails.env.production?
   Bugsnag.configure do |config|
     config.api_key = ENV["BUGSNAG_API_KEY"]
     config.ignore_classes << ActiveRecord::RecordNotFound
-    # Temporarily silence these until we can squash the majority of them, and then remove later.
-    config.ignore_classes << PackageManagerDownloadWorker::VersionUpdateFailure
+    # Temprarily uncomment this is we get a huge spike of these errors and need to investigate:
+    # config.ignore_classes << PackageManagerDownloadWorker::VersionUpdateFailure
 
     if File.exist?("#{Rails.root}/REVISION")
       config.app_version = File.read("#{Rails.root}/REVISION").strip

--- a/spec/workers/package_manager_download_worker_spec.rb
+++ b/spec/workers/package_manager_download_worker_spec.rb
@@ -29,6 +29,6 @@ describe PackageManagerDownloadWorker do
     expect(PackageManager::Go).to receive(:update).with("github.com/hi/ima.package", sync_version: "1.2.3")
     expect(Rails.logger).to receive(:info).with("[Version Update Failure] platform=go name=github.com/hi/ima.package version=1.2.3")
 
-    expect { subject.perform("go", "github.com/hi/ima.package", "1.2.3", nil, 31) }.to raise_exception(PackageManagerDownloadWorker::VersionUpdateFailure)
+    expect { subject.perform("go", "github.com/hi/ima.package", "1.2.3", nil, 16) }.to raise_exception(PackageManagerDownloadWorker::VersionUpdateFailure)
   end
 end

--- a/spec/workers/package_manager_download_worker_spec.rb
+++ b/spec/workers/package_manager_download_worker_spec.rb
@@ -24,11 +24,19 @@ describe PackageManagerDownloadWorker do
     subject.perform("go", "github.com/hi/ima.package", "1.2.3")
   end
 
-  it "should raise an error if version didn't get created after 30 attempts" do
+  it "should raise an error if version didn't get created after 15 attempts" do
+    expect(PackageManagerDownloadWorker).to_not receive(:perform_in)
+    expect(PackageManager::NPM).to receive(:update).with("a-package", sync_version: "1.2.3")
+    expect(Rails.logger).to receive(:info).with("[Version Update Failure] platform=npm name=a-package version=1.2.3")
+
+    expect { subject.perform("npm", "a-package", "1.2.3", nil, 16) }.to raise_exception(PackageManagerDownloadWorker::VersionUpdateFailure)
+  end
+
+  it "should not raise an error if version didn't get created after 15 attempts and is golang" do
     expect(PackageManagerDownloadWorker).to_not receive(:perform_in)
     expect(PackageManager::Go).to receive(:update).with("github.com/hi/ima.package", sync_version: "1.2.3")
     expect(Rails.logger).to receive(:info).with("[Version Update Failure] platform=go name=github.com/hi/ima.package version=1.2.3")
 
-    expect { subject.perform("go", "github.com/hi/ima.package", "1.2.3", nil, 16) }.to raise_exception(PackageManagerDownloadWorker::VersionUpdateFailure)
+    expect { subject.perform("go", "github.com/hi/ima.package", "1.2.3", nil, 16) }.to_not raise_exception(PackageManagerDownloadWorker::VersionUpdateFailure)
   end
 end


### PR DESCRIPTION
Sometimes go modules can't be found on pkg.go.dev, e.g. https://pkg.go.dev/github.com/oraichain/wasmd . It could be because they're forks or some other reason, but the rules around pkg.go.dev indexing are elusive and changing. 

If we come across a go version update for this case, silently ignore them. If someone notices a missing package, they can manually click "Request package" on pkg.go.dev and it'll possibly fetch the package, and then we can index it on Libraries too.