### PR TITLE
Use Addressable::URI.escape instead of URI.escape

### DIFF
--- a/app/models/repository_host/bitbucket.rb
+++ b/app/models/repository_host/bitbucket.rb
@@ -23,7 +23,7 @@ module RepositoryHost
 
     def blob_url(sha = nil)
       sha ||= repository.default_branch
-      "#{url}/src/#{URI.escape(sha)}/"
+      "#{url}/src/#{Addressable::URI.escape(sha)}/"
     end
 
     def commits_url(author = nil)
@@ -41,7 +41,7 @@ module RepositoryHost
     end
 
     def get_file_contents(path, token = nil)
-      file = api_client(token).repos.sources.list(repository.owner_name, repository.project_name, URI.escape(repository.default_branch), URI.escape(path))
+      file = api_client(token).repos.sources.list(repository.owner_name, repository.project_name, Addressable::URI.escape(repository.default_branch), Addressable::URI.escape(path))
       {
         sha: file.node,
         content: file.data
@@ -89,7 +89,7 @@ module RepositoryHost
     end
 
     def download_readme(token = nil)
-      files = api_client(token).repos.sources.list(repository.owner_name, repository.project_name, URI.escape(repository.default_branch || 'master'), '/')
+      files = api_client(token).repos.sources.list(repository.owner_name, repository.project_name, Addressable::URI.escape(repository.default_branch || 'master'), '/')
       paths =  files.files.map(&:path)
       readme_path = paths.select{|path| path.match(/^readme/i) }.sort{|path| Readme.supported_format?(path) ? 0 : 1 }.first
       return if readme_path.nil?

--- a/app/models/repository_owner/bitbucket.rb
+++ b/app/models/repository_owner/bitbucket.rb
@@ -11,10 +11,10 @@ module RepositoryOwner
 
     def self.fetch_user(id_or_login)
       begin
-        api_client.get_request "/2.0/users/#{URI.escape(id_or_login)}"
+        api_client.get_request "/2.0/users/#{Addressable::URI.escape(id_or_login)}"
       rescue BitBucket::Error::NotFound => error
         if error.message.index('is a team account')
-          api_client.get_request "/2.0/teams/#{URI.escape(id_or_login)}"
+          api_client.get_request "/2.0/teams/#{Addressable::URI.escape(id_or_login)}"
         end
       end
     rescue *RepositoryHost::Bitbucket::IGNORABLE_EXCEPTIONS
@@ -22,7 +22,7 @@ module RepositoryOwner
     end
 
     def self.fetch_org(id_or_login)
-      api_client.get_request "/2.0/teams/#{URI.escape(id_or_login)}"
+      api_client.get_request "/2.0/teams/#{Addressable::URI.escape(id_or_login)}"
     rescue *RepositoryHost::Bitbucket::IGNORABLE_EXCEPTIONS
       nil
     end

--- a/app/views/admin/projects/index.html.erb
+++ b/app/views/admin/projects/index.html.erb
@@ -10,7 +10,7 @@
         </div>
         <div class="col-md-4">
           <% if project.description.present? %>
-            <%= link_to "Google", "https://www.google.com/search?q="+URI.escape('site:github.com "' + project.description.to_s + '"'), class: 'btn btn-success', target: :blank %>
+            <%= link_to "Google", "https://www.google.com/search?q="+Addressable::URI.escape('site:github.com "' + project.description.to_s + '"'), class: 'btn btn-success', target: :blank %>
           <% end %>
           <%= link_to 'Edit in Admin', admin_project_path(project.id), class: 'btn btn-primary' %>
         </div>


### PR DESCRIPTION
Use Addressable::URI.escape instead of URI.escape to silence warnings:

`...  warning: URI.unescape is obsolete`
