### PR TITLE
Update bugsnag to silence a deprecation warning fixed in 6.13.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
       sassc (>= 2.0.0)
     brakeman (4.5.1)
     brotli (0.2.3)
-    bugsnag (6.11.1)
+    bugsnag (6.24.2)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)


### PR DESCRIPTION
`.../bugsnag-6.11.1/lib/bugsnag/cleaner.rb:65: warning: Using the last argument as keyword parameters is deprecated`

These were fixed in [bugsnag 6.13.0](https://github.com/bugsnag/bugsnag-ruby/blob/master/CHANGELOG.md#6130-30-jan-2020).
