### PR TITLE
Add covering index on repositories on (rank, stargazers_count, id)

### DIFF
--- a/db/migrate/20220930184941_add_covering_index_on_repository.rb
+++ b/db/migrate/20220930184941_add_covering_index_on_repository.rb
@@ -1,0 +1,7 @@
+class AddCoveringIndexOnRepository < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :repositories, [:rank, :stargazers_count, :id], algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_08_024404) do
+ActiveRecord::Schema.define(version: 2022_09_30_184941) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -258,6 +258,7 @@ ActiveRecord::Schema.define(version: 2022_09_08_024404) do
     t.index ["fork"], name: "index_repositories_on_fork"
     t.index ["host_type", "uuid"], name: "index_repositories_on_host_type_and_uuid", unique: true
     t.index ["private"], name: "index_repositories_on_private"
+    t.index ["rank", "stargazers_count", "id"], name: "index_repositories_on_rank_and_stargazers_count_and_id"
     t.index ["repository_organisation_id"], name: "index_repositories_on_repository_organisation_id"
     t.index ["repository_user_id"], name: "index_repositories_on_repository_user_id"
     t.index ["source_name"], name: "index_repositories_on_source_name"


### PR DESCRIPTION
The `Project#dependent_repositories` association can be an expensive query because it has a default group/order by, in which the sorted columns are not indexed. This adds an index on (rank, stargazers_count, id), which are all int columns. The query is:

Base query:
``` sql
SELECT "repositories".* 
FROM "repositories" 
INNER JOIN "repository_dependencies" ON "repositories"."id" = "repository_dependencies"."repository_id" 
WHERE "repository_dependencies"."project_id" = 1803769 
GROUP BY repositories.id 
ORDER BY repositories.rank DESC NULLS LAST, repositories.stargazers_count DESC
```

(alternatively, we could remove the `order` from this association)