### PR TITLE
Removed logging check that was causing dependency fetching to fail

### DIFF
--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -127,7 +127,7 @@ module PackageManager
       api_response = get("https://pypi.org/pypi/#{name}/#{version}/json")
       deps = api_response.dig("info", "requires_dist")
       source_info = api_response.dig("releases", version)
-      Rails.logger.warn("Pypi sdist (no deps): #{name}") unless source_info.any? { |rel| rel["packagetype"] == "bdist_wheel" }
+      #Rails.logger.warn("Pypi sdist (no deps): #{name}") unless source_info.any? { |rel| rel["packagetype"] == "bdist_wheel" }
 
       deps.map do |dep|
         name, version = dep.split


### PR DESCRIPTION
Thanks taking the time to contribute. This template should help guide you through the process of creating a pull request for review. Please erase any part of this template that is not relevant to your pull request:


- [x] Have you followed the guidelines for [contributors](http://docs.libraries.io/contributorshandbook)?
- [x] Have you checked to ensure there aren't other open pull requests on the repository for a similar change?
- [x] Is there a corresponding ticket for your pull request?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run the project with your changes locally?

Quick fix for #3008 . source_info is nil since Pypi removed `$["releases"]` from the JSON API response. Commenting out this line stops the error from being thrown and allows dependencies to be grabbed for projects in my local env. 

Unsure when the Pypi API was actually changed. Recent Pypi packages may need to be re-evaluated to ensure dependency information in libraries,io is correct.
