### PR TITLE
Fix type error in Github#download_contributions

### DIFF
--- a/app/models/repository_host/github.rb
+++ b/app/models/repository_host/github.rb
@@ -108,7 +108,7 @@ module RepositoryHost
       platform = repository.projects.first.try(:platform)
       gh_contributions.each do |c|
         next unless c['id']
-        cont = existing_contributions.find{|cnt| cnt.repository_user.try(:uuid) == c.id }
+        cont = existing_contributions.find{|cnt| cnt.repository_user.try(:uuid) == c.id.to_s }
         unless cont
           user = RepositoryUser.create_from_host('GitHub', c)
           cont = repository.contributions.find_or_create_by(repository_user: user)


### PR DESCRIPTION
A big chunk of time in `Repository#update_all_info` comes from its call to `RepositoryHost::Github#download_contributions`, which downloads all contributors and updates their contribution count. 

This fixes a type issue in the find-or-insert, which should save 3 queries per contributor that is already in the db: the "id" that comes back from GH is an integer, whereas RepositoryUser#uuid is a string.

Example for a repo that only has lookups and no updates:

### Before

> Benchmark.ms { Repository.find_by_full_name('golang/go').download_contributions(AuthToken.token)}
=> 2250.269000418484

### After

> Benchmark.ms { Repository.find_by_full_name('golang/go').download_contributions(AuthToken.token)}
=> 4314.122000243515

(hopefully this reduces memory usage a ton too)