### PR TITLE
Make repo maintainence workers unique by repo

### DIFF
--- a/app/workers/repository_maintenance_stat_worker.rb
+++ b/app/workers/repository_maintenance_stat_worker.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class RepositoryMaintenanceStatWorker
     include Sidekiq::Worker
-    sidekiq_options queue: :repo_maintenance_stat, retry: 3
+    sidekiq_options queue: :repo_maintenance_stat, retry: 3, unique: :until_executed
 
     def perform(repo_id)
         Repository.find(repo_id).gather_maintenance_stats


### PR DESCRIPTION
This should avoid a deadlock case that we've happened to hit
