### PR TITLE
Add rake task to remove repository_maintenance_stats duplicates to prepare for unique index creation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,7 +109,7 @@ end
 
 group :test do
   gem "database_cleaner"
-  gem "factory_bot_rails"
+  gem "factory_bot_rails", "~>5.2.0"
   gem "faker"
   gem "json_spec"
   gem "poltergeist", "1.17.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,10 +185,10 @@ GEM
       ffi (>= 1.15.0)
     excon (0.72.0)
     execjs (2.7.0)
-    factory_bot (5.0.2)
+    factory_bot (5.2.0)
       activesupport (>= 4.2.0)
-    factory_bot_rails (5.0.2)
-      factory_bot (~> 5.0.2)
+    factory_bot_rails (5.2.0)
+      factory_bot (~> 5.2.0)
       railties (>= 4.2.0)
     faker (1.9.3)
       i18n (>= 0.7)
@@ -629,7 +629,7 @@ DEPENDENCIES
   elasticsearch-model (~> 5)
   elasticsearch-rails (~> 5)
   escape_utils
-  factory_bot_rails
+  factory_bot_rails (~> 5.2.0)
   faker
   faraday-http-cache
   faraday_middleware

--- a/lib/tasks/one_off.rake
+++ b/lib/tasks/one_off.rake
@@ -53,16 +53,6 @@ namespace :one_off do
   task dedupe_repository_maintenance_stats: :environment do
     sql = Arel.sql(
       <<-SQL
-      DELETE FROM repository_maintenance_stats as A
-      USING repository_maintenance_stats as B
-      WHERE A.updated_at < B.updated_at
-      AND A.repository_id = B.repository_id
-      AND A.category = B.category
-    SQL
-    )
-
-    sql2 = Arel.sql(
-      <<-SQL
         DELETE FROM repository_maintenance_stats
         WHERE id IN
         (
@@ -76,6 +66,6 @@ namespace :one_off do
       SQL
     )
 
-    ActiveRecord::Base.connection.execute(sql2)
+    ActiveRecord::Base.connection.execute(sql)
   end
 end

--- a/lib/tasks/one_off.rake
+++ b/lib/tasks/one_off.rake
@@ -26,25 +26,24 @@ namespace :one_off do
 
   desc "backfill missing clojars packages with a slash, and remove packages with a dot"
   task cleanup_clojar_projects: :environment do
-    Project
-      .where(platform: "Clojars")
-      .where("name LIKE '%:%'")
-      .find_each do |p|
-      good_name = p.name.gsub(/:/, "/")
-      bad_name = p.name
-      puts "Updating #{good_name}, deleting #{bad_name}"
-      PackageManager::Clojars.update(good_name)
-      p.destroy!
+    Project.
+      where(platform: "Clojars").
+      where("name LIKE '%:%'").
+      find_each do |p|
+        good_name, bad_name = p.name.gsub(/:/, '/'), p.name
+        puts "Updating #{good_name}, deleting #{bad_name}"
+        PackageManager::Clojars.update(good_name)
+        p.destroy!
     end
   end
 
   desc "delete all hidden maven projects missing a group id"
   task delete_groupless_maven_projects: :environment do
-    Project
-      .where(platform: "Maven")
-      .where(status: "Hidden")
-      .where("name NOT LIKE '%:%'")
-      .find_each do |p|
+    Project.
+      where(platform: "Maven").
+      where(status: "Hidden").
+      where("name NOT LIKE '%:%'").
+      find_each do |p|
         puts "Deleting Maven project #{p.name} (#{p.id})"
         p.destroy!
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,8 @@ require "spec_helper"
 require "rspec/rails"
 require "webmock/rspec"
 
+Rails.application.load_tasks
+
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 
 ActiveRecord::Migration.maintain_test_schema!

--- a/spec/tasks/one_off_spec.rb
+++ b/spec/tasks/one_off_spec.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require "rake"
 
 describe "one_off rake tasks" do
-  Rails.application.load_tasks
-
   describe "dedupe_repository_maintenance_stats" do
     let(:repository) { create(:repository) }
 

--- a/spec/tasks/one_off_spec.rb
+++ b/spec/tasks/one_off_spec.rb
@@ -16,13 +16,15 @@ describe "one_off rake tasks" do
       create_list(:repository_maintenance_stat, 2, category: "bar", repository: repository) do |rms, i|
         rms.update!(updated_at: (i+1).days.ago)
       end
+
+      create(:repository_maintenance_stat, category: "baz", repository: repository, updated_at: 1.days.ago)
     end
 
     it "dedupes correctly" do
       expect do
         Rake::Task["one_off:dedupe_repository_maintenance_stats"].execute
       end.to change(RepositoryMaintenanceStat, :count)
-               .from(5).to(2)
+               .from(6).to(3)
 
       expect(RepositoryMaintenanceStat.all).to all(have_attributes(updated_at: 1.days.ago))
     end

--- a/spec/tasks/one_off_spec.rb
+++ b/spec/tasks/one_off_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "rake"
+
+describe "one_off rake tasks" do
+  Rails.application.load_tasks
+
+  describe "dedupe_repository_maintenance_stats" do
+    let(:repository) { create(:repository) }
+
+    before do
+      travel_to Time.now
+
+      create_list(:repository_maintenance_stat, 3, category: "foo", repository: repository) do |rms, i|
+        rms.update!(updated_at: (i+1).days.ago)
+      end
+
+      create_list(:repository_maintenance_stat, 2, category: "bar", repository: repository) do |rms, i|
+        rms.update!(updated_at: (i+1).days.ago)
+      end
+    end
+
+    it "dedupes correctly" do
+      expect do
+        Rake::Task["one_off:dedupe_repository_maintenance_stats"].execute
+      end.to change(RepositoryMaintenanceStat, :count)
+               .from(5).to(2)
+
+      expect(RepositoryMaintenanceStat.all).to all(have_attributes(updated_at: 1.days.ago))
+    end
+  end
+end

--- a/spec/tasks/version_scheme_counter_spec.rb
+++ b/spec/tasks/version_scheme_counter_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "rails_helper"
-require "rake"
 
 describe "version:scheme_counter" do
   describe "Scheme detection" do
@@ -57,8 +56,6 @@ describe "version:scheme_counter" do
   end
 
   describe "Rake task" do
-    Rails.application.load_tasks
-
     def create_versions(versions, project)
       versions.each do |version|
         create(:version, project: project, number: version)


### PR DESCRIPTION
There are currently 1,301,892 repository_maintenace_stats so I think it should be okay to run this query on that many records. Both queries were adapted from the queries [at this stackoverflow post](https://stackoverflow.com/questions/53722174/most-efficient-way-to-remove-duplicates-postgres).

The first query is from the OP and the second query is from the accepted answer. I like the first query better since it is really succinct and easy to understand and according to the accepted answer is faster, but the author of the question left a comment that said he didn't know why it was sometimes leaving duplicates 🤷 . I don't see anything wrong with the query and if anyone thinks our mileage might be different then I can remove sql2 and use the first sql. Otherwise I'll remove the first sql and just use sql2.

After this is run, then a unique index will be added to ensure these duplicates don't reappear.