### PR TITLE
Maven /all endpoint no longer exists, just use /recent

### DIFF
--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -42,7 +42,8 @@ module PackageManager
     end
 
     def self.project_names
-      get("https://maven.libraries.io/mavenCentral/all")
+      # NB this is just the most recent set of incremental updates to maven central, not all releases
+      get("https://maven.libraries.io/mavenCentral/recent")
     end
 
     def self.project(name)


### PR DESCRIPTION
The `/all` endpoint on the maven-updater was [removed last year](https://github.com/librariesio/maven-updater/commit/59c3a8cc76fb83acd94eb20e7b63dcedd543c206), so this updates the Maven `project_names` to just use the `/recent` endpoint, which is better than nothin.

