### PR TITLE
Two attempts at fixing the "[NEW VERSION]" logging

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -151,6 +151,7 @@ module PackageManager
 
       existing.repository_sources = Set.new(existing.repository_sources).add(self::REPOSITORY_SOURCE_NAME).to_a if self::HAS_MULTIPLE_REPO_SOURCES
       existing.save!
+      existing.log_version_creation
     rescue ActiveRecord::RecordNotUnique => e
       # Until all package managers support version-specific updates, we'll have this race condition
       # of 2+ jobs trying to add versions at the same time.

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -48,8 +48,8 @@ class Version < ApplicationRecord
   after_create_commit { ProjectTagsUpdateWorker.perform_async(project_id) }
   after_create_commit :send_notifications_async,
                       :update_repository_async,
-                      :log_version_creation
-                      :save_project,
+                      :log_version_creation,
+                      :save_project
 
   scope :newest_first, -> { order("versions.published_at DESC") }
 

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -48,8 +48,8 @@ class Version < ApplicationRecord
   after_create_commit { ProjectTagsUpdateWorker.perform_async(project_id) }
   after_create_commit :send_notifications_async,
                       :update_repository_async,
-                      :save_project,
                       :log_version_creation
+                      :save_project,
 
   scope :newest_first, -> { order("versions.published_at DESC") }
 


### PR DESCRIPTION
* move logging callback before the 'save_project' callback, which is skipped when saving project
* explicitly log the version after it's created in PackageManager::Base