### PR TITLE
Don't log api_key param, but include custom api_key object if it exists.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -290,5 +290,12 @@ class ApplicationController < ActionController::Base
     payload[:rescued_error] = @rescued_error if @rescued_error
     payload[:current_user] = @current_user.id if @current_user
     payload[:remote_ip] = request.remote_ip
+    if @current_api_key
+      payload[:api_key] = {
+        api_key_id: @current_api_key&.id,
+        api_key_user_id: @current_api_key&.user_id,
+        api_key_is_internal: @current_api_key&.is_internal,
+      }
+    end
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -108,12 +108,13 @@ Rails.application.configure do
   config.lograge.enabled = true
   config.lograge.ignore_actions = ["HealthcheckController#index"]
   config.lograge.formatter = Lograge::Formatters::Json.new
-  params_exceptions = %w[controller action format id].freeze
+  # "api_key" is the one from params, which we might overwrite beneath with our own "api_key" object.
+  params_exceptions = %w[controller action format id api_key].freeze
   config.lograge.custom_options = lambda do |event|
     {}.tap do |options|
       options[:params] = event.payload[:params].except(*params_exceptions)
       # extra keys that we want to log. Add these in the append_info_to_payload() overrided controller methods.
-      %i[rescued_error current_user remote_ip].each do |key|
+      %i[rescued_error current_user remote_ip api_key].each do |key|
         options[key] = event.payload[key] if event.payload[key]
       end
     end


### PR DESCRIPTION
* don't log `params[:api_key]` (it's redacted currently anyway)
* build our own custom "api_key" object for Logstash for filtering request logs, etc