### PR TITLE
bibliothecary 8.5.1 ~> 8.6.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
     ast (2.4.2)
     autoprefixer-rails (9.5.1.1)
       execjs
-    bibliothecary (8.5.1)
+    bibliothecary (8.6.0)
       commander
       deb_control
       librariesio-gem-parser
@@ -364,7 +364,7 @@ GEM
     org-ruby (0.9.12)
       rubypants (~> 0.2)
     os (1.1.1)
-    ox (2.14.13)
+    ox (2.14.14)
     packageurl-ruby (0.1.0)
     parallel (1.17.0)
     parser (3.0.0.0)


### PR DESCRIPTION
Updates bibliothecary for [this change](https://github.com/librariesio/bibliothecary/pull/568/), which improves pyproject.toml parsing.