### PR TITLE
Revert "Revert "Add repository_status to projects""

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -42,7 +42,7 @@
 #  index_projects_on_dependents_count               (dependents_count)
 #  index_projects_on_keywords_array                 (keywords_array) USING gin
 #  index_projects_on_lower_language                 (lower((language)::text))
-#  index_projects_on_maintained                     (platform,language,id) WHERE (((status)::text = ANY (ARRAY[('Active'::character varying)::text, ('Help Wanted'::character varying)::text])) OR (status IS NULL))
+#  index_projects_on_maintained                     (platform,language,id) WHERE (((status)::text = ANY ((ARRAY['Active'::character varying, 'Help Wanted'::character varying])::text[])) OR (status IS NULL))
 #  index_projects_on_normalized_licenses            (normalized_licenses) USING gin
 #  index_projects_on_platform_and_dependents_count  (platform,dependents_count)
 #  index_projects_on_platform_and_name              (platform,name) UNIQUE
@@ -88,6 +88,7 @@ class Project < ApplicationRecord
     platform
     rank
     repository_license
+    repository_status
     repository_url
     stars
     status
@@ -265,6 +266,10 @@ class Project < ApplicationRecord
 
   def repository_license
     repository&.license
+  end
+
+  def repository_status
+    repository&.status
   end
 
   def download_url(version = nil)

--- a/app/serializers/optimized_project_serializer.rb
+++ b/app/serializers/optimized_project_serializer.rb
@@ -60,6 +60,7 @@ class OptimizedProjectSerializer
           latest_download_url: project.latest_download_url,
           package_manager_url: project.package_manager_url,
           repository_license: project.repository_license,
+          repository_status: project.repository_status,
           stars: project.stars,
           versions: project.versions
         ).tap do |result|

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -22,6 +22,7 @@ class ProjectSerializer < ActiveModel::Serializer
     platform
     rank
     repository_license
+    repository_status
     repository_url
     stars
     status

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -47,7 +47,7 @@ RSpec.configure do |config|
 end
 
 def project_json_response(projects)
-  projects.as_json(only: Project::API_FIELDS, methods: %i[package_manager_url stars forks keywords latest_download_url repository_license], include: { versions: { only: %i[number published_at original_license spdx_expression researched_at repository_sources] } })
+  projects.as_json(only: Project::API_FIELDS, methods: %i[package_manager_url stars forks keywords latest_download_url repository_license repository_status], include: { versions: { only: %i[number published_at original_license spdx_expression researched_at repository_sources] } })
 end
 
 RSpec::Sidekiq.configure do |config|

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -186,6 +186,7 @@ describe "Api::ProjectsController" do
           platform: project.platform,
           rank: project.rank,
           repository_license: project.repository_license,
+          repository_status: project.repository_status,
           repository_url: project.repository_url,
           stars: project.stars,
           status: project.status,

--- a/spec/requests/api/subscriptions_spec.rb
+++ b/spec/requests/api/subscriptions_spec.rb
@@ -11,7 +11,7 @@ describe "Api::SubscriptionsController" do
       get "/api/subscriptions?api_key=#{user.api_key}"
       expect(response).to have_http_status(:success)
       expect(response.content_type).to eq('application/json')
-      expect(response.body).to be_json_eql [subscription.as_json(only: [:include_prerelease, :created_at, :updated_at], include: {project: {only: Project::API_FIELDS, methods: [:package_manager_url, :stars, :forks, :keywords, :latest_download_url, :repository_license], include: {versions: {only: [:number, :published_at]} }}})].to_json
+      expect(response.body).to be_json_eql [subscription.as_json(only: [:include_prerelease, :created_at, :updated_at], include: {project: {only: Project::API_FIELDS, methods: [:package_manager_url, :stars, :forks, :keywords, :latest_download_url, :repository_license, :repository_status], include: {versions: {only: [:number, :published_at]} }}})].to_json
     end
   end
 
@@ -20,7 +20,7 @@ describe "Api::SubscriptionsController" do
       get "/api/subscriptions/#{subscription.project.platform}/#{subscription.project.name}?api_key=#{user.api_key}"
       expect(response).to have_http_status(:success)
       expect(response.content_type).to eq('application/json')
-      expect(response.body).to be_json_eql subscription.to_json(only: [:include_prerelease, :created_at, :updated_at], include: {project: {only: Project::API_FIELDS, methods: [:package_manager_url, :stars, :forks, :keywords, :latest_download_url, :repository_license], include: {versions: {only: [:number, :published_at]} }}})
+      expect(response.body).to be_json_eql subscription.to_json(only: [:include_prerelease, :created_at, :updated_at], include: {project: {only: Project::API_FIELDS, methods: [:package_manager_url, :stars, :forks, :keywords, :latest_download_url, :repository_license, :repository_status], include: {versions: {only: [:number, :published_at]} }}})
     end
   end
 
@@ -45,7 +45,7 @@ describe "Api::SubscriptionsController" do
       put "/api/subscriptions/#{subscription.project.platform}/#{subscription.project.name}?api_key=#{user.api_key}", params: { subscription: { include_prerelease: true } }
       expect(response).to have_http_status(:success)
       expect(response.content_type).to eq('application/json')
-      expect(response.body).to be_json_eql subscription.reload.to_json(only: [:include_prerelease, :created_at, :updated_at], include: {project: {only: Project::API_FIELDS, methods: [:package_manager_url, :stars, :forks, :keywords, :latest_download_url, :repository_license], include: {versions: {only: [:number, :published_at]} }}})
+      expect(response.body).to be_json_eql subscription.reload.to_json(only: [:include_prerelease, :created_at, :updated_at], include: {project: {only: Project::API_FIELDS, methods: [:package_manager_url, :stars, :forks, :keywords, :latest_download_url, :repository_license, :repository_status], include: {versions: {only: [:number, :published_at]} }}})
     end
   end
 

--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -25,6 +25,7 @@ describe ProjectSerializer do
       platform
       rank
       repository_license
+      repository_status
       repository_url
       stars
       status


### PR DESCRIPTION
Reverts librariesio/libraries.io#3054

This *un*-reverts librariesio/libraries.io#3052 which we reverted because we thought it was related to a live bug, but proved otherwise.

Please see the above un-reverted PR for approvals on exactly the same code.