### PR TITLE
Resync Version Dependencies on Manual Sync

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -245,7 +245,10 @@ module PackageManager
         # if we are forcing a resync of the dependencies in here then wipe out existing ones
         # so that we have the fresh and correct dependency information from the most recent
         # call to dependencies() from the platform provider
-        db_version.dependencies.destroy_all if force_sync_dependencies
+        if force_sync_dependencies
+          Rails.logger.info("[Full Dependency Refresh] platform=#{db_platform} name=#{name} version=#{db_version.number}")
+          db_version.dependencies.destroy_all
+        end
 
         deps.each do |dep|
           next if dep[:project_name].blank? || dep[:requirements].blank? || db_version.dependencies.any? { |d| d.project_name == dep[:project_name] }

--- a/app/models/package_manager/go.rb
+++ b/app/models/package_manager/go.rb
@@ -74,7 +74,7 @@ module PackageManager
       data
     end
 
-    def self.update(name, sync_version: :all)
+    def self.update(name, sync_version: :all, force_sync_dependencies: false)
       project = super(name, sync_version: sync_version)
       # call update on base module name if the name is appended with major version
       # example: github.com/myexample/modulename/v2

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -204,7 +204,7 @@ class Project < ApplicationRecord
   end
 
   def manual_sync
-    async_sync
+    async_sync(force_sync_dependencies: true)
     update_repository_async
     forced_save
   end
@@ -218,10 +218,10 @@ class Project < ApplicationRecord
     update_attribute(:last_synced_at, Time.zone.now)
   end
 
-  def async_sync
+  def async_sync(force_sync_dependencies: false)
     return unless platform_class_exists?
 
-    sync_classes.each { |sync_class| PackageManagerDownloadWorker.perform_async(sync_class.name, name, nil, "project", 0, true) }
+    sync_classes.each { |sync_class| PackageManagerDownloadWorker.perform_async(sync_class.name, name, nil, "project", 0, force_sync_dependencies) }
     CheckStatusWorker.perform_async(id, status == "Removed" || status == "Deprecated")
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -221,7 +221,7 @@ class Project < ApplicationRecord
   def async_sync
     return unless platform_class_exists?
 
-    sync_classes.each { |sync_class| PackageManagerDownloadWorker.perform_async(sync_class.name, name, nil, "project") }
+    sync_classes.each { |sync_class| PackageManagerDownloadWorker.perform_async(sync_class.name, name, nil, "project", 0, true) }
     CheckStatusWorker.perform_async(id, status == "Removed" || status == "Deprecated")
   end
 

--- a/app/workers/package_manager_download_worker.rb
+++ b/app/workers/package_manager_download_worker.rb
@@ -2,9 +2,9 @@
 
 class PackageManagerDownloadWorker
   include Sidekiq::Worker
-  
-  # For stale repo pages without fresh versions, we have a manual retry mechanism 
-  # below. All other errors retry 3 times. 
+
+  # For stale repo pages without fresh versions, we have a manual retry mechanism
+  # below. All other errors retry 3 times.
   sidekiq_options queue: :critical, retry: 3
 
   # We were unable to fetch version, even after waiting for repo caches to refresh.

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -391,4 +391,23 @@ describe Project, type: :model do
       end
     end
   end
+
+  describe "manual_sync" do
+    let!(:project) { create(:project, platform: 'Rubygems', name: 'my_gem') }
+
+    before { allow(PackageManagerDownloadWorker).to receive(:perform_async) }
+
+    it "sends option to sync all dependencies to download worker" do
+      project.manual_sync
+
+      expect(PackageManagerDownloadWorker).to have_received(:perform_async).with(
+        'PackageManager::Rubygems',
+        project.name,
+        nil,
+        "project",
+        0,
+        true
+      )
+    end
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -393,7 +393,7 @@ describe Project, type: :model do
   end
 
   describe "manual_sync" do
-    let!(:project) { create(:project, platform: 'Rubygems', name: 'my_gem') }
+    let!(:project) { create(:project, platform: "Rubygems", name: "my_gem") }
 
     before { allow(PackageManagerDownloadWorker).to receive(:perform_async) }
 
@@ -401,7 +401,7 @@ describe Project, type: :model do
       project.manual_sync
 
       expect(PackageManagerDownloadWorker).to have_received(:perform_async).with(
-        'PackageManager::Rubygems',
+        "PackageManager::Rubygems",
         project.name,
         nil,
         "project",

--- a/spec/workers/package_manager_download_worker_spec.rb
+++ b/spec/workers/package_manager_download_worker_spec.rb
@@ -8,7 +8,7 @@ describe PackageManagerDownloadWorker do
   end
 
   it "should sync all versions if none are specified" do
-    expect(PackageManager::Rubygems).to receive(:update).with("rails", sync_version: :all)
+    expect(PackageManager::Rubygems).to receive(:update).with("rails", sync_version: :all, force_sync_dependencies: false)
     subject.perform("PackageManager::Rubygems", "rails")
   end
 
@@ -17,8 +17,8 @@ describe PackageManagerDownloadWorker do
   end
 
   it "should delay version requested if version didn't get created" do
-    expect(PackageManagerDownloadWorker).to receive(:perform_in).with(5.seconds, "go", "github.com/hi/ima.package", "1.2.3", "unknown", 1)
-    expect(PackageManager::Go).to receive(:update).with("github.com/hi/ima.package", sync_version: "1.2.3")
+    expect(PackageManagerDownloadWorker).to receive(:perform_in).with(5.seconds, "go", "github.com/hi/ima.package", "1.2.3", "unknown", 1, false)
+    expect(PackageManager::Go).to receive(:update).with("github.com/hi/ima.package", sync_version: "1.2.3", force_sync_dependencies: false)
     expect(Rails.logger).to receive(:info).with("[Version Update Failure] platform=go name=github.com/hi/ima.package version=1.2.3")
 
     subject.perform("go", "github.com/hi/ima.package", "1.2.3")
@@ -26,7 +26,7 @@ describe PackageManagerDownloadWorker do
 
   it "should raise an error if version didn't get created after 15 attempts" do
     expect(PackageManagerDownloadWorker).to_not receive(:perform_in)
-    expect(PackageManager::NPM).to receive(:update).with("a-package", sync_version: "1.2.3")
+    expect(PackageManager::NPM).to receive(:update).with("a-package", sync_version: "1.2.3", force_sync_dependencies: false)
     expect(Rails.logger).to receive(:info).with("[Version Update Failure] platform=npm name=a-package version=1.2.3")
 
     expect { subject.perform("npm", "a-package", "1.2.3", nil, 16) }.to raise_exception(PackageManagerDownloadWorker::VersionUpdateFailure)
@@ -34,7 +34,7 @@ describe PackageManagerDownloadWorker do
 
   it "should not raise an error if version didn't get created after 15 attempts and is golang" do
     expect(PackageManagerDownloadWorker).to_not receive(:perform_in)
-    expect(PackageManager::Go).to receive(:update).with("github.com/hi/ima.package", sync_version: "1.2.3")
+    expect(PackageManager::Go).to receive(:update).with("github.com/hi/ima.package", sync_version: "1.2.3", force_sync_dependencies: false)
     expect(Rails.logger).to receive(:info).with("[Version Update Failure] platform=go name=github.com/hi/ima.package version=1.2.3")
 
     expect { subject.perform("go", "github.com/hi/ima.package", "1.2.3", nil, 16) }.to_not raise_exception(PackageManagerDownloadWorker::VersionUpdateFailure)


### PR DESCRIPTION
This passes a flag to the package download worker and then platform update methods to completely resync the dependencies. This isn't anything fancy. It will remove any existing dependencies and replace them with the ones from the platform provider's response in the `save_dependencies` function. This should allow us to clear out any Projects with incorrectly formatted dependency information on a case-by-case basis.