### PR TITLE
Fix error handling while pulling github contributor stats

### DIFF
--- a/app/models/maintenance_stats/queries/github/repository_contributor_stats_query.rb
+++ b/app/models/maintenance_stats/queries/github/repository_contributor_stats_query.rb
@@ -13,7 +13,7 @@ module MaintenanceStats
         def query(params: {})
           validate_params(params)
 
-          @client.contributor_stats(params[:full_name], retry_wait: 0.5, retry_timeout: 10)
+          @client.contributor_stats(params[:full_name], retry_timeout: 10)
         end
       end
     end

--- a/app/models/maintenance_stats/queries/github/repository_contributor_stats_query.rb
+++ b/app/models/maintenance_stats/queries/github/repository_contributor_stats_query.rb
@@ -5,22 +5,15 @@ module MaintenanceStats
       class RepositoryContributorStatsQuery < BaseQuery
         VALID_PARAMS = [:full_name]
         REQUIRED_PARAMS = [:full_name]
-        RETRY_AMOUNT = 4
 
         def self.client_type
           :v3
         end
 
-        def query(params: {}, count: 0)
-          raise Octokit::Error.new "Didn't get a response after #{RETRY_AMOUNT} attempts" if params[:count].present? && params[:count] >= RETRY_AMOUNT
+        def query(params: {})
           validate_params(params)
 
-          resp = @client.contributor_stats(params[:full_name])
-          if @client.last_response.status == 202
-            sleep (count + 1) * 0.5
-            return query(params: params, count: count+=1)
-          end
-          resp
+          @client.contributor_stats(params[:full_name], retry_wait: 0.5, retry_timeout: 10)
         end
       end
     end

--- a/app/models/maintenance_stats/queries/github/repository_contributor_stats_query.rb
+++ b/app/models/maintenance_stats/queries/github/repository_contributor_stats_query.rb
@@ -5,6 +5,7 @@ module MaintenanceStats
       class RepositoryContributorStatsQuery < BaseQuery
         VALID_PARAMS = [:full_name]
         REQUIRED_PARAMS = [:full_name]
+        TIMEOUT_SEC = 10
 
         def self.client_type
           :v3
@@ -13,7 +14,7 @@ module MaintenanceStats
         def query(params: {})
           validate_params(params)
 
-          result = @client.contributor_stats(params[:full_name], retry_timeout: 10)
+          result = @client.contributor_stats(params[:full_name], retry_timeout: TIMEOUT_SEC)
 
           raise Octokit::Error, "Could not fetch contributor stats for #{params[:full_name]}" if result.nil?
 

--- a/app/models/maintenance_stats/queries/github/repository_contributor_stats_query.rb
+++ b/app/models/maintenance_stats/queries/github/repository_contributor_stats_query.rb
@@ -13,7 +13,11 @@ module MaintenanceStats
         def query(params: {})
           validate_params(params)
 
-          @client.contributor_stats(params[:full_name], retry_timeout: 10)
+          result = @client.contributor_stats(params[:full_name], retry_timeout: 10)
+
+          raise Octokit::Error, "Could not fetch contributor stats for #{params[:full_name]}" if result.nil?
+
+          result
         end
       end
     end


### PR DESCRIPTION
This method had a broken adhoc retry mechanism for a Github REST API call. Octokit can already perform retries on this call if passed a timeout value. With the default 0.5 second wait, 10 seconds allowed enough attempts to pass with the existing VCR cassettes.