### PR TITLE
Fix errors on projects from certain maven repositories

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -348,7 +348,7 @@ module PackageManager
     private_class_method def self.download_async(names)
       if SYNC_ACTIVE != true
         logger.info("Skipping Package update for inactive platform=#{platform_name} names=#{names.join(',')}")
-        returnß
+        return
       end
 
       names.each_slice(1000).each_with_index do |group, index|

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -8,6 +8,7 @@ module PackageManager
     HAS_MULTIPLE_REPO_SOURCES = false
     SECURITY_PLANNED = false
     HIDDEN = false
+    SYNC_ACTIVE = true
     HAS_OWNERS = false
     ENTIRE_PACKAGE_CAN_BE_DEPRECATED = false
     SUPPORTS_SINGLE_VERSION_UPDATE = false
@@ -345,6 +346,11 @@ module PackageManager
     end
 
     private_class_method def self.download_async(names)
+      if SYNC_ACTIVE != true
+        logger.info("Skipping Package update for inactive platform=#{platform_name} names=#{names.join(',')}")
+        returnß
+      end
+
       names.each_slice(1000).each_with_index do |group, index|
         group.each { |name| PackageManagerDownloadWorker.perform_in(index.hours, self.name, name, nil, "download_async") }
       end

--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -19,8 +19,13 @@ module PackageManager
     NAME_DELIMITER = ":"
 
     PROVIDER_MAP = {
+      "Atlassian" => Atlassian,
       "default" => MavenCentral,
+      "Hortonworks" => Hortonworks,
       "Maven" => MavenCentral,
+      "SpringLibs" => SpringLibs,
+      "Jboss" => Jboss,
+      "JbossEa" => JbossEa,
     }.freeze
 
     class POMNotFound < StandardError

--- a/app/models/package_manager/maven/atlassian.rb
+++ b/app/models/package_manager/maven/atlassian.rb
@@ -2,6 +2,7 @@
 
 class PackageManager::Maven::Atlassian < PackageManager::Maven::Common
   REPOSITORY_SOURCE_NAME = "Atlassian"
+  SYNC_ACTIVE = false
 
   def self.repository_base
     "https://packages.atlassian.com/maven-central-local"

--- a/app/models/package_manager/maven/hortonworks.rb
+++ b/app/models/package_manager/maven/hortonworks.rb
@@ -2,6 +2,7 @@
 
 class PackageManager::Maven::Hortonworks < PackageManager::Maven::Common
   REPOSITORY_SOURCE_NAME = "Hortonworks"
+  SYNC_ACTIVE = false
 
   def self.repository_base
     "https://repo.hortonworks.com/content/groups/releases"

--- a/app/models/package_manager/maven/jboss.rb
+++ b/app/models/package_manager/maven/jboss.rb
@@ -3,6 +3,7 @@
 class PackageManager::Maven::Jboss < PackageManager::Maven::Common
   REPOSITORY_SOURCE_NAME = "Jboss"
   HIDDEN = true
+  SYNC_ACTIVE = false
 
   def self.repository_base
     "https://repository.jboss.org/nexus/content/repositories/releases"

--- a/app/models/package_manager/maven/jboss_ea.rb
+++ b/app/models/package_manager/maven/jboss_ea.rb
@@ -3,6 +3,7 @@
 class PackageManager::Maven::JbossEa < PackageManager::Maven::Common
   REPOSITORY_SOURCE_NAME = "JbossEa"
   HIDDEN = true
+  SYNC_ACTIVE = false
 
   def self.repository_base
     "https://repository.jboss.org/nexus/content/repositories/ea"

--- a/app/models/package_manager/maven/spring_libs.rb
+++ b/app/models/package_manager/maven/spring_libs.rb
@@ -3,6 +3,7 @@
 class PackageManager::Maven::SpringLibs < PackageManager::Maven::Common
   REPOSITORY_SOURCE_NAME = "SpringLibs"
   HIDDEN = true
+  SYNC_ACTIVE = false
 
   def self.repository_base
     "https://repo.spring.io/libs-release-local"

--- a/app/workers/package_manager_download_worker.rb
+++ b/app/workers/package_manager_download_worker.rb
@@ -67,7 +67,12 @@ class PackageManagerDownloadWorker
     version = version.to_s.strip
     sync_version = (platform::SUPPORTS_SINGLE_VERSION_UPDATE && version.presence) || :all
 
-    logger.info("Package update for platform=#{key} name=#{name} version=#{version} source=#{source}")
+    if platform::SYNC_ACTIVE != true
+      Rails.logger.info("Skipping Package update for inactive platform=#{key} name=#{name} version=#{version} source=#{source}")
+      return
+    end
+
+    Rails.logger.info("Package update for platform=#{key} name=#{name} version=#{version} source=#{source}")
     project = platform.update(name, sync_version: sync_version, force_sync_dependencies: force_sync_dependencies)
 
     # Raise/log if version was requested but not found

--- a/spec/workers/package_manager_download_worker_spec.rb
+++ b/spec/workers/package_manager_download_worker_spec.rb
@@ -19,14 +19,26 @@ describe PackageManagerDownloadWorker do
   it "should delay version requested if version didn't get created" do
     expect(PackageManagerDownloadWorker).to receive(:perform_in).with(5.seconds, "go", "github.com/hi/ima.package", "1.2.3", "unknown", 1, false)
     expect(PackageManager::Go).to receive(:update).with("github.com/hi/ima.package", sync_version: "1.2.3", force_sync_dependencies: false)
+    expect(Rails.logger).to receive(:info).with(a_string_matching("Package update"))
     expect(Rails.logger).to receive(:info).with("[Version Update Failure] platform=go name=github.com/hi/ima.package version=1.2.3")
 
     subject.perform("go", "github.com/hi/ima.package", "1.2.3")
   end
 
+  it "should skip if platform syncing not active" do
+    an_inactive_platform = PackageManager::Maven::Atlassian
+    expect(an_inactive_platform::SYNC_ACTIVE).to_not eq(true)
+    expect(an_inactive_platform).to_not receive(:update)
+    expect(PackageManagerDownloadWorker).to_not receive(:perform_in)
+    expect(Rails.logger).to receive(:info).with(a_string_matching("Skipping"))
+
+    subject.perform("maven_atlassian", "github.com/hi/ima.package", "1.2.3")
+  end
+
   it "should raise an error if version didn't get created after 15 attempts" do
     expect(PackageManagerDownloadWorker).to_not receive(:perform_in)
     expect(PackageManager::NPM).to receive(:update).with("a-package", sync_version: "1.2.3", force_sync_dependencies: false)
+    expect(Rails.logger).to receive(:info).with(a_string_matching("Package update"))
     expect(Rails.logger).to receive(:info).with("[Version Update Failure] platform=npm name=a-package version=1.2.3")
 
     expect { subject.perform("npm", "a-package", "1.2.3", nil, 16) }.to raise_exception(PackageManagerDownloadWorker::VersionUpdateFailure)
@@ -35,8 +47,9 @@ describe PackageManagerDownloadWorker do
   it "should not raise an error if version didn't get created after 15 attempts and is golang" do
     expect(PackageManagerDownloadWorker).to_not receive(:perform_in)
     expect(PackageManager::Go).to receive(:update).with("github.com/hi/ima.package", sync_version: "1.2.3", force_sync_dependencies: false)
+    expect(Rails.logger).to receive(:info).with(a_string_matching("Package update"))
     expect(Rails.logger).to receive(:info).with("[Version Update Failure] platform=go name=github.com/hi/ima.package version=1.2.3")
 
-    expect { subject.perform("go", "github.com/hi/ima.package", "1.2.3", nil, 16) }.to_not raise_exception(PackageManagerDownloadWorker::VersionUpdateFailure)
+    expect { subject.perform("go", "github.com/hi/ima.package", "1.2.3", nil, 16) }.to_not raise_exception
   end
 end


### PR DESCRIPTION
[Shortcut](https://app.shortcut.com/tidelift/story/31152/maven-projects-from-removed-repositories-causing-errors)

This restores these removed classes from maven's provider map while still omitting them from being automatically synced