### PR TITLE
Fixes for gathering github maintenance stats

### DIFF
--- a/app/models/maintenance_stats/queries/github/repository_contributor_stats_query.rb
+++ b/app/models/maintenance_stats/queries/github/repository_contributor_stats_query.rb
@@ -13,8 +13,9 @@ module MaintenanceStats
 
         def query(params: {})
           validate_params(params)
+          full_name = params[:full_name]
 
-          result = @client.contributor_stats(params[:full_name], retry_timeout: TIMEOUT_SEC)
+          result = @client.contributor_stats(full_name, retry_timeout: TIMEOUT_SEC)
 
           raise Octokit::Error, { body: "Could not fetch contributor stats for #{full_name}" } if result.nil?
 

--- a/app/models/maintenance_stats/queries/github/repository_contributor_stats_query.rb
+++ b/app/models/maintenance_stats/queries/github/repository_contributor_stats_query.rb
@@ -16,7 +16,7 @@ module MaintenanceStats
 
           result = @client.contributor_stats(params[:full_name], retry_timeout: TIMEOUT_SEC)
 
-          raise Octokit::Error, "Could not fetch contributor stats for #{params[:full_name]}" if result.nil?
+          raise Octokit::Error, { body: "Could not fetch contributor stats for #{full_name}" } if result.nil?
 
           result
         end

--- a/spec/models/package_manager/rubygems_spec.rb
+++ b/spec/models/package_manager/rubygems_spec.rb
@@ -51,7 +51,7 @@ describe PackageManager::Rubygems do
       json_versions = [{number: "1.0.0", published_at: nil, original_license: nil}]
       described_class.deprecate_versions(project, json_versions)
 
-      expect(project.reload.versions.pluck(:number, :status)).to eq([["1.0.0", nil], ["1.0.1", "Removed"]])
+      expect(project.reload.versions.pluck(:number, :status)).to match_array([["1.0.0", nil], ["1.0.1", "Removed"]])
     end
   end
 end


### PR DESCRIPTION
* Octokit::Error expects to be initialized with response hash