### PR TITLE
Add project_urls.Code as a possible PyPI repository URL

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -303,6 +303,15 @@ module PackageManager
       end
     end
 
+    # Use librariesio-url-parser to attempt to select one of the provided
+    # URLs as the URL for this repository. This means that if the URL is
+    # not considered a repository URL by that gem, its raw value will be
+    # used. This would allow for a project that self-hosts to still have
+    # a valid repo URL.
+    #
+    # @param repo String A string we think is a project's repository URL
+    # @param homepage String A string we thing is a project's homepage URL
+    # @return String The best URL we can select for the project's repository, or "" if we can't find one
     def self.repo_fallback(repo, homepage)
       repo = "" if repo.nil?
       homepage = "" if homepage.nil?

--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -72,6 +72,17 @@ module PackageManager
       }
     end
 
+    def self.select_repository_url(raw_project)
+      ["Source", "Source Code", "Repository", "Code"].filter_map do |field|
+        raw_project.dig("info", "project_urls", field)
+      end.first
+    end
+
+    def self.select_homepage_url(raw_project)
+      raw_project["info"]["home_page"].presence ||
+        raw_project.dig("info", "project_urls", "Homepage")
+    end
+
     def self.mapping(raw_project)
       {
         name: raw_project["info"]["name"],
@@ -80,12 +91,8 @@ module PackageManager
         keywords_array: Array.wrap(raw_project["info"]["keywords"].try(:split, /[\s.,]+/)),
         licenses: licenses(raw_project),
         repository_url: repo_fallback(
-          raw_project.dig("info", "project_urls", "Source").presence ||
-          raw_project.dig("info", "project_urls", "Source Code").presence ||
-          raw_project.dig("info", "project_urls", "Repository").presence ||
-          raw_project.dig("info", "project_urls", "Code"),
-          raw_project["info"]["home_page"].presence ||
-          raw_project.dig("info", "project_urls", "Homepage")
+          select_repository_url(raw_project),
+          select_homepage_url(raw_project)
         ),
       }
     end

--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -80,8 +80,12 @@ module PackageManager
         keywords_array: Array.wrap(raw_project["info"]["keywords"].try(:split, /[\s.,]+/)),
         licenses: licenses(raw_project),
         repository_url: repo_fallback(
-          raw_project.dig("info", "project_urls", "Source").presence || raw_project.dig("info", "project_urls", "Source Code").presence || raw_project.dig("info", "project_urls", "Repository"),
-          raw_project["info"]["home_page"].presence || raw_project.dig("info", "project_urls", "Homepage")
+          raw_project.dig("info", "project_urls", "Source").presence ||
+          raw_project.dig("info", "project_urls", "Source Code").presence ||
+          raw_project.dig("info", "project_urls", "Repository").presence ||
+          raw_project.dig("info", "project_urls", "Code"),
+          raw_project["info"]["home_page"].presence ||
+          raw_project.dig("info", "project_urls", "Homepage")
         ),
       }
     end

--- a/spec/models/package_manager/base_spec.rb
+++ b/spec/models/package_manager/base_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+describe PackageManager::Base do
+  describe ".repo_fallback" do
+    let(:result) { described_class.repo_fallback(repo, homepage) }
+
+    context "both nil" do
+      let(:repo) { nil }
+      let(:homepage) { nil }
+
+      it "returns blank" do
+        expect(result).to eq("")
+      end
+    end
+
+    context "repo nil, homepage not a url" do
+      let(:repo) { nil }
+      let(:homepage) { "test" }
+
+      it "returns blank" do
+        expect(result).to eq("")
+      end
+    end
+
+    context "repo nil, homepage a non-repo url" do
+      let(:repo) { nil }
+      let(:homepage) { "http://homepage" }
+
+      it "returns blank" do
+        expect(result).to eq("")
+      end
+    end
+
+    context "repo nil, homepage a repo url" do
+      let(:repo) { nil }
+      let(:homepage) { "https://github.com/librariesio/libraries.io" }
+
+      it "returns blank" do
+        expect(result).to eq("https://github.com/librariesio/libraries.io")
+      end
+    end
+
+    context "repo not a url, homepage a url" do
+      let(:repo) { "test" }
+      let(:homepage) { "https://github.com/librariesio/libraries.io" }
+
+      it "returns homepage" do
+        expect(result).to eq("https://github.com/librariesio/libraries.io")
+      end
+    end
+
+    context "repo not a repo url, homepage not a repo url" do
+      let(:repo) { "http://repo" }
+      let(:homepage) { "http://homepage" }
+
+      it "returns repo" do
+        expect(result).to eq("http://repo")
+      end
+    end
+  end
+end

--- a/spec/models/package_manager/base_spec.rb
+++ b/spec/models/package_manager/base_spec.rb
@@ -4,17 +4,16 @@ describe PackageManager::Base do
   describe ".repo_fallback" do
     let(:result) { described_class.repo_fallback(repo, homepage) }
 
-    context "both nil" do
-      let(:repo) { nil }
-      let(:homepage) { nil }
+    let(:repo) { nil }
+    let(:homepage) { nil }
 
+    context "both nil" do
       it "returns blank" do
         expect(result).to eq("")
       end
     end
 
     context "repo nil, homepage not a url" do
-      let(:repo) { nil }
       let(:homepage) { "test" }
 
       it "returns blank" do
@@ -23,7 +22,6 @@ describe PackageManager::Base do
     end
 
     context "repo nil, homepage a non-repo url" do
-      let(:repo) { nil }
       let(:homepage) { "http://homepage" }
 
       it "returns blank" do
@@ -32,7 +30,6 @@ describe PackageManager::Base do
     end
 
     context "repo nil, homepage a repo url" do
-      let(:repo) { nil }
       let(:homepage) { "https://github.com/librariesio/libraries.io" }
 
       it "returns blank" do

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -239,31 +239,44 @@ describe PackageManager::Pypi do
     end
   end
 
-  describe "#mapping" do
-    let(:result) { described_class.mapping(raw_project) }
+  describe ".select_repository_url" do
+    let(:result) { described_class.select_repository_url(raw_project) }
 
     let(:raw_project) do
       {
         "info" => {
-          "name" => "name",
-          "summary" => "summary",
-          "home_page" => "home_page",
-          "keywords" => "keywords",
-          "classifiers" => [],
           "project_urls" => project_urls,
         },
       }
     end
 
-    context "respository url" do
-      context "project_urls.Code" do
-        let(:project_urls) do
-          { "Code" => "wow" }
-        end
+    context "project_urls.Code" do
+      let(:project_urls) do
+        { "Code" => "wow" }
+      end
 
-        it "uses correct value" do
-          expect(result[:repository_url]).to eq("wow")
-        end
+      it "uses correct value" do
+        expect(result).to eq("wow")
+      end
+    end
+
+    context "both Source and Code" do
+      let(:project_urls) do
+        { "Source" => "cool", "Code" => "wow" }
+      end
+
+      it "uses correct value" do
+        expect(result).to eq("cool")
+      end
+    end
+
+    context "none" do
+      let(:project_urls) do
+        {}
+      end
+
+      it "returns nil" do
+        expect(result).to eq(nil)
       end
     end
   end

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -238,4 +238,33 @@ describe PackageManager::Pypi do
       end
     end
   end
+
+  describe "#mapping" do
+    let(:result) { described_class.mapping(raw_project) }
+
+    let(:raw_project) do
+      {
+        "info" => {
+          "name" => "name",
+          "summary" => "summary",
+          "home_page" => "home_page",
+          "keywords" => "keywords",
+          "classifiers" => [],
+          "project_urls" => project_urls,
+        },
+      }
+    end
+
+    context "respository url" do
+      context "project_urls.Code" do
+        let(:project_urls) do
+          { "Code" => "wow" }
+        end
+
+        it "uses correct value" do
+          expect(result[:repository_url]).to eq("wow")
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## PyPI API response

```
$ curl https://pypi.org/pypi/CairoSVG/json 2>/dev/null | jq '.info.project_urls'
{
  "Code": "https://github.com/Kozea/CairoSVG/",
  "Documentation": "https://cairosvg.org/documentation/",
  "Donation": "https://opencollective.com/courtbouillon",
  "Homepage": "https://courtbouillon.org/cairosvg",
  "Issue tracker": "https://github.com/Kozea/CairoSVG/issues"
}
```

##  Live site

![Screenshot_20230316_162100](https://user-images.githubusercontent.com/35267397/225744993-8856708d-d834-44d5-b081-2d1fac6fcc67.png)

## With this change

![Screenshot_20230316_162125](https://user-images.githubusercontent.com/35267397/225745018-cdab0a1a-fdb9-4e4b-92e3-f6cfee1972bc.png)
