### PR TITLE
Don't let a bad Project spoil its Repository's stats

### DIFF
--- a/app/models/maintenance_stats/stats/github/release_stats.rb
+++ b/app/models/maintenance_stats/stats/github/release_stats.rb
@@ -10,7 +10,7 @@ module MaintenanceStats
 
         def get_stats
           return {} if @results.nil?
-          
+
           last_week_releases = @results.select {|release| DateTime.parse(release.published_at) > @now - 1.week}.count
           last_month_releases = @results.select {|release| DateTime.parse(release.published_at) > @now - 1.month}.count
           last_two_month_releases = @results.select {|release| DateTime.parse(release.published_at) > @now - 2.months}.count

--- a/app/models/repository_host/bitbucket.rb
+++ b/app/models/repository_host/bitbucket.rb
@@ -144,7 +144,7 @@ module RepositoryHost
     end
 
     def gather_maintenance_stats
-      if repository.host_type != "Bitbucket" || repository.projects.any? { |project| project.bitbucket_name_with_owner.blank? }
+      if repository.host_type != "Bitbucket" || repository.owner_name.blank? || repository.project_name.blank?
         repository.repository_maintenance_stats.destroy_all
         return []
       end

--- a/app/models/repository_host/github.rb
+++ b/app/models/repository_host/github.rb
@@ -208,7 +208,7 @@ module RepositoryHost
     end
 
     def gather_maintenance_stats
-      if repository.host_type != "GitHub" || repository.projects.any? { |project| project.github_name_with_owner.blank? }
+      if repository.host_type != "GitHub" || repository.owner_name.blank? || repository.project_name.blank?
         repository.repository_maintenance_stats.destroy_all
         return []
       end

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -287,41 +287,9 @@ describe Repository, type: :model do
     end
 
     context "with non GitHub repository" do
-      let(:repository) { create(:repository, host_type: "Bitbucket") }
+      let(:repository) { create(:repository, host_type: "Gitlab") }
 
       it "should not save any values" do
-        VCR.use_cassette("github/chalk_api", match_requests_on: %i[method uri body query]) do
-          repository.gather_maintenance_stats
-        end
-
-        maintenance_stats = repository.repository_maintenance_stats
-        expect(maintenance_stats.count).to be 0
-      end
-    end
-
-    context "with a GitHub repository but for some reason not a GitHub Project" do
-      let!(:project) do
-        repository.projects.create!(
-          name: "test-project",
-          platform: "Maven",
-          repository_url: "https://def.not.github.com",
-          homepage: "https://def.not.github.com"
-        )
-      end
-
-      it "should not save any values" do
-        repository.gather_maintenance_stats
-
-        maintenance_stats = repository.repository_maintenance_stats
-        expect(maintenance_stats.count).to be 0
-      end
-
-      it "should delete existing stats" do
-        repository.repository_maintenance_stats.create!(
-          category: "test",
-          value: "yep"
-        )
-
         repository.gather_maintenance_stats
 
         maintenance_stats = repository.repository_maintenance_stats


### PR DESCRIPTION
A Repository can be related to multiple Projects. Right now, if **any** those Projects have an erroneous or missing `repository_url`|`homepage` set, then the Project doesn't have a github|bitbucket_owner_name set, and we don't gather stats on that repository and trash existing ones. Given not the name or anything from Projects are actually needed or used when gathering repository stats, I've replaced that check. 

If there's a reason at the Project level we'd want this integrity check or to skip/reset gathering stats can find a better place to do it.