### PR TITLE
Add "request_id" to Libraries' log_tags

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,7 +48,7 @@ Rails.application.configure do
   config.log_level = :info
 
   # Prepend all log lines with the following tags.
-  # config.log_tags = [ :subdomain, :uuid ]
+  config.log_tags = [:request_id]
 
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)


### PR DESCRIPTION
Not very consequential, just useful to have for grouping, searching, e.g.:

```
[2c7ffd7c-cb44-4bba-87d4-f5f1e7eac364] [dd.env=development dd.service=libraries dd.version=0cf971e2cc63994ef271c39b8e6d5c9061c70932 dd.trace_id=2696306947296716588 dd.span_id=2672779687593121511] {"method":"GET",...}

```