### PR TITLE
Track "github_event" in logs from the GH hook header.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -297,5 +297,7 @@ class ApplicationController < ActionController::Base
         api_key_is_internal: @current_api_key&.is_internal,
       }
     end
+    # helpful for tracking down github hook logs
+    payload[:github_event] = @github_event if @github_event
   end
 end

--- a/app/controllers/hooks_controller.rb
+++ b/app/controllers/hooks_controller.rb
@@ -9,7 +9,8 @@ class HooksController < ApplicationController
       payload = params
     end
 
-    handler.run(request.env['HTTP_X_GITHUB_EVENT'], payload)
+    @github_event = request.env['HTTP_X_GITHUB_EVENT']    
+    handler.run(@github_event, payload)
 
     render json: nil, status: :ok
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -114,7 +114,7 @@ Rails.application.configure do
     {}.tap do |options|
       options[:params] = event.payload[:params].except(*params_exceptions)
       # extra keys that we want to log. Add these in the append_info_to_payload() overrided controller methods.
-      %i[rescued_error current_user remote_ip api_key].each do |key|
+      %i[rescued_error current_user remote_ip api_key github_event].each do |key|
         options[key] = event.payload[key] if event.payload[key]
       end
     end


### PR DESCRIPTION
Start tracking the "X-Github-Event" header from github hooks in our logs, when they exist, so we can correlate logs to GH events.