### PR TITLE
Add returning names only for project dependents

### DIFF
--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -11,8 +11,14 @@ class Api::ProjectsController < Api::ApplicationController
   end
 
   def dependents
-    dependents = paginate(@project.dependent_projects).includes(:versions, :repository)
-    render json: dependents
+    dependents = @project.dependent_projects
+
+    if params[:subset] == "name_only"
+      render json: dependents.pluck(:name).map { |n| { name: n } }
+    else
+      dependents = paginate(dependents).includes(:versions, :repository)
+      render json: dependents
+    end
   end
 
   def dependent_repositories

--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -14,7 +14,7 @@ class Api::ProjectsController < Api::ApplicationController
     dependents = @project.dependent_projects
 
     if params[:subset] == "name_only"
-      render json: dependents.pluck(:name).map { |n| { name: n } }
+      render json: paginate(dependents).order(name: :asc).pluck(:name).map { |n| { name: n } }
     else
       dependents = paginate(dependents).includes(:versions, :repository)
       render json: dependents

--- a/app/views/api/docs/index.html.erb
+++ b/app/views/api/docs/index.html.erb
@@ -94,7 +94,10 @@
       Get packages that have at least one version that depends on a given project.
     </p>
 
-
+    <p>
+      The dependents endpoint accepts a <code>subset</code> parameter, one of
+        <code>name_only</code>.
+    </p>
 
     <p>
       <code>GET https://libraries.io/api/:platform/:name/dependents?api_key=<%= @api_key %></code>

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -79,7 +79,7 @@ Create a [Personal access token on GitHub](https://help.github.com/articles/crea
 ```sh
  bundle exec rails c
  irb> AuthToken.create(token: "<secure github token here>")
- irb> PackageManager::NPM.update "pictogram"
+ irb> PackageManager::NPM.update "base62" # this is needed to make the API page work
  irb> PackageManager::Rubygems.update "split"
  irb> PackageManager::Bower.update "sbteclipse"
  irb> PackageManager::Maven.update "junit:junit"

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -44,6 +44,13 @@ describe "Api::ProjectsController" do
       expect(response.content_type).to eq("application/json")
       expect(response.body).to be_json_eql [project_json_response(project)].to_json
     end
+
+    it "renders name only" do
+      get "/api/#{dependent_project.platform}/#{dependent_project.name}/dependents?subset=name_only"
+      expect(response).to have_http_status(:success)
+      expect(response.content_type).to eq("application/json")
+      expect(response.body).to be_json_eql [{ name: project.name }].to_json
+    end
   end
 
   describe "GET /api/:platform/:name/dependent_repositories", type: :request do


### PR DESCRIPTION
The current method of getting names of packages that are dependent packages is not only too slow, but can result in causing Libraries to time out due to JSON rendering. This enables retrieving just the names of the current set of dependent packages for a single package, rendering only a minimal amount of JSON to do so.