### PR TITLE
Fix deprecation_info() for cargo, by changing its method signature

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -323,7 +323,7 @@ module PackageManager
       [project_name]
     end
 
-    def self.deprecation_info(_name)
+    def self.deprecation_info(_db_project)
       { is_deprecated: false, message: nil }
     end
 

--- a/app/models/package_manager/cargo.rb
+++ b/app/models/package_manager/cargo.rb
@@ -28,10 +28,10 @@ module PackageManager
       "https://crates.io/api/v1/crates/#{db_project.name}"
     end
 
-    def self.deprecation_info(name)
-      item = project(name)
-      version = item.dig("crate", "newest_version")
-      url = download_url(name, version)
+    def self.deprecation_info(db_project)
+      raw_project = project(db_project.name)
+      version = raw_project.dig("crate", "newest_version")
+      url = download_url(db_project, version)
       body = get_raw(url)
       tar_extract = Gem::Package::TarReader.new(Zlib::GzipReader.new(StringIO.new(body)))
       tar_extract.rewind

--- a/app/models/package_manager/npm.rb
+++ b/app/models/package_manager/npm.rb
@@ -40,8 +40,8 @@ module PackageManager
       get("http://registry.npmjs.org/#{name.gsub('/', '%2F')}")
     end
 
-    def self.deprecation_info(name)
-      versions = project(name)["versions"].values
+    def self.deprecation_info(db_project)
+      versions = project(db_project.name)["versions"].values
       is_deprecated = versions.all? { |version| !!version["deprecated"] }
       message = is_deprecated ? versions.last["deprecated"] : nil
 

--- a/app/models/package_manager/nu_get.rb
+++ b/app/models/package_manager/nu_get.rb
@@ -27,8 +27,8 @@ module PackageManager
       "Install-Package #{db_project.name}" + (version ? " -Version #{version}" : "")
     end
 
-    def self.deprecation_info(name)
-      info = latest_remote_version(name)
+    def self.deprecation_info(db_project)
+      info = latest_remote_version(db_project.name)
       deprecation = info.dig("items")&.first&.dig("items")&.first&.dig("catalogEntry", "deprecation")
 
       # alternate_package is not currently stored in DB but I wanted to record it because it seems useful

--- a/app/models/package_manager/packagist.rb
+++ b/app/models/package_manager/packagist.rb
@@ -58,8 +58,8 @@ module PackageManager
         get("https://repo.packagist.org/p2/#{name}~dev.json")&.dig("packages", name)
     end
 
-    def self.deprecation_info(name)
-      is_deprecated = project(name)&.first&.dig("abandoned") || ""
+    def self.deprecation_info(db_project)
+      is_deprecated = project(db_project.name)&.first&.dig("abandoned") || ""
 
       {
         is_deprecated: is_deprecated != "",

--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -52,8 +52,8 @@ module PackageManager
       {}
     end
 
-    def self.deprecation_info(name)
-      p = project(name)
+    def self.deprecation_info(db_project)
+      p = project(db_project.name)
       last_version = p["releases"].reject { |version, _releases| version =~ PYPI_PRERELEASE }.values.last&.first
 
       is_deprecated, message = if last_version && last_version["yanked"] == true

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -621,7 +621,7 @@ class Project < ApplicationRecord
     elsif platform.downcase == "pypi" && response.response_code == 404
       update_attribute(:status, "Removed")
     elsif can_have_entire_package_deprecated?
-      result = platform_class.deprecation_info(name)
+      result = platform_class.deprecation_info(self)
       if result[:is_deprecated]
         update_attribute(:status, "Deprecated")
         update_attribute(:deprecation_reason, result[:message])

--- a/spec/models/package_manager/npm_spec.rb
+++ b/spec/models/package_manager/npm_spec.rb
@@ -44,7 +44,7 @@ describe PackageManager::NPM do
         }
       })
 
-      expect(described_class.deprecation_info('foo')).to eq({is_deprecated: false, message: nil})
+      expect(described_class.deprecation_info(project)).to eq({is_deprecated: false, message: nil})
     end
 
     it "returns deprecated if all versions are deprecated" do
@@ -56,7 +56,7 @@ describe PackageManager::NPM do
         }
       })
 
-      expect(described_class.deprecation_info('foo')).to eq({is_deprecated: true, message: "This package is deprecated"})
+      expect(described_class.deprecation_info(project)).to eq({is_deprecated: true, message: "This package is deprecated"})
     end
   end
 end

--- a/spec/models/package_manager/packagist_spec.rb
+++ b/spec/models/package_manager/packagist_spec.rb
@@ -3,13 +3,13 @@
 require "rails_helper"
 
 describe PackageManager::Packagist do
+  let(:project) { create(:project, name: "foo", platform: described_class.formatted_name) }
+
   it 'has formatted name of "Packagist"' do
     expect(described_class.formatted_name).to eq("Packagist")
   end
 
   describe "#package_link" do
-    let(:project) { create(:project, name: "foo", platform: described_class.formatted_name) }
-
     it "returns a link to project website" do
       expect(described_class.package_link(project)).to eq("https://packagist.org/packages/foo#")
     end

--- a/spec/models/package_manager/packagist_spec.rb
+++ b/spec/models/package_manager/packagist_spec.rb
@@ -76,7 +76,7 @@ describe PackageManager::Packagist do
                                                                                       "abandoned" => false,
                                                                                     }])
 
-      expect(described_class.deprecation_info("foo")).to eq({ is_deprecated: false, message: "" })
+      expect(described_class.deprecation_info(project)).to eq({ is_deprecated: false, message: "" })
     end
 
     it "return deprecated if 'abandoned' is true'" do
@@ -84,7 +84,7 @@ describe PackageManager::Packagist do
                                                                                       "abandoned" => true,
                                                                                     }])
 
-      expect(described_class.deprecation_info("foo")).to eq({ is_deprecated: true, message: "" })
+      expect(described_class.deprecation_info(project)).to eq({ is_deprecated: true, message: "" })
     end
 
     it "return deprecated if 'abandoned' is set to a replacement package'" do
@@ -92,7 +92,7 @@ describe PackageManager::Packagist do
                                                                                       "abandoned" => "use-this/package-instead",
                                                                                     }])
 
-      expect(described_class.deprecation_info("foo")).to eq({ is_deprecated: true, message: "Replacement: use-this/package-instead" })
+      expect(described_class.deprecation_info(project)).to eq({ is_deprecated: true, message: "Replacement: use-this/package-instead" })
     end
   end
 end

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -70,7 +70,7 @@ describe PackageManager::Pypi do
                                                                                  },
                                                                                })
 
-      expect(described_class.deprecation_info("foo")).to eq({ is_deprecated: false, message: nil })
+      expect(described_class.deprecation_info(project)).to eq({ is_deprecated: false, message: nil })
     end
 
     it "returns deprecated if last version is deprecated" do
@@ -82,7 +82,7 @@ describe PackageManager::Pypi do
                                                                                  },
                                                                                })
 
-      expect(described_class.deprecation_info("foo")).to eq({ is_deprecated: true, message: "This package is deprecated" })
+      expect(described_class.deprecation_info(project)).to eq({ is_deprecated: true, message: "This package is deprecated" })
     end
 
     it "returns not-deprecated if last version is a pre-release and deprecated" do
@@ -95,7 +95,7 @@ describe PackageManager::Pypi do
                                                                                  },
                                                                                })
 
-      expect(described_class.deprecation_info("foo")).to eq({ is_deprecated: false, message: nil })
+      expect(described_class.deprecation_info(project)).to eq({ is_deprecated: false, message: nil })
     end
 
     it "return not-deprecated if 'development status' is not 'inactive'" do
@@ -106,7 +106,7 @@ describe PackageManager::Pypi do
                                                                                  },
                                                                                })
 
-      expect(described_class.deprecation_info("foo")).to eq({ is_deprecated: false, message: nil })
+      expect(described_class.deprecation_info(project)).to eq({ is_deprecated: false, message: nil })
     end
 
     it "return deprecated if 'development status' is 'inactive'" do
@@ -117,7 +117,7 @@ describe PackageManager::Pypi do
                                                                                  },
                                                                                })
 
-      expect(described_class.deprecation_info("foo")).to eq({ is_deprecated: true, message: "Development Status :: 7 - Inactive" })
+      expect(described_class.deprecation_info(project)).to eq({ is_deprecated: true, message: "Development Status :: 7 - Inactive" })
     end
   end
 


### PR DESCRIPTION
`deprecation_info()` was occasionally failing for Cargo since 2021, which means we haven't been updating Cargo project statuses recently. This fixes that, which requires changing the arg for `deprecation_info(name)` to use `db_project` instead.

```
NoMethodErrorCheckStatusWorker@status
undefined method `name' for "tokio-io":String
```