### PR TITLE
Ignore GitHub hooks where the "sender" field is nil

### DIFF
--- a/app/services/github_hook_handler.rb
+++ b/app/services/github_hook_handler.rb
@@ -14,7 +14,7 @@ class GithubHookHandler
     when "issue_comment", "issues", "pull_request"
       return nil # noop
     when "push"
-      GithubHookWorker.perform_async(payload["repository"]["id"], payload["sender"]["id"])
+      GithubHookWorker.perform_async(payload["repository"]["id"], payload.dig("sender", "id"))
     when "public", "release", "repository"
       CreateRepositoryWorker.perform_async("GitHub", payload["repository"]["full_name"], nil)
     when "watch"

--- a/app/workers/github_hook_worker.rb
+++ b/app/workers/github_hook_worker.rb
@@ -4,6 +4,9 @@ class GithubHookWorker
   sidekiq_options queue: :critical, unique: :until_executed
 
   def perform(github_id, sender_id)
+    # some events like "push" may not always have the "sender" field, e.g. PR merge commits
+    return if sender_id.blank?
+
     Repository.update_from_hook(github_id, sender_id)
   end
 end

--- a/spec/workers/github_hook_worker_spec.rb
+++ b/spec/workers/github_hook_worker_spec.rb
@@ -12,4 +12,11 @@ describe GithubHookWorker do
     expect(Repository).to receive(:update_from_hook).with(github_id, sender_id)
     subject.perform(github_id, sender_id)
   end
+
+  it "should not update from hook if sender is missing" do
+    github_id = 1
+    sender_id = nil
+    expect(Repository).to_not receive(:update_from_hook)
+    subject.perform(github_id, sender_id)
+  end
 end


### PR DESCRIPTION
Occasionally we receive GH hook events like "push" where the "sender" field is missing, e.g. for PR merges it seems. The docs [say](https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#push) that "sender" is optional for these events, and we don't update the Repository unless we find the "sender"'s GH token anyway, so we can ignore these. 

Fixes https://app.bugsnag.com/tidelift/libraries-dot-io/errors/63e7fef4e6b45a000baf7d20