### PR TITLE
Silence exception backtraces in production.

### DIFF
--- a/app/models/package_manager/go.rb
+++ b/app/models/package_manager/go.rb
@@ -238,7 +238,7 @@ module PackageManager
         # We can get here from go modules that don't exist anymore, or having server troubles:
         # Fallback to the given name, cache the host as "bad" for a day,
         # log it (to analyze later) and notify us to be safe.
-        Rails.logger.info "[Caching unreacahble go host] name=#{name}"
+        Rails.logger.info "[Caching unreachable go host] name=#{name}"
         Rails.cache.write("unreachable-go-hosts:#{host}", true, ex: 1.day)
         Bugsnag.notify(e)
         [name]

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -119,4 +119,6 @@ Rails.application.configure do
       end
     end
   end
+  # Skip the noisy exception stack traces that DebugExceptions outputs, and check Bugsnag instead.
+  config.middleware.delete(ActionDispatch::DebugExceptions)
 end


### PR DESCRIPTION
This disables the ActionDispatch::DebugExceptions middleware in Rails, which prints out stacktraces whenever we encounter exceptions, e.g. ActiveRecord::RecordNotFound. Libraries uses lograge/JSON for log output, so these backtraces aren't in the right format anyway.

This should remove about ~10 extraneous log lines, in the case of ActiveRecord::RecordNotFound.