### PR TITLE
Remove the "active connection" log

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,8 +7,6 @@ class ApplicationController < ActionController::Base
 
   helper_method :current_user, :logged_in?, :logged_out?, :current_host, :formatted_host, :tidelift_flash_partial
 
-  before_action :log_active_connections
-
   around_action :trace_span
 
   private
@@ -17,12 +15,6 @@ class ApplicationController < ActionController::Base
     Datadog::Tracing.trace("endpoint##{controller_path}##{action_name}") do |_span, _trace|
       block.call
     end
-  end
-
-  def log_active_connections
-    # Only log 1 in 10 requests
-    return unless rand(10) == 5
-    Rails.logger.info("Active ActiveRecord connection count: #{ActiveRecord::Base.connection_pool.connections.size}")
   end
 
   def tidelift_flash_partial


### PR DESCRIPTION
This was added about 3 years ago in https://github.com/librariesio/libraries.io/pull/2632, but I don't think we've done much with it, and we can probably inspect this via DD now. It takes up about 150k lines per day.

Alternatively, I could just add this information to the request logs too, to take up less log room.