### PR TITLE
Add IP to trusted_proxies so we get the real IP in logs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -282,6 +282,7 @@ class ApplicationController < ActionController::Base
     payload[:rescued_error] = @rescued_error if @rescued_error
     payload[:current_user] = @current_user.id if @current_user
     payload[:remote_ip] = request.remote_ip
+    payload[:ip] = request.ip # TODO: remove this if these are always the same
     if @current_api_key
       payload[:api_key] = {
         api_key_id: @current_api_key&.id,

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -114,7 +114,7 @@ Rails.application.configure do
     {}.tap do |options|
       options[:params] = event.payload[:params].except(*params_exceptions)
       # extra keys that we want to log. Add these in the append_info_to_payload() overrided controller methods.
-      %i[rescued_error current_user remote_ip api_key github_event].each do |key|
+      %i[rescued_error current_user remote_ip ip api_key github_event].each do |key|
         options[key] = event.payload[key] if event.payload[key]
       end
     end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -121,4 +121,7 @@ Rails.application.configure do
   end
   # Skip the noisy exception stack traces that DebugExceptions outputs, and check Bugsnag instead.
   config.middleware.delete(ActionDispatch::DebugExceptions)
+
+  # GCP sends proxy IP as last value of X-Forwarded-For, so we need to ensure it gets filtered out for remote_ip() method
+  config.action_dispatch.trusted_proxies = ActionDispatch::RemoteIp::TRUSTED_PROXIES + ["35.244.128.241"]
 end


### PR DESCRIPTION
* adds libraries' IP to the trusted proxy list, so that `remote_ip()` filters it out from`X-Forwarded-For`
* also log `ip()`, to make sure it's correct (since that's the same value that rack-attack is using)