### PR TITLE
Disable dependents view & API access

### DIFF
--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -11,14 +11,16 @@ class Api::ProjectsController < Api::ApplicationController
   end
 
   def dependents
-    dependents = @project.dependent_projects
+    render json: { message: "Disabled for performance reasons" }
 
-    if params[:subset] == "name_only"
-      render json: paginate(dependents).order(name: :asc).pluck(:name).map { |n| { name: n } }
-    else
-      dependents = paginate(dependents).includes(:versions, :repository)
-      render json: dependents
-    end
+    #    dependents = @project.dependent_projects
+    #
+    #    if params[:subset] == "name_only"
+    #      render json: paginate(dependents).order(name: :asc).pluck(:name).map { |n| { name: n } }
+    #    else
+    #      dependents = paginate(dependents).includes(:versions, :repository)
+    #      render json: dependents
+    #    end
   end
 
   def dependent_repositories

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -55,21 +55,19 @@ class ProjectsController < ApplicationController
       end
     end
     find_version
-    @contributors = @project.contributors.order('count DESC').visible.limit(24).select(:host_type, :name, :login, :uuid)
+    @contributors = @project.contributors.order("count DESC").visible.limit(24).select(:host_type, :name, :login, :uuid)
     @owners = @project.registry_users.limit(24)
   end
 
-  def sourcerank
-
-  end
+  def sourcerank; end
 
   def about
     find_version
-    send_data render_to_string(:about, layout: false), filename: "#{@project.platform.downcase}-#{@project}.ABOUT", type: 'application/text', disposition: 'attachment'
+    send_data render_to_string(:about, layout: false), filename: "#{@project.platform.downcase}-#{@project}.ABOUT", type: "application/text", disposition: "attachment"
   end
 
   def dependents
-    @dependents = @project.dependent_projects.visible.paginate(page: page_number)
+    # @dependents = @project.dependent_projects.visible.paginate(page: page_number)
   end
 
   def dependent_repos

--- a/app/views/projects/_statistics.html.erb
+++ b/app/views/projects/_statistics.html.erb
@@ -21,7 +21,8 @@
       Dependent packages
     </dt>
     <dd class='col-xs-4'>
-      <%= link_to number_to_human(@project.dependents_count), project_dependents_path(@project.to_param) %>
+      <% #link_to number_to_human(@project.dependents_count), project_dependents_path(@project.to_param) %>
+      <%= number_to_human(@project.dependents_count) %>
     </dd>
   <% end %>
     <dt class='col-xs-8'>

--- a/app/views/projects/dependents.html.erb
+++ b/app/views/projects/dependents.html.erb
@@ -4,23 +4,5 @@
   <div class="pictogram pictogram-<%= @project.platform.downcase %>"></div>
   <%= link_to @project, project_path(@project.to_param) %>
 </h1>
-<hr>
-<% if @dependents.any? %>
-  <p class="lead"><strong><%= @dependents.total_entries %></strong> <%= 'packages'.pluralize(@dependents.total_entries) %> depend on <%= link_to @project, project_path(@project.to_param) %>:</p>
-<% end %>
 
-<div class="row">
-  <div class="col-sm-8">
-    <% if @dependents.any? %>
-      <%= render @dependents %>
-      <%= will_paginate @dependents, page_links: false %>
-    <% else %>
-      <p>
-        No packages found, go back to <%= link_to @project, project_path(@project.to_param) %>.
-      </p>
-    <% end %>
-  </div>
-  <div class="col-sm-4">
-
-  </div>
-</div>
+<h2>This view is currently disabled for performance reasons.</h2>

--- a/app/views/projects/top_dependent_projects.html.erb
+++ b/app/views/projects/top_dependent_projects.html.erb
@@ -1,8 +1,10 @@
   <% @top_dependent_projects = @project.dependent_projects.limit(10) %>
   <% if @top_dependent_projects.length > 0 %>
+    <% if false %>
     <h4 data-ga-tracked-el='dependent-projects'>
       <%= link_to "Dependent Packages", project_dependents_path(@project.to_param) %>
     </h4>
+    <% end %>
     <dl class='row'>
       <% if @top_dependent_projects.length > 0 %>
         <% @top_dependent_projects.each do |project| %>

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -37,7 +37,8 @@ describe "Api::ProjectsController" do
     end
   end
 
-  describe "GET /api/:platform/:name/dependents", type: :request do
+  # Disabled for performance reasons
+  xdescribe "GET /api/:platform/:name/dependents", type: :request do
     it "renders successfully" do
       get "/api/#{dependent_project.platform}/#{dependent_project.name}/dependents"
       expect(response).to have_http_status(:success)


### PR DESCRIPTION
Gathering dependents details about a package is currently way too slow to be used practically. How we gather and present this data will need to be rethought in order to do it efficiently.

![Screenshot_20230414_095928](https://user-images.githubusercontent.com/35267397/232066468-a41b75d1-0c9a-49bc-bb6c-a43c5b0df590.png)
![Screenshot_20230414_095903](https://user-images.githubusercontent.com/35267397/232066470-7a3fa94f-bfb3-4ea8-a64a-c3261dd6992e.png)
