### PR TITLE
RackAttack updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -399,8 +399,8 @@ GEM
     puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.0)
-    rack (2.2.4)
-    rack-attack (6.0.0)
+    rack (2.2.6.4)
+    rack-attack (6.6.1)
       rack (>= 1.0, < 3)
     rack-attack-rate-limit (1.1.0)
       rack

--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -1,32 +1,34 @@
 # frozen_string_literal: true
 
-class Rack::Attack::Request < ::Rack::Request
-  def valid_key
-    return @valid_key if defined? @valid_key
+class Rack::Attack
+  class Request < ::Rack::Request
+    def valid_key
+      return @valid_key if defined? @valid_key
 
-    @valid_key = ApiKey.active.find_by_access_token(params["api_key"])
+      @valid_key = ApiKey.active.find_by_access_token(params["api_key"])
+    end
   end
-end
 
-Rack::Attack.blocklist("invalid api key") do |req|
-  !req.valid_key if req.params["api_key"].present?
-end
-
-limit_proc = proc do |req|
-  if req.params["api_key"].present?
-    req.valid_key.rate_limit
-  else
-    10 # req/min for anonymous users
+  blocklist("invalid api key") do |req|
+    !req.valid_key if req.params["api_key"].present?
   end
-end
 
-Rack::Attack.throttle('api', limit: limit_proc, period: 1.minute) do |req|
-  if req.path.match(/^\/api\/.+/) && !req.path.match(/^\/api\/bower-search/)
-    req.params['api_key'] || req.ip
+  limit_proc = proc do |req|
+    if req.params["api_key"].present?
+      req.valid_key.rate_limit
+    else
+      10 # req/min for anonymous users
+    end
   end
-end
 
-# throttle scraping
-Rack::Attack.throttle('scrapers', limit: 30, period: 5.minutes) do |req|
-  req.ip if req.user_agent && req.user_agent.match(/Scrapy.*/)
+  throttle('api', limit: limit_proc, period: 1.minute) do |req|
+    if req.path.match(/^\/api\/.+/) && !req.path.match(/^\/api\/bower-search/)
+      req.params['api_key'] || req.ip
+    end
+  end
+
+  # throttle scraping
+  throttle('scrapers', limit: 30, period: 5.minutes) do |req|
+    req.ip if req.user_agent && req.user_agent.match(/Scrapy.*/)
+  end
 end

--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -32,3 +32,5 @@ class Rack::Attack
     req.ip if req.user_agent && req.user_agent.match(/Scrapy.*/)
   end
 end
+
+require "subscribers/rack-attack"

--- a/lib/subscribers/rack-attack.rb
+++ b/lib/subscribers/rack-attack.rb
@@ -1,0 +1,8 @@
+ActiveSupport::Notifications.subscribe(/rack_attack/) do |name, start, finish, request_id, payload|
+  req = payload[:request]
+  match = req.env["rack.attack.matched"]
+  match_type = req.env["rack.attack.match_type"]
+  match_discriminator = req.env["rack.attack.match_discriminator"].to_s[0, 16] # truncate, could be an api key
+
+  Rails.logger.info "[RACK_ATTACK] method=#{req.request_method} path=#{req.fullpath} match_type=#{match_type} match=#{match} match_discriminator=#{match_discriminator} request_id=#{request_id} ip=#{req.ip}"
+end


### PR DESCRIPTION
* update `rack-attack` to latest version
* minor change to the format of the rack-attack initializer
* adds an `ActiveSupport::Notifications` subscriber that will log whenever a rack-attack match is made, e.g.:

```[RACK_ATTACK] method=HEAD path=/api/foo match_type=throttle match=api match_discriminator=127.0.0.1 request_id=dbc6380acd1bf84e81c3 ip=127.0.0.1```
