### PR TITLE
Rack::Attack: use ActionDispatch's remote_ip instead of Rack's ip

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -281,8 +281,9 @@ class ApplicationController < ActionController::Base
     super
     payload[:rescued_error] = @rescued_error if @rescued_error
     payload[:current_user] = @current_user.id if @current_user
-    payload[:remote_ip] = request.remote_ip
-    payload[:ip] = request.ip # TODO: remove this if these are always the same
+    # Ae've added the load balancer ip to ActionDispatch trusted_proxies, but not Rack::Request.ip_filter, 
+    # so use ActionDispatch's remote_ip instead of Rack's ip.
+    payload[:remote_ip] = request.remote_ip 
     if @current_api_key
       payload[:api_key] = {
         api_key_id: @current_api_key&.id,

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -281,7 +281,7 @@ class ApplicationController < ActionController::Base
     super
     payload[:rescued_error] = @rescued_error if @rescued_error
     payload[:current_user] = @current_user.id if @current_user
-    # Ae've added the load balancer ip to ActionDispatch trusted_proxies, but not Rack::Request.ip_filter, 
+    # We've added our IP to ActionDispatch trusted_proxies, but not Rack::Request.ip_filter, 
     # so use ActionDispatch's remote_ip instead of Rack's ip.
     payload[:remote_ip] = request.remote_ip 
     if @current_api_key

--- a/lib/subscribers/rack-attack.rb
+++ b/lib/subscribers/rack-attack.rb
@@ -4,5 +4,5 @@ ActiveSupport::Notifications.subscribe(/rack_attack/) do |name, start, finish, r
   match_type = req.env["rack.attack.match_type"]
   match_discriminator = req.env["rack.attack.match_discriminator"].to_s[0, 16] # truncate, could be an api key
 
-  Rails.logger.info "[RACK_ATTACK] method=#{req.request_method} path=#{req.fullpath} match_type=#{match_type} match=#{match} match_discriminator=#{match_discriminator} request_id=#{request_id} ip=#{req.ip}"
+  Rails.logger.info "[RACK_ATTACK] method=#{req.request_method} path=#{req.fullpath} match_type=#{match_type} match=#{match} match_discriminator=#{match_discriminator} request_id=#{request_id} ip=#{req.remote_ip}"
 end

--- a/lib/subscribers/rack-attack.rb
+++ b/lib/subscribers/rack-attack.rb
@@ -4,5 +4,5 @@ ActiveSupport::Notifications.subscribe(/rack_attack/) do |name, start, finish, r
   match_type = req.env["rack.attack.match_type"]
   match_discriminator = req.env["rack.attack.match_discriminator"].to_s[0, 16] # truncate, could be an api key
 
-  Rails.logger.info "[RACK_ATTACK] method=#{req.request_method} path=#{req.fullpath} match_type=#{match_type} match=#{match} match_discriminator=#{match_discriminator} request_id=#{request_id} ip=#{req.remote_ip}"
+  Rails.logger.info "[RACK_ATTACK] method=#{req.request_method} path=#{req.fullpath} match_type=#{match_type} match=#{match} match_discriminator=#{match_discriminator} request_id=#{request_id} remote_ip=#{req.remote_ip}"
 end


### PR DESCRIPTION
Instead of adding our proxy to Rack's ip_filter to fix `request.ip`, we can just use ActionDispatch's algorithm via the `remote_ip()` method.