### PR TITLE
Add 30 second statement timeout to db

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -20,6 +20,8 @@ default: &default
   # For details on connection pooling, see rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: 5
+  variables:
+    statement_timeout: 30000  # 30 second query timeout
 
 development:
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -21,7 +21,7 @@ default: &default
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: 5
   variables:
-    statement_timeout: 30000  # 30 second query timeout
+    statement_timeout: 300000  # 5 min query timeout
 
 development:
   <<: *default


### PR DESCRIPTION
Query timeouts would now surface as this error: 

```
> ActiveRecord::Base.connection.exec_query("select 1 from pg_sleep(50000);")
ActiveRecord::QueryCanceled: PG::QueryCanceled: ERROR:  canceling statement due to statement timeout
: select 1 from pg_sleep(50000); /*application:Libraries*/
```