### PR TITLE
Adds ActiveRecord::Base.connection.with_statement_timeout

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -374,7 +374,9 @@ class Project < ApplicationRecord
   def set_dependents_count
     return if destroyed?
 
-    new_dependents_count = dependents.joins(:version).pluck(Arel.sql("DISTINCT versions.project_id")).count
+    new_dependents_count = ActiveRecord::Base.connection.with_statement_timeout(10.minutes.to_i) do
+      dependents.joins(:version).pluck(Arel.sql("DISTINCT versions.project_id")).count
+    end
     new_dependent_repos_count = dependent_repos_fast_count
 
     updates = {}

--- a/config/initializers/active_record.rb
+++ b/config/initializers/active_record.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module WithStatementTimeout
+    # Use this for egregious query plans that sometimes exceed our default db statement timeout
+    def with_statement_timeout(seconds)
+      raise "Must pass an integer (in seconds) of timeout" unless seconds.is_a?(Integer)
+      ActiveRecord::Base.connection.execute("SET statement_timeout = '#{seconds * 1000}';")
+      yield
+    ensure
+      ActiveRecord::Base.connection.execute("SET statement_timeout = '#{ActiveRecord::Base.configurations.dig(Rails.env, "variables", "statement_timeout")}';")
+    end
+  end
+end
+
+ActiveRecord::ConnectionAdapters::AbstractAdapter.prepend(ActiveRecord::WithStatementTimeout)

--- a/spec/ext/active_record_spec.rb
+++ b/spec/ext/active_record_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ActiveRecord do
+  describe "with_statement_timeout" do
+    it "should run the block with a temporary statement_timeout" do
+      before_timeout = ActiveRecord::Base.connection.exec_query("SHOW statement_timeout;").first["statement_timeout"]
+      temporary_timeout = ActiveRecord::Base.connection.with_statement_timeout(1234) do
+        ActiveRecord::Base.connection.exec_query("SHOW statement_timeout;").first["statement_timeout"]
+      end
+      after_timeout = ActiveRecord::Base.connection.exec_query("SHOW statement_timeout;").first["statement_timeout"]
+
+      expect(after_timeout).to eq(before_timeout)
+      expect(temporary_timeout).to eq("1234s")
+    end
+  end
+end


### PR DESCRIPTION
Now that we have a db query timeout, there are places where we might want to temporarily extend the timeout until we can optimize the query, e.g.:

``` ruby
> ActiveRecord::Base.connection.exec_query("SHOW statement_timeout").first["statement_timeout"]
=> "5min"
> ActiveRecord::Base.connection.with_statement_timeout(10.minutes) do
>   ActiveRecord::Base.connection.exec_query("SHOW statement_timeout").first["statement_timeout"]
 end  
=> "10min"
> ActiveRecord::Base.connection.exec_query("SHOW statement_timeout").first["statement_timeout"]
=> "5min"
```