### PR TITLE
Some improvements to with_statement_timeout

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -374,7 +374,7 @@ class Project < ApplicationRecord
   def set_dependents_count
     return if destroyed?
 
-    new_dependents_count = ActiveRecord::Base.connection.with_statement_timeout(10.minutes.to_i) do
+    new_dependents_count = ActiveRecord::Base.connection.with_statement_timeout(20.minutes.to_i) do
       dependents.joins(:version).pluck(Arel.sql("DISTINCT versions.project_id")).count
     end
     new_dependent_repos_count = dependent_repos_fast_count

--- a/config/initializers/active_record.rb
+++ b/config/initializers/active_record.rb
@@ -6,11 +6,9 @@ module ActiveRecord
     # the current connection, so the rest of the connection pool connections will remain the default.
     # Example: ActiveRecord::Base.connection.with_statement_timeout(500_000) { |conn| puts conn.get_statement_timeout }
     def with_statement_timeout(seconds)
-      transaction do
-        raise "Must pass an integer (in seconds) of timeout" unless seconds.is_a?(Integer)
-        execute("SET statement_timeout = '#{seconds * 1000}';")
-        yield(self)
-      end
+      raise "Must pass an integer (in seconds) of timeout" unless seconds.is_a?(Integer)
+      execute("SET statement_timeout = '#{seconds * 1000}';")
+      yield(self)
     ensure
       execute("SET statement_timeout = '#{ActiveRecord::Base.configurations.dig(Rails.env, "variables", "statement_timeout")}';")
     end


### PR DESCRIPTION
* cleanup the `with_statement_timeout` code a bit, and pass the connection as an arg to the block
* adds `get_statement_timeout` to make verifying timeout easier
* adds a spec to confirm that `with_statement_timeout` doesn't affect other connections' timeouts
* extend the timeout of a query that seems occasionally problematic