### PR TITLE
Fix retrieval of project status

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -618,20 +618,16 @@ class Project < ApplicationRecord
       update_attribute(:status, "Removed")
     elsif platform.downcase != "packagist" && [400, 404, 410].include?(response.response_code)
       update_attribute(:status, "Removed")
-    elsif platform.downcase == "clojars" && response.response_code == 404
-      update_attribute(:status, "Removed")
-    elsif platform.downcase == "pypi" && response.response_code == 404
-      update_attribute(:status, "Removed")
     elsif can_have_entire_package_deprecated?
       result = platform_class.deprecation_info(self)
       if result[:is_deprecated]
         update_attribute(:status, "Deprecated")
         update_attribute(:deprecation_reason, result[:message])
       else # in case package was accidentally marked as deprecated (their logic or ours), mark it as not deprecated
-        update_attribute(:status, '')
+        update_attribute(:status, nil)
         update_attribute(:deprecation_reason, nil)
       end
-    elsif deprecated_or_removed
+    elsif deprecated_or_removed # if package is already deprecated or removed and isn't anymore, remove status
       update_attribute(:status, nil)
     end
   end

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+PLATFORMS_FOR_STATUS_CHECKS = ['pypi', 'npm', 'rubygems', 'packagist', 'cpan', 'clojars', 'cocoapods', 'hackage', 'cran', 'pub', 'elm', 'dub']
+
 namespace :projects do
   desc 'Sync projects'
   task sync: :environment do
@@ -23,8 +26,7 @@ namespace :projects do
   desc 'Check status of projects'
   task check_status: :environment do
     exit if ENV['READ_ONLY'].present?
-    ['pypi', 'npm', 'rubygems', 'packagist', 'cpan', 'clojars', 'cocoapods',
-    'hackage', 'cran', 'pub', 'elm', 'dub'].each do |platform|
+    PLATFORMS_FOR_STATUS_CHECKS.each do |platform|
       Project.platform(platform).not_removed.where('projects.updated_at < ?', 1.week.ago).select('id').find_each do |project|
         CheckStatusWorker.perform_async(project.id)
       end
@@ -57,8 +59,7 @@ namespace :projects do
   task check_removed_status: :environment do
     exit if ENV['READ_ONLY'].present?
     # Check if removed/deprecated projects are still deprecated/removed
-    ['pypi', 'npm', 'rubygems', 'packagist', 'cpan', 'clojars', 'cocoapods',
-    'hackage', 'cran', 'pub', 'elm', 'dub'].each do |platform|
+    PLATFORMS_FOR_STATUS_CHECKS.each do |platform|
       Project.platform(platform).removed_or_deprecated.select('id').find_each do |project|
         CheckStatusWorker.perform_async(project.id, true)
       end

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -23,7 +23,7 @@ namespace :projects do
   desc 'Check status of projects'
   task check_status: :environment do
     exit if ENV['READ_ONLY'].present?
-    ['npm', 'rubygems', 'packagist', 'nuget', 'cpan', 'clojars', 'cocoapods',
+    ['pypi', 'npm', 'rubygems', 'packagist', 'cpan', 'clojars', 'cocoapods',
     'hackage', 'cran', 'pub', 'elm', 'dub'].each do |platform|
       Project.platform(platform).not_removed.where('projects.updated_at < ?', 1.week.ago).select('id').find_each do |project|
         CheckStatusWorker.perform_async(project.id)

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -262,7 +262,7 @@ describe Project, type: :model do
     end
 
     context "some of project deprecated" do
-      let!(:project) { Project.create(platform: "NPM", name: "react", status: "") }
+      let!(:project) { Project.create(platform: "NPM", name: "react", status: nil) }
 
       it "should use the result of entire_package_deprecation_info" do
         VCR.use_cassette("project/check_status/react") do
@@ -270,7 +270,7 @@ describe Project, type: :model do
 
           project.reload
 
-          expect(project.status).to eq("")
+          expect(project.status).to eq(nil)
         end
       end
     end
@@ -284,7 +284,7 @@ describe Project, type: :model do
 
           project.reload
 
-          expect(project.status).to eq("")
+          expect(project.status).to eq(nil)
           expect(project.deprecation_reason).to eq(nil)
         end
       end


### PR DESCRIPTION
[Story](https://app.shortcut.com/tidelift/story/32776/fix-libraries-io-retrieval-of-project-status)

[Related PR for infra](https://github.com/tidelift/infra/pull/385)

This PR fixes `Project#check_status` and the `projects:check_status` rake task (which is being used in a new cron job in the related infra PR). We already regularly check removed projects to see if they've been reintroduced [here](https://github.com/tidelift/infra/blob/main/libraries-kube/cronjobs/libraries-projects-check-removed-status.yaml). This change is to do the opposite and check whether projects that exist have been removed.