### PR TITLE
Fix npm deprecation detection when there's no published versions

### DIFF
--- a/app/models/package_manager/npm.rb
+++ b/app/models/package_manager/npm.rb
@@ -42,7 +42,7 @@ module PackageManager
 
     def self.deprecation_info(db_project)
       versions = project(db_project.name)["versions"].values
-      is_deprecated = versions.all? { |version| !!version["deprecated"] }
+      is_deprecated = versions.any? && versions.all? { |version| !!version["deprecated"] }
       message = is_deprecated ? versions.last["deprecated"] : nil
 
       {

--- a/spec/models/package_manager/npm_spec.rb
+++ b/spec/models/package_manager/npm_spec.rb
@@ -34,29 +34,46 @@ describe PackageManager::NPM do
     end
   end
 
-  describe '#deprecation_info' do
-    it "returns not-deprecated if any version isn't deprecated" do
-      expect(PackageManager::NPM).to receive(:project).with('foo').and_return({
-        "versions" => {
+  describe "#deprecation_info" do
+    subject(:deprecation_info) { described_class.deprecation_info(project) }
+    before do
+      expect(PackageManager::NPM).to receive(:project).with("foo").and_return({ "versions" => version_data })
+    end
+
+    context "any version isn't deprecated" do
+      let(:version_data) do
+        {
           "0.0.1" => { "deprecated" => "This package is deprecated" },
           "0.0.2" => { "deprecated" => "This package is deprecated" },
           "0.0.3" => {},
         }
-      })
+      end
 
-      expect(described_class.deprecation_info(project)).to eq({is_deprecated: false, message: nil})
+      it "project not considered deprecated" do
+        expect(deprecation_info).to eq({ is_deprecated: false, message: nil })
+      end
     end
 
-    it "returns deprecated if all versions are deprecated" do
-      expect(PackageManager::NPM).to receive(:project).with('foo').and_return({
-        "versions" => {
+    context "all versions deprecated" do
+      let(:version_data) do
+        {
           "0.0.1" => { "deprecated" => "This package is deprecated" },
           "0.0.2" => { "deprecated" => "This package is deprecated" },
           "0.0.3" => { "deprecated" => "This package is deprecated" },
         }
-      })
+      end
 
-      expect(described_class.deprecation_info(project)).to eq({is_deprecated: true, message: "This package is deprecated"})
+      it "project considered deprecated" do
+        expect(deprecation_info).to eq({ is_deprecated: true, message: "This package is deprecated" })
+      end
+    end
+
+    context "no published versions" do
+      let(:version_data) { {} }
+
+      it "project not considered deprecated" do
+        expect(deprecation_info).to eq({ is_deprecated: false, message: nil })
+      end
     end
   end
 end


### PR DESCRIPTION
Missed this case before, but npm packages may in fact have 0 versions. 

[Related bugsnag](https://app.bugsnag.com/tidelift/libraries-dot-io/errors/6449ef47ba806a00087c3d74?event_id=6449ef4700bbaa8be9b90000&i=sk&m=nw)