### PR TITLE
NPM deprecation fixes part deux

### DIFF
--- a/app/models/package_manager/npm.rb
+++ b/app/models/package_manager/npm.rb
@@ -41,7 +41,7 @@ module PackageManager
     end
 
     def self.deprecation_info(db_project)
-      versions = project(db_project.name)["versions"].values
+      versions = project(db_project.name)["versions"]&.values || []
       is_deprecated = versions.any? && versions.all? { |version| !!version["deprecated"] }
       message = is_deprecated ? versions.last["deprecated"] : nil
 


### PR DESCRIPTION
In addition to being included but empty, the `versions` data may just not be present at all

[Bugsnag](https://app.bugsnag.com/tidelift/libraries-dot-io/errors/643606b6c120cb000af4e770)