### PR TITLE
chore: Update project:check_status to take in processing configurations

### DIFF
--- a/db/migrate/20230502182027_add_index_to_projects_updated_at.rb
+++ b/db/migrate/20230502182027_add_index_to_projects_updated_at.rb
@@ -1,0 +1,7 @@
+class AddIndexToProjectsUpdatedAt < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :projects, :updated_at, algorithm: :concurrently unless index_exists?(:projects, :updated_at)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_17_210423) do
+ActiveRecord::Schema.define(version: 2023_05_02_182027) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"


### PR DESCRIPTION
# What this PR does
- Adds back the missing project.updated_at index
- Updates the project:check_status to take in processing configs so we can process packages in smaller chunks
- Prioritize the projects that haven't been touched in the longest time first for getting refreshed