### PR TITLE
chore: [sc-33382] Remove the deprecated_or_removed param from Project

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -620,6 +620,8 @@ class Project < ApplicationRecord
         update_attribute(:status, nil)
         update_attribute(:deprecation_reason, nil)
       end
+    elsif status == "Removed"
+      update_attribute(:status, nil)
     end
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -620,7 +620,7 @@ class Project < ApplicationRecord
         update_attribute(:status, nil)
         update_attribute(:deprecation_reason, nil)
       end
-    elsif status == "Removed"
+    else
       update_attribute(:status, nil)
     end
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -605,7 +605,7 @@ class Project < ApplicationRecord
   # NB deprecated_or_removed most likely exists so that we
   # can explicitly reset the status to nil in certain cases. We probably
   # don't always want to because Repository#check_status can overwrite Project#status.
-  def check_status(deprecated_or_removed = false)
+  def check_status
     url = platform_class.check_status_url(self)
     return if url.blank?
 
@@ -623,8 +623,6 @@ class Project < ApplicationRecord
         update_attribute(:status, nil)
         update_attribute(:deprecation_reason, nil)
       end
-    elsif deprecated_or_removed # if package is already deprecated or removed and isn't anymore, remove status
-      update_attribute(:status, nil)
     end
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -602,9 +602,6 @@ class Project < ApplicationRecord
     ProjectDependentRepository.where(project_id: id).count
   end
 
-  # NB deprecated_or_removed most likely exists so that we
-  # can explicitly reset the status to nil in certain cases. We probably
-  # don't always want to because Repository#check_status can overwrite Project#status.
   def check_status
     url = platform_class.check_status_url(self)
     return if url.blank?

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -328,23 +328,22 @@ class Repository < ApplicationRecord
     nil
   end
 
-  def check_status(removed = false)
-    Repository.check_status(host_type, full_name, removed)
+  def check_status
+    Repository.check_status(host_type, full_name)
   end
 
-  def self.check_status(host_type, repo_full_name, removed = false)
+  def self.check_status(host_type, repo_full_name)
     domain = RepositoryHost::Base.domain(host_type)
     response = Typhoeus.head("#{domain}/#{repo_full_name}")
 
     if response.response_code == 404
       repo = Repository.includes(:projects).find_by_full_name(repo_full_name)
       if repo
-        status = removed ? nil : "Removed"
-        repo.update_attribute(:status, status) unless repo.private?
+        repo.update_attribute(:status, "Removed") unless repo.private?
         repo.projects.each do |project|
           next unless %w[bower go elm alcatraz julia nimble].include?(project.platform.downcase)
 
-          project.update_attribute(:status, status)
+          project.update_attribute(:status, "Removed")
         end
       end
     end

--- a/app/workers/check_repo_status_worker.rb
+++ b/app/workers/check_repo_status_worker.rb
@@ -4,7 +4,7 @@ class CheckRepoStatusWorker
   include Sidekiq::Worker
   sidekiq_options queue: :status, unique: :until_executed
 
-  def perform(host_type, repo_full_name, removed = false)
-    Repository.check_status(host_type, repo_full_name, removed)
+  def perform(host_type, repo_full_name)
+    Repository.check_status(host_type, repo_full_name)
   end
 end

--- a/app/workers/check_status_worker.rb
+++ b/app/workers/check_status_worker.rb
@@ -4,7 +4,7 @@ class CheckStatusWorker
   include Sidekiq::Worker
   sidekiq_options queue: :status, unique: :until_executed
 
-  def perform(project_id, deprecated_or_removed = false)
-    Project.find_by_id(project_id).try(:check_status, deprecated_or_removed)
+  def perform(project_id)
+    Project.find_by_id(project_id).try(:check_status)
   end
 end

--- a/spec/fixtures/vcr_cassettes/project/check_status/rails.yml
+++ b/spec/fixtures/vcr_cassettes/project/check_status/rails.yml
@@ -75,4 +75,2724 @@ http_interactions:
       string: This rubygem could not be found.
     http_version:
   recorded_at: Fri, 12 May 2023 18:45:18 GMT
+- request:
+    method: get
+    uri: https://rubygems.org/api/v1/versions/rails.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Last-Modified:
+      - Mon, 13 Mar 2023 18:53:44 GMT
+      Cache-Control:
+      - max-age=60, public
+      Content-Security-Policy:
+      - default-src 'self'; font-src 'self' https://fonts.gstatic.com; img-src 'self'
+        https://secure.gaug.es https://gravatar.com https://www.gravatar.com https://secure.gravatar.com
+        https://*.fastly-insights.com https://avatars.githubusercontent.com; object-src
+        'none'; script-src 'self' https://secure.gaug.es https://www.fastly-insights.com
+        'nonce-'; style-src 'self' https://fonts.googleapis.com; connect-src 'self'
+        https://s3-us-west-2.amazonaws.com/rubygems-dumps/ https://*.fastly-insights.com
+        https://fastly-insights.com https://api.github.com http://localhost:*; form-action
+        'self' https://github.com/login/oauth/authorize; frame-ancestors 'self'; report-uri
+        https://csp-report.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pub852fa3e2312391fafa5640b60784e660&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=service%3Arubygems.org%2Cversion%3A4d14d0ea76b245de7e23151d118aa43c7e889110%2Cenv%3Aproduction%2Ctrace_id%3A735925964818907718
+      X-Request-Id:
+      - faa10ed1-7805-47e0-8db4-faa331d19207
+      X-Runtime:
+      - '0.114117'
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Backend:
+      - F_Rails 34.211.73.229:443
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Mon, 15 May 2023 22:37:09 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '0'
+      X-Served-By:
+      - cache-bos4669-BOS
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1684190229.017567,VS0,VE692
+      Vary:
+      - Accept-Encoding
+      Etag:
+      - '"ad603b576042266c34153303824fe08d"'
+      Server:
+      - RubyGems.org
+      Content-Length:
+      - '308112'
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"authors":"David Heinemeier Hansson","built_at":"2023-03-13T00:00:00.000Z","created_at":"2023-03-13T18:53:43.517Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2267681,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.4.3","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.4.3","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.4.3/","rubygems_mfa_required":"true"},"number":"7.0.4.3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5b675b237abb7328020002d06cc6c9003a09cde4b4774f989bfa440c6e93e2ed"},{"authors":"David
+        Heinemeier Hansson","built_at":"2023-01-25T00:00:00.000Z","created_at":"2023-01-25T03:14:29.671Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2048405,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.4.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.4.2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.4.2/","rubygems_mfa_required":"true"},"number":"7.0.4.2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0c2e25beb5aa029a2b5ffe354ac76f61d49347c37e3422231666c56fa5c78435"},{"authors":"David
+        Heinemeier Hansson","built_at":"2023-01-17T00:00:00.000Z","created_at":"2023-01-17T18:55:33.129Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":633778,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.4.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.4.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.4.1/","rubygems_mfa_required":"true"},"number":"7.0.4.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"cee99186c0450fa500fb7aa114e504b3061e0508f3cd0f2310541b07547dc2f7"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-09-09T00:00:00.000Z","created_at":"2022-09-09T18:42:56.698Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":4296603,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.4","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.4","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.4/","rubygems_mfa_required":"true"},"number":"7.0.4","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e1d2dabe57de44b4baee978426aba811858c5e9ad0e258fc09157361937f5f31"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-07-12T00:00:00.000Z","created_at":"2022-07-12T17:31:41.727Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2952909,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.3.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.3.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.3.1/","rubygems_mfa_required":"true"},"number":"7.0.3.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0b771be1bf5c5a54c4d8118355b3d8d9a8d823e82a90c0573b48d14262254a8c"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-05-09T00:00:00.000Z","created_at":"2022-05-09T13:41:57.714Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2722131,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.3","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.3","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.3/","rubygems_mfa_required":"true"},"number":"7.0.3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"7e0c3e1a97551eef4ae6d7e7fdb5109f72f6a451deab9a26fb6a6ab8ff82ae1d"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-04-26T00:00:00.000Z","created_at":"2022-04-26T19:33:25.138Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":510226,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.2.4","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.2.4","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.2.4/","rubygems_mfa_required":"true"},"number":"7.0.2.4","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5eee151313cdb86365bdeb65f61ad012c2fa2e86df03b0cf4484a2e5eee5a601"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-03-08T00:00:00.000Z","created_at":"2022-03-08T17:50:52.496Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1268338,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.2.3","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.2.3","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.2.3/","rubygems_mfa_required":"true"},"number":"7.0.2.3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ee4e24075c72dec6e02e3fcddec86399c2b4eb0466efe4ccb5f78f96d3daa283"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-02-11T00:00:00.000Z","created_at":"2022-02-11T19:44:19.017Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":831795,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.2.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.2.2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.2.2/","rubygems_mfa_required":"true"},"number":"7.0.2.2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3393e21131e2120a42cf634416033e587b5dfdccdc84d1a2d2c176b847f6f17f"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-02-11T00:00:00.000Z","created_at":"2022-02-11T18:19:21.363Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1763,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.2.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.2.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.2.1/","rubygems_mfa_required":"true"},"number":"7.0.2.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"92110c43177d167f354200eef2154d33c3c8e551cfa385b724a6dc714283176e"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-02-08T00:00:00.000Z","created_at":"2022-02-08T23:13:21.486Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":102663,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.2/","rubygems_mfa_required":"true"},"number":"7.0.2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ef82869adc909aa7f318519d6b3e5c930a29f507e730e8b5af532d8f14d2ab72"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-01-06T00:00:00.000Z","created_at":"2022-01-06T21:55:27.202Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":535420,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.1/","rubygems_mfa_required":"true"},"number":"7.0.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3f03f0a134807e99ae587206d25d199ed4f6f715818ef1c1ac618c845487d8f9"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-12-15T00:00:00.000Z","created_at":"2021-12-15T23:45:57.959Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":252359,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.0","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.0","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.0/","rubygems_mfa_required":"true"},"number":"7.0.0","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"1bf449e7b3e41218e5aa31e0dbf771d1a777914dd2c8861738c8a6affdcc3d5e"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-12-14T00:00:00.000Z","created_at":"2021-12-14T23:04:49.725Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":6863,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.0.rc3","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.0.rc3","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.0.rc3/","rubygems_mfa_required":"true"},"number":"7.0.0.rc3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"362322691e482200f1fe8db7ef01eeee08054ec2e333fce419aea7295ad44a36"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-12-14T00:00:00.000Z","created_at":"2021-12-14T19:40:58.273Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1140,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.0.rc2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.0.rc2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.0.rc2/","rubygems_mfa_required":"true"},"number":"7.0.0.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"aae062d30add20779437e11ef9c22cf8ab76c685f0fbcfac477519b8fc76e207"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-12-06T00:00:00.000Z","created_at":"2021-12-06T21:33:14.325Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":17612,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.0.rc1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.0.rc1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.0.rc1/","rubygems_mfa_required":"true"},"number":"7.0.0.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"d7a13a11304e7aa861182238660acf1f71ef234163fcc5b123f3bf50e4fd82ca"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-09-15T00:00:00.000Z","created_at":"2021-09-15T23:16:26.580Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":69242,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.0.alpha2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.0.alpha2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.0.alpha2/"},"number":"7.0.0.alpha2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"3b86ad7ded351a824c8a831473670f0615f4c4f061ae11d3adbf804cdd24e096"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-09-15T00:00:00.000Z","created_at":"2021-09-15T21:58:08.365Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1333,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.0.alpha1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.0.alpha1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.0.alpha1/"},"number":"7.0.0.alpha1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"ae683afdab830e44900fc90a21335b6ac1a94c2a275be1f62ec6699ca6e5988b"},{"authors":"David
+        Heinemeier Hansson","built_at":"2023-03-13T00:00:00.000Z","created_at":"2023-03-13T18:48:59.163Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2359461,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.7.3","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.7.3","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.7.3/","rubygems_mfa_required":"true"},"number":"6.1.7.3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d27a251e2a55e1951cd676c19e51d359945ecd4bbef1d88cb97c9b3e1b3e9a1d"},{"authors":"David
+        Heinemeier Hansson","built_at":"2023-01-25T00:00:00.000Z","created_at":"2023-01-25T03:23:38.693Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3282602,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.7.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.7.2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.7.2/","rubygems_mfa_required":"true"},"number":"6.1.7.2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d50796f4106fe1793e048e80e11bc9aee4af1674c94a24ebe7f7b411217befac"},{"authors":"David
+        Heinemeier Hansson","built_at":"2023-01-17T00:00:00.000Z","created_at":"2023-01-17T18:54:36.574Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1090402,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.7.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.7.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.7.1/","rubygems_mfa_required":"true"},"number":"6.1.7.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ad209c9822b494e0f0ff9faa68381bf209e4b7ca7d2e3e65f08a842e750163f7"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-09-09T00:00:00.000Z","created_at":"2022-09-09T18:39:14.216Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3650462,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.7","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.7","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.7/","rubygems_mfa_required":"true"},"number":"6.1.7","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"6e3b9226fb9f82d916990b7da9a121191890ed20ac49f40e902d4e6952308006"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-07-12T00:00:00.000Z","created_at":"2022-07-12T17:29:59.374Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":8125411,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.6.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.6.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.6.1/","rubygems_mfa_required":"true"},"number":"6.1.6.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"17024921a3913fb341f584542b06adf6bb12977a8b92d5fce093c3996c963686"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-05-09T00:00:00.000Z","created_at":"2022-05-09T13:46:43.653Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3045653,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.6","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.6","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.6/","rubygems_mfa_required":"true"},"number":"6.1.6","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"1f1dd2b3a0b91216f0ceb3d975ad33067ade51b0e9f13e97863239c1c0c09f1b"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-04-26T00:00:00.000Z","created_at":"2022-04-26T19:30:41.477Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1535445,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.5.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.5.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.5.1/","rubygems_mfa_required":"true"},"number":"6.1.5.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"68bfd72fd5cd1f0afc56e6f79fcd65cc13c3ce8038fe98981c8060f204e54921"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-03-10T00:00:00.000Z","created_at":"2022-03-10T21:17:17.197Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1985596,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.5","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.5","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.5/","rubygems_mfa_required":"true"},"number":"6.1.5","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"bbfda8082ca2d76b01fd1e78bff14e17fe07908f1ff4e028f3853b5b8c3626fb"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-03-08T00:00:00.000Z","created_at":"2022-03-08T17:49:05.430Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2976394,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.4.7","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.4.7","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.4.7/"},"number":"6.1.4.7","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c58a13335748caa55182e69afac033d864c84c2d1e7e891b754b56ea0de0974f"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-02-11T00:00:00.000Z","created_at":"2022-02-11T19:42:12.433Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2663511,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.4.6","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.4.6","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.4.6/"},"number":"6.1.4.6","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"eaa3d5cf0678a85eab88c4430aa49dc19fd79511a539aa006738f29ac5ebbb06"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-02-11T00:00:00.000Z","created_at":"2022-02-11T18:23:00.402Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1998,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.4.5","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.4.5","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.4.5/"},"number":"6.1.4.5","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"264b960d7b1cfaf721fdd38e218e2e3ac98ccd6128374ad48e4711f43cd87a2a"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-12-15T00:00:00.000Z","created_at":"2021-12-15T22:54:43.260Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3311211,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.4.4","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.4.4","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.4.4/"},"number":"6.1.4.4","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"14314547cff50bbbcaedf2c1262ba547c043f1e9e584fec960e6ba2fafa77e83"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-12-14T00:00:00.000Z","created_at":"2021-12-14T23:02:52.630Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":244163,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.4.3","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.4.3","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.4.3/"},"number":"6.1.4.3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a630e9a5f2254d84d0708bf23e8e6cc2f8f8d357a1cf3369914b41cbb3c0ed76"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-12-14T00:00:00.000Z","created_at":"2021-12-14T19:54:23.219Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":521328,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.4.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.4.2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.4.2/"},"number":"6.1.4.2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"68a41a4374cb5815c558ae451337a0ecb55462976f58aef2d0a2939e1cca1c10"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-08-19T00:00:00.000Z","created_at":"2021-08-19T16:27:05.901Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":8480302,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.4.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.4.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.4.1/"},"number":"6.1.4.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"7f5dd7a71046aedb6859eb4288b31b738fb8544bd9fb27574085b58cbaa8a9f8"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-06-24T00:00:00.000Z","created_at":"2021-06-24T20:41:36.150Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2775800,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.4","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.4","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.4/"},"number":"6.1.4","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b0a266453e4d53beaaf911434f49868fbc6dd3f1e317149e4b160ba6981a6d4c"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-05-05T00:00:00.000Z","created_at":"2021-05-05T15:47:12.170Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":4950767,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.3.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.3.2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.3.2/"},"number":"6.1.3.2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"36680669c708bec0a4fb3cdcbae65df62fd99a2a94b0b1f60732ad8322bd963a"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-03-26T00:00:00.000Z","created_at":"2021-03-26T18:08:37.957Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2278248,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.3.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.3.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.3.1/"},"number":"6.1.3.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"68889774d4716a7817f32ad18eefd2a5737966539cde5308c0536ef784e786fa"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-02-17T00:00:00.000Z","created_at":"2021-02-17T18:43:25.690Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1014060,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.3","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.3","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.3/"},"number":"6.1.3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"7f097f7c565c7ce6c9a0c07345c3af61f9776d65b9bee2fda72718a53db3aa41"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-02-10T00:00:00.000Z","created_at":"2021-02-10T20:46:54.673Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":226998,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.2.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.2.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.2.1/"},"number":"6.1.2.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"32409615eb41eb7719a82715c6d167757f18d9080a6ba7fa7fcf6e1b59f52112"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-02-09T00:00:00.000Z","created_at":"2021-02-09T21:30:59.508Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":38552,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.2/"},"number":"6.1.2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e62c90c4a62f0d177161e0df05d7ba417010858fa418affdb2d93981e407a04e"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-01-07T00:00:00.000Z","created_at":"2021-01-07T23:00:39.767Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":706318,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.1/"},"number":"6.1.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b7710f82e68af72db1ffa30ff3d67437e8fb91c26255659f3c2602964b834a64"},{"authors":"David
+        Heinemeier Hansson","built_at":"2020-12-09T00:00:00.000Z","created_at":"2020-12-09T19:58:25.767Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":687427,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.0","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.0","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.0/"},"number":"6.1.0","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e66d0b9a1dd8640c5a98da5b4ebd7ef5d1e01be67477f910e0cf514fa89c221b"},{"authors":"David
+        Heinemeier Hansson","built_at":"2020-12-01T00:00:00.000Z","created_at":"2020-12-01T22:02:12.587Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":7274,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.0.rc2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.0.rc2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.0.rc2/"},"number":"6.1.0.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"096df9b6ff41006daefe6565ed36524ff3f44c5b214920c2bf8d3604772359ad"},{"authors":"David
+        Heinemeier Hansson","built_at":"2020-11-02T00:00:00.000Z","created_at":"2020-11-02T21:21:17.693Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":17744,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.0.rc1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.0.rc1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.0.rc1/"},"number":"6.1.0.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"68666e4cf3ed5fc7dda1257e9923b9859388084f0464dd4140fcaae3d706815e"},{"authors":"David
+        Heinemeier Hansson","built_at":"2023-01-17T00:00:00.000Z","created_at":"2023-01-17T18:53:31.767Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":847699,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.6.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.6.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.6.1/","rubygems_mfa_required":"true"},"number":"6.0.6.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"069df2abdb0ec0baccd226af4e82ce82102223d6aad9c3c05daf8c42f2a2fa74"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-09-09T00:00:00.000Z","created_at":"2022-09-09T18:32:26.797Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1153747,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.6","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.6","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.6/","rubygems_mfa_required":"true"},"number":"6.0.6","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4591c0b0434f57678efa71ef4133ae7e2577a0a2131a069f5213e7a296c609e1"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-07-12T00:00:00.000Z","created_at":"2022-07-12T17:28:31.607Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1781357,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.5.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.5.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.5.1/","rubygems_mfa_required":"true"},"number":"6.0.5.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"2abcfe2eff00e3c5d83e91bd6efcff5a03c16499c918b341354ef9e69188904a"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-05-09T00:00:00.000Z","created_at":"2022-05-09T13:55:52.176Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":910179,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.5","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.5","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.5/","rubygems_mfa_required":"true"},"number":"6.0.5","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e810af40d58ba99ca9fda7e446ed19e93da83da748224dd9277c4c2999556ed7"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-04-26T00:00:00.000Z","created_at":"2022-04-26T19:27:17.853Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2702744,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.4.8","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.4.8","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.4.8/"},"number":"6.0.4.8","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"2d0ab1ec42beda9c60e979c9759e7ea9332cc8128650173f6e128495b74d1917"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-03-08T00:00:00.000Z","created_at":"2022-03-08T17:47:49.182Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1421406,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.4.7","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.4.7","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.4.7/"},"number":"6.0.4.7","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"cb2eccd564ac30e9efccc33f7bab0408cdaffc0d862ef41be275e8a3fa4a2be5"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-02-11T00:00:00.000Z","created_at":"2022-02-11T19:40:17.360Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1157499,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.4.6","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.4.6","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.4.6/"},"number":"6.0.4.6","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"6034231cb496dcd4467fccfa2792ee921347eba1d666b866f8f3b530b72b1620"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-02-11T00:00:00.000Z","created_at":"2022-02-11T18:25:30.490Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1262,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.4.5","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.4.5","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.4.5/"},"number":"6.0.4.5","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b606edc9d12b13f1620cc6019b7f6d48431515056261dca7186bc28778139263"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-12-15T00:00:00.000Z","created_at":"2021-12-15T22:48:07.861Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":951777,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.4.4","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.4.4","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.4.4/"},"number":"6.0.4.4","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5d3a7faac56f22fbe50c69bcaef1a87c6b99bcbfa74ab2de973e67c2bbdc31bf"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-12-14T00:00:00.000Z","created_at":"2021-12-14T23:01:12.359Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":330326,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.4.3","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.4.3","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.4.3/"},"number":"6.0.4.3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"33b7a4b723ca8e3b4ba55ac31d244e0270a44dfb0714432ffdc32d5508195a5d"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-12-14T00:00:00.000Z","created_at":"2021-12-14T20:11:34.368Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":76762,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.4.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.4.2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.4.2/"},"number":"6.0.4.2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0b23a2522d0d06ec67934a125fce3699a8011467c2e32cc73bf456bb41b2d03b"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-08-19T00:00:00.000Z","created_at":"2021-08-19T16:24:04.111Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2215141,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.4.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.4.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.4.1/"},"number":"6.0.4.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"62f6b50573e2afc305575f580ed72783512874464726d8e52fe8c10b981d1ee0"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-06-15T00:00:00.000Z","created_at":"2021-06-15T20:18:42.690Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1037582,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.4","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.4","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.4/"},"number":"6.0.4","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4fcf7ceeae044e95be52efd5a3f94ec14872643121a461187424246fdd0df7cb"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-05-05T00:00:00.000Z","created_at":"2021-05-05T16:02:39.448Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":4464676,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.3.7","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.3.7","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.3.7/"},"number":"6.0.3.7","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"41e295498229ae1134c052b2529df7835bd5639b92e54a30979b4b0d45601a6f"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-03-26T00:00:00.000Z","created_at":"2021-03-26T17:34:24.038Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3524387,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.3.6","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.3.6","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.3.6/"},"number":"6.0.3.6","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"790a078dad5832c6b93c460cd9f530f85cf3233a4306135713e97c9f30e9bc06"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-02-10T00:00:00.000Z","created_at":"2021-02-10T20:40:58.384Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2918660,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.3.5","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.3.5","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.3.5/"},"number":"6.0.3.5","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0a914868970c2f8cf3ca5e6e331337d630d8994a4bdbe62a919258fcb274fb05"},{"authors":"David
+        Heinemeier Hansson","built_at":"2020-10-07T00:00:00.000Z","created_at":"2020-10-07T16:51:45.423Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":7788126,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.3.4","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.3.4","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.3.4/"},"number":"6.0.3.4","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"af3b76d0641875e903a6d1006b5556d3a8070cbeaa416bc50025df729f9b446f"},{"authors":"David
+        Heinemeier Hansson","built_at":"2020-09-09T00:00:00.000Z","created_at":"2020-09-09T18:40:40.945Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3114509,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.3.3","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.3.3","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.3.3/"},"number":"6.0.3.3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c470ef45cd2ef9c0742c5f4d1fbd2b24e2bea05c5e9122fb9e5d8fb0348f1ae3"},{"authors":"David
+        Heinemeier Hansson","built_at":"2020-06-17T00:00:00.000Z","created_at":"2020-06-17T14:55:22.792Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":4124456,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.3.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.3.2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.3.2/"},"number":"6.0.3.2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5daa748fe3983204fc44f00697fa75cd8c0310b35d37ba85c317141d4123aa8e"},{"authors":"David
+        Heinemeier Hansson","built_at":"2020-05-18T00:00:00.000Z","created_at":"2020-05-18T15:47:58.979Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3332348,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.3.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.3.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.3.1/"},"number":"6.0.3.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"846a0d06fba09378298d97efd01595596ee2d6841602da4f14a0e1f400136ab2"},{"authors":"David
+        Heinemeier Hansson","built_at":"2020-05-06T00:00:00.000Z","created_at":"2020-05-06T18:06:19.228Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":723314,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.3","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.3","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.3/"},"number":"6.0.3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"399039af4ca160751f87505e13d1a000dfb65e15e4d86601eb34070b85fc73e7"},{"authors":"David
+        Heinemeier Hansson","built_at":"2020-05-01T00:00:00.000Z","created_at":"2020-05-01T17:19:16.854Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":7751,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.3.rc1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.3.rc1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.3.rc1/"},"number":"6.0.3.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"bd2558f622b5c02f3eb40514f861465c24cec0e2903cd6edf3a89da6dfa6c0f0"},{"authors":"David
+        Heinemeier Hansson","built_at":"2020-03-19T00:00:00.000Z","created_at":"2020-03-19T16:44:43.643Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2114224,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.2.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.2.2","mailing_list_uri":"https://groups.google.com/forum/#!forum/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.2.2/"},"number":"6.0.2.2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4b789dc6d942e133032485169aa30553482b528ffea5dd52a3bab853fca0c822"},{"authors":"David
+        Heinemeier Hansson","built_at":"2019-12-18T00:00:00.000Z","created_at":"2019-12-18T19:09:59.411Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3421502,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.2.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.2.1","mailing_list_uri":"https://groups.google.com/forum/#!forum/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.2.1/"},"number":"6.0.2.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"32a07bc27a22c80752847936aa52497c5d97de9c577b1120a2e897dda77f93b0"},{"authors":"David
+        Heinemeier Hansson","built_at":"2019-12-13T00:00:00.000Z","created_at":"2019-12-13T18:22:04.637Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":831843,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.2","mailing_list_uri":"https://groups.google.com/forum/#!forum/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.2/"},"number":"6.0.2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b5223754088b3adfca6608a1901fbd7813b4b994af4ec514accd0b3b5ce05d0b"},{"authors":"David
+        Heinemeier Hansson","built_at":"2019-12-09T00:00:00.000Z","created_at":"2019-12-09T16:14:24.296Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3736,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.2.rc2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.2.rc2","mailing_list_uri":"https://groups.google.com/forum/#!forum/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.2.rc2/"},"number":"6.0.2.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"5cb22ec58dd58fb79fa1f3da50adff4692a41cf19ff4a2fa6cde482885d9f310"},{"authors":"David
+        Heinemeier Hansson","built_at":"2019-11-27T00:00:00.000Z","created_at":"2019-11-27T15:14:18.533Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":7046,"metadata":{"bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.2.rc1","mailing_list_uri":"https://groups.google.com/forum/#!forum/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.2.rc1/"},"number":"6.0.2.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"64981b76140ca930e008f8e58879ec963a8ad5386fb894d58e655b491a7bd1fd"},{"authors":"David
+        Heinemeier Hansson","built_at":"2019-11-05T00:00:00.000Z","created_at":"2019-11-05T14:41:11.133Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1139270,"metadata":{"bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.1","mailing_list_uri":"https://groups.google.com/forum/#!forum/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.1/"},"number":"6.0.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"87c242b5dbac85026ef3fe1278a51bee6d81913fb631465c4bfee2e8e8759ec8"},{"authors":"David
+        Heinemeier Hansson","built_at":"2019-10-31T00:00:00.000Z","created_at":"2019-10-31T20:12:42.982Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3523,"metadata":{"bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.1.rc1","mailing_list_uri":"https://groups.google.com/forum/#!forum/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.1.rc1/"},"number":"6.0.1.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"eee594a0a944fc2d182a29a440c2bca62b8e55ec63ada2a77cfe003d6447e4ed"},{"authors":"David
+        Heinemeier Hansson","built_at":"2019-08-16T00:00:00.000Z","created_at":"2019-08-16T18:01:50.039Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2151814,"metadata":{},"number":"6.0.0","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"dcb924cb0e7ec85c9773f9711caac1fd7c8f3791eb42d389dd6967d02545fdc2"},{"authors":"David
+        Heinemeier Hansson","built_at":"2019-07-22T00:00:00.000Z","created_at":"2019-07-22T21:13:05.492Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":120762,"metadata":{},"number":"6.0.0.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"8ccb7e5a01880ec88de4d729de358c9ca0534777b1789467aef80dc54812cc9d"},{"authors":"David
+        Heinemeier Hansson","built_at":"2019-04-24T00:00:00.000Z","created_at":"2019-04-24T18:51:47.763Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":305535,"metadata":{},"number":"6.0.0.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"7b9b4224a0ccfaf63d66234679afc6485accb7ac7bd06cce67a49dd2945115ce"},{"authors":"David
+        Heinemeier Hansson","built_at":"2019-03-13T00:00:00.000Z","created_at":"2019-03-13T17:03:33.751Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":66347,"metadata":{},"number":"6.0.0.beta3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"b08df88e745edaca9b38162e115bc14935bbf6749eaf4809745c9679d7816c07"},{"authors":"David
+        Heinemeier Hansson","built_at":"2019-02-25T00:00:00.000Z","created_at":"2019-02-25T22:46:20.904Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":15295,"metadata":{},"number":"6.0.0.beta2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"f0db1c34c709adb06ca4b21eb199dde46a26eccdd5916278f4f9af2553207a87"},{"authors":"David
+        Heinemeier Hansson","built_at":"2019-01-18T00:00:00.000Z","created_at":"2019-01-18T21:24:30.197Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":20729,"metadata":{},"number":"6.0.0.beta1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"f70cc2e606eafd6c3fd1d7e15f015d6a3e5626d34724ba5c0114922a8eb864b8"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-07-12T00:00:00.000Z","created_at":"2022-07-12T17:26:29.354Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":5502903,"metadata":{},"number":"5.2.8.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"cf18751a5e603cc1996536de8109459da9998c843dc5381ab8f87680a793c4cb"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-05-09T00:00:00.000Z","created_at":"2022-05-09T14:04:34.858Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1359292,"metadata":{},"number":"5.2.8","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8910529ca26e845b7d0e4448f844f07f0b929b29c8d733f1217e914aa3f80421"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-04-26T00:00:00.000Z","created_at":"2022-04-26T19:23:33.623Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1643576,"metadata":{},"number":"5.2.7.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a917d368f804a06aba6a2538c42b68d7a908337be51d527ef5db83d8dc0bfa7e"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-03-10T00:00:00.000Z","created_at":"2022-03-11T00:01:27.495Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":861889,"metadata":{},"number":"5.2.7","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b650a8f5a0a896555b4539b9f523024a64c605fb849de92affea803a9c6b0ee6"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-03-08T00:00:00.000Z","created_at":"2022-03-08T17:46:06.998Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":787142,"metadata":{},"number":"5.2.6.3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d621ec624f3da36cb05483e6048759bbce13be1f092135ca39276b2da71526a5"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-02-11T00:00:00.000Z","created_at":"2022-02-11T19:37:40.891Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1452052,"metadata":{},"number":"5.2.6.2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c0ebe849cca73a5e053e673376349eb46674770dfb4ee46e4152c8314ea3eb39"},{"authors":"David
+        Heinemeier Hansson","built_at":"2022-02-11T00:00:00.000Z","created_at":"2022-02-11T18:44:20.296Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1201,"metadata":{},"number":"5.2.6.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c178b03c57728fd34a1b7cf3495762a1b52e9c5115072f65a41cca91f2f4b155"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-05-05T00:00:00.000Z","created_at":"2021-05-05T17:09:14.109Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":8086166,"metadata":{},"number":"5.2.6","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ccdef9f57c2c0f67faae9d5b6d155f5e61b033f944499ea09d6383e6626d27dc"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-03-26T00:00:00.000Z","created_at":"2021-03-26T17:21:08.771Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2728146,"metadata":{},"number":"5.2.5","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4c14aa2558250f2dbb85d4a5c6046159ff7cf285b86c367d9dae3eabcd501adc"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-05-05T00:00:00.000Z","created_at":"2021-05-05T15:29:45.600Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2444399,"metadata":{},"number":"5.2.4.6","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"cb1369b8e341092cc154ef9ebb9b3a57801366ec32506d5166b9b2a6530eda7d"},{"authors":"David
+        Heinemeier Hansson","built_at":"2021-02-10T00:00:00.000Z","created_at":"2021-02-10T20:36:47.152Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1741721,"metadata":{},"number":"5.2.4.5","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"cd4dd4b224e58a8bc03c3fb182fd748dda2f36abfae6ecd8db145a8c5da8fadb"},{"authors":"David
+        Heinemeier Hansson","built_at":"2020-09-09T00:00:00.000Z","created_at":"2020-09-09T18:40:04.077Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":5372159,"metadata":{},"number":"5.2.4.4","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"005bdf45d254f7e315f157eb0ceff38584fb41b772234e889eccaea50b1caf2c"},{"authors":"David
+        Heinemeier Hansson","built_at":"2020-05-18T00:00:00.000Z","created_at":"2020-05-18T15:43:14.514Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":5232323,"metadata":{},"number":"5.2.4.3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f29c6b2dea33410c2988f17f42b69531871e3ba71b446558da46af045f7503fb"},{"authors":"David
+        Heinemeier Hansson","built_at":"2020-03-19T00:00:00.000Z","created_at":"2020-03-19T16:38:05.377Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2175514,"metadata":{},"number":"5.2.4.2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"44ab2836290ef259ed12fc6a24c1e62e317a534b79c37c0d1a8ec7ef893513f5"},{"authors":"David
+        Heinemeier Hansson","built_at":"2019-12-18T00:00:00.000Z","created_at":"2019-12-18T19:04:02.693Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2169961,"metadata":{},"number":"5.2.4.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"402c80f8533052bb9f62e9c61aad9a559b96c04961ddda93151852b8f8572885"},{"authors":"David
+        Heinemeier Hansson","built_at":"2019-11-27T00:00:00.000Z","created_at":"2019-11-27T15:48:34.344Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1049726,"metadata":{},"number":"5.2.4","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3abc0d1c5a6a87821ed73d0f523fbb63e09610dbdfd7f8b948e14a15f7749481"},{"authors":"David
+        Heinemeier Hansson","built_at":"2019-11-23T00:00:00.000Z","created_at":"2019-11-23T00:29:26.852Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1717,"metadata":{},"number":"5.2.4.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"c9f9a2381a465888619736d6dd5108c795bbffabf0f1cd7cf49fbac26e4e88c8"},{"authors":"David
+        Heinemeier Hansson","built_at":"2019-03-28T00:00:00.000Z","created_at":"2019-03-28T03:02:40.948Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":13537497,"metadata":{},"number":"5.2.3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f9b51b66a91d556d63d36d04449ecc23867683f99531db21eb7a263be2d7ecdc"},{"authors":"David
+        Heinemeier Hansson","built_at":"2019-03-22T00:00:00.000Z","created_at":"2019-03-22T03:35:22.787Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3008,"metadata":{},"number":"5.2.3.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"419a56071b85f5496de89810700d6bfab8c373ceb8beccc3052bbb6c8e3fc6b3"},{"authors":"David
+        Heinemeier Hansson","built_at":"2019-03-13T00:00:00.000Z","created_at":"2019-03-13T16:54:48.659Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3807436,"metadata":{},"number":"5.2.2.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e9d64c83adc309c84e1561f2842474b16906cb812756084d08763d3e7de6b5cb"},{"authors":"David
+        Heinemeier Hansson","built_at":"2018-12-04T00:00:00.000Z","created_at":"2018-12-04T18:15:02.233Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":5303290,"metadata":{},"number":"5.2.2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d9ff5d9be16ee277dfc8f3c760bf171aa497d8685ec5c8988fba21a3dbd72cd5"},{"authors":"David
+        Heinemeier Hansson","built_at":"2018-11-28T00:00:00.000Z","created_at":"2018-11-28T22:55:23.827Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":11044,"metadata":{},"number":"5.2.2.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"8e1fdbabab9eae02fc76078eea1dc1d975a9be8cbcfeda4395137503da3f1bf7"},{"authors":"David
+        Heinemeier Hansson","built_at":"2018-11-27T00:00:00.000Z","created_at":"2018-11-27T20:14:16.796Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":522722,"metadata":{},"number":"5.2.1.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b5e1fe216d108d6908e23aaaed563dcf8fae7ec92c4ea776607732785bad8f10"},{"authors":"David
+        Heinemeier Hansson","built_at":"2018-08-07T00:00:00.000Z","created_at":"2018-08-07T21:44:52.020Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3888067,"metadata":{},"number":"5.2.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"776cfea45140972f1780236748f7cfe72cf95c032056812128433273c366078c"},{"authors":"David
+        Heinemeier Hansson","built_at":"2018-07-30T00:00:00.000Z","created_at":"2018-07-30T20:22:38.749Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":5846,"metadata":{},"number":"5.2.1.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"78fbe88491b0a68f9fe68d7dd8594e2bc102c1aed99a5c5e8acca87e2ec914e7"},{"authors":"David
+        Heinemeier Hansson","built_at":"2018-04-09T00:00:00.000Z","created_at":"2018-04-09T20:07:04.834Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":5154398,"metadata":{},"number":"5.2.0","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"035dde6374845b5a17bb2c024fb60dfe46e78a04d47cfe22c81e6c5912b51686"},{"authors":"David
+        Heinemeier Hansson","built_at":"2018-03-20T00:00:00.000Z","created_at":"2018-03-20T17:54:58.165Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":56503,"metadata":{},"number":"5.2.0.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"5a1ac4795aa7a0c79dc91ad3982dc49230c6178b158f759711138f8bd9bdf1c0"},{"authors":"David
+        Heinemeier Hansson","built_at":"2018-01-30T00:00:00.000Z","created_at":"2018-01-30T23:38:56.843Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":67057,"metadata":{},"number":"5.2.0.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"da5667e1eb9364e6ac4b7633bd38ba47c67cf75a3d8c7a3e06e85f841c24aa63"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-11-28T00:00:00.000Z","created_at":"2017-11-28T05:04:37.765Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":42480,"metadata":{},"number":"5.2.0.beta2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"bad7e22c0d3709d141d7714ff91be84ab2c3850d71aea6d2d670a4443cd9581a"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-11-27T00:00:00.000Z","created_at":"2017-11-27T19:19:13.809Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2591,"metadata":{},"number":"5.2.0.beta1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"7844ee3f1819835e219a7f332e6cd0985bae9b97b479371ae9ad460fdbbf40a9"},{"authors":"David
+        Heinemeier Hansson","built_at":"2019-03-28T00:00:00.000Z","created_at":"2019-03-28T02:48:31.504Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":12565650,"metadata":{},"number":"5.1.7","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8d7f527c446de3f99ec506e6a680c42c38979a44b37beb15f7d451a33e74dcf5"},{"authors":"David
+        Heinemeier Hansson","built_at":"2019-03-22T00:00:00.000Z","created_at":"2019-03-22T04:13:43.625Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1543,"metadata":{},"number":"5.1.7.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"ca0f895446ceece1d904e96bedff90224e715acb9f124b60ffc9ac1b568ed07d"},{"authors":"David
+        Heinemeier Hansson","built_at":"2019-03-13T00:00:00.000Z","created_at":"2019-03-13T16:46:09.784Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2096728,"metadata":{},"number":"5.1.6.2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8e721f8e6c7ea0dfd6dbf7fe215f2c40b1de5d104b6cf5d1e1313dc02be640e9"},{"authors":"David
+        Heinemeier Hansson","built_at":"2018-11-27T00:00:00.000Z","created_at":"2018-11-27T20:11:47.585Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1099416,"metadata":{},"number":"5.1.6.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f64f110ff439f10616e87e35dee23aeb0932e77869c64b3e2239b1332db5c863"},{"authors":"David
+        Heinemeier Hansson","built_at":"2018-03-29T00:00:00.000Z","created_at":"2018-03-29T18:29:03.149Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":4261858,"metadata":{},"number":"5.1.6","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b8301a87151de3feb7cbdf57a66842bb668493f4cec464fd0f67d4c7173b6051"},{"authors":"David
+        Heinemeier Hansson","built_at":"2018-02-14T00:00:00.000Z","created_at":"2018-02-14T20:02:02.541Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2761192,"metadata":{},"number":"5.1.5","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"fee9771fc53f3060875267a6789aea9e35975e5c344ff5c3175e27be92a01561"},{"authors":"David
+        Heinemeier Hansson","built_at":"2018-02-01T00:00:00.000Z","created_at":"2018-02-01T19:00:37.520Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":5905,"metadata":{},"number":"5.1.5.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"aab580fb652a277b9b3801cecd8d93735de02ca650481bf34cef71de6f51f064"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-09-08T00:00:00.000Z","created_at":"2017-09-08T00:52:07.791Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":7015093,"metadata":{},"number":"5.1.4","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5cc2192045678789e5e7b289476af8bc0a79210ee6713886200cb303ed6f98b8"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-08-24T00:00:00.000Z","created_at":"2017-08-24T19:37:37.728Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":4440,"metadata":{},"number":"5.1.4.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"c8134e1efcc5f17ac28927a76423146f3a7baf618d97a5d752d09edf4c5eeb7c"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-08-03T00:00:00.000Z","created_at":"2017-08-03T19:15:15.370Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1036912,"metadata":{},"number":"5.1.3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"28c73c5aba5ce71d4bcd6af273be3e565ab7a49abd22fd511dc79fcb36329d19"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-07-31T00:00:00.000Z","created_at":"2017-07-31T19:12:53.241Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3334,"metadata":{},"number":"5.1.3.rc3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"f3551c5eec9649bc225552e0ed8ecee6dac9f4f97ca13e78bf018e36385852e8"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-07-25T00:00:00.000Z","created_at":"2017-07-25T20:18:18.420Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":4312,"metadata":{},"number":"5.1.3.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"d7ea7b6ee2ad1881f44bec83af5183dad6a52fed6ba7d25430bdab5f2394d067"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-07-19T00:00:00.000Z","created_at":"2017-07-19T19:38:05.393Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2701,"metadata":{},"number":"5.1.3.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"a06eded7f5e2bf1d6ecc69589062966bb701ccb8896d5aac5a6171ff38d037d4"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-06-26T00:00:00.000Z","created_at":"2017-06-26T21:51:41.161Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1375398,"metadata":{},"number":"5.1.2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4ee8ea1a2760cafbd70fbc878fd0c4ad2fec105082719c818934b39fd4ff0e9b"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-06-20T00:00:00.000Z","created_at":"2017-06-20T17:03:49.322Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3410,"metadata":{},"number":"5.1.2.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"50a14c6e4952297f0a9a510b268ea845833474dccbe1619594c0406ceab5c7fa"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-05-12T00:00:00.000Z","created_at":"2017-05-12T20:11:39.743Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1112539,"metadata":{},"number":"5.1.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"175e79dd0770470e4ff7055989ae136fee9cbb4b3145bcb00a5c4783e941aed7"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-04-27T00:00:00.000Z","created_at":"2017-04-27T21:00:47.670Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":506976,"metadata":{},"number":"5.1.0","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d843e2d2c61987f1fb7877cd98bc5d1f2704ad4eee9adf9c1455858769b6ec32"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-04-21T00:00:00.000Z","created_at":"2017-04-21T01:31:13.442Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":29814,"metadata":{},"number":"5.1.0.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"3c9dc0e1df91b756fe83ce6d7f3184fd27a3c60fc101588a59a30b390308be2b"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-03-20T00:00:00.000Z","created_at":"2017-03-20T18:57:56.595Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":48883,"metadata":{},"number":"5.1.0.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"1d40e4918ae7358628fce6e0fb629fece66e6022e0b68cc286ddacfb7b4fbd0b"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-02-23T00:00:00.000Z","created_at":"2017-02-23T20:00:44.720Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":28261,"metadata":{},"number":"5.1.0.beta1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"5e1378a454fefe69f1573782f6ac532ecb346f72404753921623a87e5817e5b1"},{"authors":"David
+        Heinemeier Hansson","built_at":"2019-03-13T00:00:00.000Z","created_at":"2019-03-13T16:44:05.926Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":6762145,"metadata":{},"number":"5.0.7.2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3ce2eac8fa58ce138e3e2a2fa9b544c8f43128e0c24d0a1d8d751b3a515bb82a"},{"authors":"David
+        Heinemeier Hansson","built_at":"2018-11-27T00:00:00.000Z","created_at":"2018-11-27T20:09:36.347Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":895309,"metadata":{},"number":"5.0.7.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3ce11ed1acf1eea4b4b35b4516251e81a5cbbd889227432b232409cb9c658a2e"},{"authors":"David
+        Heinemeier Hansson","built_at":"2018-03-29T00:00:00.000Z","created_at":"2018-03-29T18:18:14.388Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2018695,"metadata":{},"number":"5.0.7","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"76815a2a7e99c83b53ea52325c5bbc5ca15e25ecdfb741ea329ca153cf11ff84"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-09-08T00:00:00.000Z","created_at":"2017-09-08T00:47:42.201Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3172886,"metadata":{},"number":"5.0.6","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a86663f8d0d4dd0cb07272394a6d0c7d250be617c6efe77edd2ebc9c9d139746"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-08-24T00:00:00.000Z","created_at":"2017-08-24T19:21:20.599Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2290,"metadata":{},"number":"5.0.6.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"7873311d5340bffbabeb33cb9d3ce2c97056bc2bebad3abfcba6f5b38b209075"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-07-31T00:00:00.000Z","created_at":"2017-07-31T19:05:29.060Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":525695,"metadata":{},"number":"5.0.5","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"15e2c25872e5dc2069b0d7bf4535eb4887e77d49166ccfba5871a904c18957b1"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-07-25T00:00:00.000Z","created_at":"2017-07-25T20:26:10.369Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3298,"metadata":{},"number":"5.0.5.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"35792281ba2c7af605f2b17453856dd6ee64649d94545e8501ec91db111a6451"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-07-19T00:00:00.000Z","created_at":"2017-07-19T19:43:58.280Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3123,"metadata":{},"number":"5.0.5.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"0fd92b43895a1a73d639b93eec67159bed1003ce2a3f6250030b05091ae40046"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-06-19T00:00:00.000Z","created_at":"2017-06-19T21:58:56.501Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":593894,"metadata":{},"number":"5.0.4","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"956e9bd0acf86701b139432eb3c9e6bc6d2f51e7cccec9a5dcf9c7d3cb14d87d"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-06-14T00:00:00.000Z","created_at":"2017-06-14T20:49:29.610Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2380,"metadata":{},"number":"5.0.4.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"44843943d4fc377d589bbead59fb74b5bb82e2ab9d1c160fe8884cac6bc17c17"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-05-12T00:00:00.000Z","created_at":"2017-05-12T20:08:33.226Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":745257,"metadata":{},"number":"5.0.3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"fba5f99999f1b01367010f0d85a28b5d992d5866766fbc3d485bce8e14915f2b"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-03-01T00:00:00.000Z","created_at":"2017-03-01T23:13:53.219Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2264429,"metadata":{},"number":"5.0.2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"49c6c350286e2f177df5c2214f9668f0866d87411ab5a63e051e25eb64453f70"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-02-25T00:00:00.000Z","created_at":"2017-02-25T00:55:48.618Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3129,"metadata":{},"number":"5.0.2.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"a7e221850b4ba50150d814c12750b559b2bf20c164cad3f647e8c7b41da267ed"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-12-21T00:00:00.000Z","created_at":"2016-12-21T00:07:46.527Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2757641,"metadata":{},"number":"5.0.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3f9acd2c489c9eed11ff200a37cb32784cf15ddc5e561657d50b847ced3c361d"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-12-09T00:00:00.000Z","created_at":"2016-12-09T19:13:12.953Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":10465,"metadata":{},"number":"5.0.1.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"05d95c4eb44510e11af692406500762ac18693d7f01fa2accee68ffaac044df3"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-11-30T00:00:00.000Z","created_at":"2016-11-30T20:02:44.553Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":6146,"metadata":{},"number":"5.0.1.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"2e7c269b909eaedb6a8448991ca783beec337e2e5452bf0905b40191be80db75"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-08-10T00:00:00.000Z","created_at":"2016-08-11T17:35:27.196Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2441218,"metadata":{},"number":"5.0.0.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b51cf641a376e16166587cfe41f46e37bd3a510c13a8b79f0682985c1603e4d8"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-06-30T00:00:00.000Z","created_at":"2016-06-30T21:32:45.255Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1009329,"metadata":{},"number":"5.0.0","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"2e7be2dd453d6ccd7561cc21c5d60a4042f7b3455325f1d9e8dc3d7f79e2d5ef"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-06-22T00:00:00.000Z","created_at":"2016-06-22T20:03:41.237Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":54208,"metadata":{},"number":"5.0.0.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"e2a9e578d1c86057028a91de3e0d1084479f22833ce361a9317597e0c8631c19"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-05-06T00:00:00.000Z","created_at":"2016-05-06T21:57:46.793Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":117920,"metadata":{},"number":"5.0.0.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"311fa05f7f50a9b0b9207326e80b7a28767f11ccd97d0a741f60c135136817b7"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-05-06T00:00:00.000Z","created_at":"2016-05-06T22:02:43.345Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":4578,"metadata":{},"number":"5.0.0.racecar1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"9b94fe9a06d7ae47ef6d9572a0e5ebb5f422cce5e75b5b284790fc7845a83492"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-04-27T00:00:00.000Z","created_at":"2016-04-27T20:55:26.508Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":19575,"metadata":{},"number":"5.0.0.beta4","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"f8ad4dcc39609eaa7e3e9d9b5e21f4d83d02ba82e39427725a4cfa0b56038bb6"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-02-24T00:00:00.000Z","created_at":"2016-02-24T16:16:22.722Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":116700,"metadata":{},"number":"5.0.0.beta3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"10af87af6b7e4fac0c61c6b2d51b6af34da5c2335b014f03b677a035156ed6a3"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-02-01T00:00:00.000Z","created_at":"2016-02-01T22:06:25.279Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":29299,"metadata":{},"number":"5.0.0.beta2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"a370398f8f031f4dc839f3b6109254a7de3040b638bf56058c8c3466516c6322"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-01-25T00:00:00.000Z","created_at":"2016-01-25T19:26:49.903Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":8039,"metadata":{},"number":"5.0.0.beta1.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"65cc4ea4425d2898b06ced0adb04dfbb963e13076d01665b9360faa18fcb8c12"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-12-18T00:00:00.000Z","created_at":"2015-12-18T21:18:13.306Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":25850,"metadata":{},"number":"5.0.0.beta1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"ba530b37029df58da41e789e31c1655eff73e2bfacb8cb048e5ecdd77e7781f4"},{"authors":"David
+        Heinemeier Hansson","built_at":"2020-05-15T00:00:00.000Z","created_at":"2020-05-15T18:35:36.370Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3173077,"metadata":{},"number":"4.2.11.3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"7502ee83259abce924803052e34f3a9d072b01050e41e2ae94a22ddfd16d9686"},{"authors":"David
+        Heinemeier Hansson","built_at":"2020-05-15T00:00:00.000Z","created_at":"2020-05-15T16:30:58.148Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2146,"metadata":{},"number":"4.2.11.2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"605887324b823a5de5154952c3b7de99a972994d25c448614a2b2d31ffb0c130"},{"authors":"David
+        Heinemeier Hansson","built_at":"2019-03-11T00:00:00.000Z","created_at":"2019-03-13T16:37:43.380Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":7279887,"metadata":{},"number":"4.2.11.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b4b6536187eab61696358d851e043d60be3fc8313da67815467bb4968a8e9bfb"},{"authors":"David
+        Heinemeier Hansson","built_at":"2018-11-27T00:00:00.000Z","created_at":"2018-11-27T20:07:25.845Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2783283,"metadata":{},"number":"4.2.11","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"dd12ffea8f548accec41ae1ef6add3cf9f1e00275744f92da60a713a0b0d1766"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-09-27T00:00:00.000Z","created_at":"2017-09-27T14:29:42.567Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":7230862,"metadata":{},"number":"4.2.10","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"141067e1dd4ec59d7a49e54936b68d8e44d8616515625dcf0387405a276d6b97"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-09-20T00:00:00.000Z","created_at":"2017-09-20T19:42:33.297Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2079,"metadata":{},"number":"4.2.10.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"9e43e2cda17c4d68b65eff9ef4df6c62c87a0f5779a612fd3dc06e80f0182c7c"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-06-26T00:00:00.000Z","created_at":"2017-06-26T21:30:56.077Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":14299205,"metadata":{},"number":"4.2.9","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"eaaa4c1cafb3f9bd9f8dd58dd142522e398a5ad0d03abf2e3de364a63d4b7d1a"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-06-19T00:00:00.000Z","created_at":"2017-06-19T22:28:22.086Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2383,"metadata":{},"number":"4.2.9.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"eb7cdb1b7bb1196ff40d74a98ec44d4521fe3c4e0f4226c814be41e8b1f17d6b"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-06-13T00:00:00.000Z","created_at":"2017-06-13T18:50:29.897Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3228,"metadata":{},"number":"4.2.9.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"c7de4f0e62498acf407928a5f147a9e297a63e900882f627489e91b033026b69"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-02-21T00:00:00.000Z","created_at":"2017-02-21T16:08:53.220Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":5393223,"metadata":{},"number":"4.2.8","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"90552099146e785e66cf90ede51dca0c1814440026eef2f8c418aebffc70eb36"},{"authors":"David
+        Heinemeier Hansson","built_at":"2017-02-10T00:00:00.000Z","created_at":"2017-02-10T02:46:51.222Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":8165,"metadata":{},"number":"4.2.8.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"5405ee45ce29c39a4bde749ac32bb4940e88fea5da3cc1c88f3f5bd5accae76f"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-08-10T00:00:00.000Z","created_at":"2016-08-11T17:35:16.160Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":6370069,"metadata":{},"number":"4.2.7.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9414bef218365d548c5e42080e70364ad2809d6263856f591ba2e393a3096dab"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-07-13T00:00:00.000Z","created_at":"2016-07-13T02:57:05.601Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":862695,"metadata":{},"number":"4.2.7","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"76dbbc22ac7fc20edb2fb653a9517590537073ef57669c2da8f3d32ff1767c0c"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-07-01T00:00:00.000Z","created_at":"2016-07-01T00:33:36.424Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2541,"metadata":{},"number":"4.2.7.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"3762801c4aeedaf8a560bd91a57bad8fff04ac29cbbe6d58d3353afd7cc65d8f"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-03-07T00:00:00.000Z","created_at":"2016-03-07T22:33:22.563Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":4544414,"metadata":{},"number":"4.2.6","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a199258c0d2bae09993a6932c49df254fd66428899d1823b8c5285de02e5bc33"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-03-01T00:00:00.000Z","created_at":"2016-03-01T18:37:54.172Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":4102,"metadata":{},"number":"4.2.6.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"29c9b33cfcf82b16457b338f68b10a5c81841bd17340a4b27129f2e7246d6f93"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-02-29T00:00:00.000Z","created_at":"2016-02-29T19:17:10.564Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":973148,"metadata":{},"number":"4.2.5.2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"aa93c1b9eb8b535eee58280504e30237f88217699fe9bb016e458e5122eefa2e"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-01-25T00:00:00.000Z","created_at":"2016-01-25T19:26:41.410Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1516387,"metadata":{},"number":"4.2.5.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0bb3795fc6d971522f2681dea730b49be880809012939a8a570bd086b583460e"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-11-12T00:00:00.000Z","created_at":"2015-11-12T17:06:55.226Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2253953,"metadata":{},"number":"4.2.5","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"6248f75d4ecbcaa004166aa2b1484f87b7e956013853e905e49b68f29397b565"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-11-05T00:00:00.000Z","created_at":"2015-11-05T03:02:33.340Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":5101,"metadata":{},"number":"4.2.5.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"869306afca63bf6749490a13a5b4f155cd29f594ceff2e2f03985bd8898a9619"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-10-30T00:00:00.000Z","created_at":"2015-10-30T20:47:59.397Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":5757,"metadata":{},"number":"4.2.5.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"7422830437d58a940d8ffb1b8b5dc084b438007b629d50dc0712724578fb476d"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-08-24T00:00:00.000Z","created_at":"2015-08-24T18:27:12.716Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2470918,"metadata":{},"number":"4.2.4","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"1c33dd7c280d1c5dc4235509f774d673bac1d3f2e8c53b1353f677e7578ffc5a"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-08-14T00:00:00.000Z","created_at":"2015-08-14T15:21:15.566Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":5376,"metadata":{},"number":"4.2.4.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"d64188a2b9b03bcca5499ce6ac6d422e5ae4f8c1ecc5f3af44db14e82823ce7d"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-06-25T00:00:00.000Z","created_at":"2015-06-25T21:30:57.890Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1951117,"metadata":{},"number":"4.2.3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"6a19b32cf92ac3585c2effbf5356642e84349abf55ee82827313ec3c7ce34870"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-06-22T00:00:00.000Z","created_at":"2015-06-22T14:23:17.788Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3766,"metadata":{},"number":"4.2.3.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"9e36a4dee4e39def83123c0e260426994204fc9201ca2afa2a1a77ff66f6e3a3"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-06-16T00:00:00.000Z","created_at":"2015-06-16T18:03:17.061Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":926254,"metadata":{},"number":"4.2.2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"60826c698420631bd4b623c8eb305510a428e507c202885b4cc52551293901c1"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-03-19T00:00:00.000Z","created_at":"2015-03-19T16:42:01.191Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2621786,"metadata":{},"number":"4.2.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"6b5f7d3a4a9eb2f181bab4a657315dbe08d0be218eae6017bef8a45dede211cb"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-03-12T00:00:00.000Z","created_at":"2015-03-12T21:25:52.551Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":6215,"metadata":{},"number":"4.2.1.rc4","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"67b780da327c1ff8efee6e6d41e1fd735e4fa8734bc34ae450bb587db34ff8ad"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-03-02T00:00:00.000Z","created_at":"2015-03-02T21:35:50.169Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":6928,"metadata":{},"number":"4.2.1.rc3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"90043b5ce4c1191e62a0c5b6bc4580553a540d7e6d18c7975de180fe8af61462"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-02-25T00:00:00.000Z","created_at":"2015-02-25T22:19:50.245Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":4561,"metadata":{},"number":"4.2.1.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"ea1ef28f02f4293c168c5055d3c86bb708395c5234c9537d7e241cba1b1309ad"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-02-20T00:00:00.000Z","created_at":"2015-02-20T22:21:34.214Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":4492,"metadata":{},"number":"4.2.1.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"aade7124ac2625b2a2c5049b9aa6a1984a2c4e2d7ffe4ddb70df40f693498a3f"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-12-20T00:00:00.000Z","created_at":"2014-12-20T00:15:37.476Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":33746310,"metadata":{},"number":"4.2.0","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d394a78b2237145fffff3b7556ae64006139a7d1c04bc66b0bd39bbd5e4d3088"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-12-13T00:00:00.000Z","created_at":"2014-12-13T02:58:44.762Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":21107,"metadata":{},"number":"4.2.0.rc3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"aa939ee565e8ff5fab80ca4ac41820bc0923f48fa8c9dc39586d5b32d3c99f86"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-12-05T00:00:00.000Z","created_at":"2014-12-05T23:20:12.824Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":19328,"metadata":{},"number":"4.2.0.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"466ee46b83645d96721cd0ce8f04a7523ebdbea9d662236f5d65628c05765750"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-11-28T00:00:00.000Z","created_at":"2014-11-28T17:53:27.822Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":19288,"metadata":{},"number":"4.2.0.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"7ff0c8fdf7eacfdb66ffdd8295b3e7e337b0c4106135342f368c96c3b83b861d"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-10-30T00:00:00.000Z","created_at":"2014-10-30T22:13:30.689Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":39696,"metadata":{},"number":"4.2.0.beta4","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"8604a52c018fbc983188f4918b76fdd1391cc4d0628025da1b614f8f25eee94a"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-10-29T00:00:00.000Z","created_at":"2014-10-30T18:37:59.690Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3100,"metadata":{},"number":"4.2.0.beta3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"965834f54d88d45018b94606bc9942f8c9ba6664fcd5d046880a3955d64f96d6"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-09-29T00:00:00.000Z","created_at":"2014-09-29T17:16:38.761Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":39587,"metadata":{},"number":"4.2.0.beta2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"6a23c9f15562066ee77c555ed3251687ed21280a9851e045710c8e3e4b150c4e"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-08-20T00:00:00.000Z","created_at":"2014-08-20T02:34:44.046Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":27662,"metadata":{},"number":"4.2.0.beta1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"461642476534a11b33462e14176c667e737fd7310a1fc5e8f3aceb2a8f1c347d"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-07-12T00:00:00.000Z","created_at":"2016-07-12T22:20:56.527Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1337721,"metadata":{},"number":"4.1.16","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a19899f82c0a03a08cd2629636b75b582e0a64d908bda84c57e9cb70ac7adbd3"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-07-02T00:00:00.000Z","created_at":"2016-07-02T02:15:20.923Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2028,"metadata":{},"number":"4.1.16.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"1924d4e7d3175cc3f4ccb868050dddf67badb31174e32014e58e42459bf0d446"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-03-07T00:00:00.000Z","created_at":"2016-03-07T22:37:14.594Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":437073,"metadata":{},"number":"4.1.15","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9c94775ade272961c3bfae2a5a4ff2cddc319e48fd269d8e779240e2c94677d1"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-03-01T00:00:00.000Z","created_at":"2016-03-01T18:43:40.764Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2305,"metadata":{},"number":"4.1.15.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"bb56ce545d4c36ffcc19f41901a2dc73b26f70a6d750ce2a0da715eb3ac640a6"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-02-29T00:00:00.000Z","created_at":"2016-02-29T19:19:55.523Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":311016,"metadata":{},"number":"4.1.14.2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e5ca9faf11ef90c3e17b7e116b9297fc479910b22ef0775e64aaddcb8779885b"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-01-25T00:00:00.000Z","created_at":"2016-01-25T19:26:27.339Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":275661,"metadata":{},"number":"4.1.14.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"bde7704f906e5cf7dd4b098231a6e6471ac1b13ce1ac4940a320144be37f778d"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-11-12T00:00:00.000Z","created_at":"2015-11-12T18:20:40.613Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":223462,"metadata":{},"number":"4.1.14","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b617d83abc53f51a053a73678b6a5bc9357e6ae8348fadcc1461986b3deb59b9"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-11-05T00:00:00.000Z","created_at":"2015-11-05T02:55:44.276Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2326,"metadata":{},"number":"4.1.14.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"51352f9891747f4b780ac88a0de444ec653bf835344e29387e4d524ad8e3f668"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-10-30T00:00:00.000Z","created_at":"2015-10-30T20:45:42.801Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2605,"metadata":{},"number":"4.1.14.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"5f30dbd05959aa49e1d03fc9b5dff1a1ffaf31fc8ef6bd20a4cf1efeb567b677"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-08-24T00:00:00.000Z","created_at":"2015-08-24T18:02:56.741Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":239273,"metadata":{},"number":"4.1.13","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d11d1a3ca07f1494f2abb634677f390f897bb5ae4b818e1612aa6a6412837d1b"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-08-14T00:00:00.000Z","created_at":"2015-08-14T15:13:26.943Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3355,"metadata":{},"number":"4.1.13.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"bf3c029c337c0635a5390f32b3d7bd79828d683a71087c0e8979d0e49b728810"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-06-25T00:00:00.000Z","created_at":"2015-06-25T21:26:08.544Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":281703,"metadata":{},"number":"4.1.12","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"bb45840dc30f8accb1c38170383f8407b851b6321e06693c9adad7279237564c"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-06-22T00:00:00.000Z","created_at":"2015-06-22T14:05:08.486Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":6476,"metadata":{},"number":"4.1.12.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"84332f3ea6d94852fdd77fb1e0da3e6fb103c769436298fa2d2811e790c72404"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-06-16T00:00:00.000Z","created_at":"2015-06-16T18:00:13.043Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":311659,"metadata":{},"number":"4.1.11","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"eb7a9f8c5cb838e16f934e53f71f14e14ac2ef646939134a59eb65b3e209102b"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-03-19T00:00:00.000Z","created_at":"2015-03-19T16:50:27.388Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":384473,"metadata":{},"number":"4.1.10","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9f81f8b716ba76ea768b1c0ed4a185a3f7647b384fc297c26c2b51be82856fd3"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-03-12T00:00:00.000Z","created_at":"2015-03-12T21:32:52.724Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":6272,"metadata":{},"number":"4.1.10.rc4","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"178baf8604ad8212cb76c6e36052031de4ed2fc03d9f63e470735c482e1164bd"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-03-02T00:00:00.000Z","created_at":"2015-03-02T21:39:47.964Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2631,"metadata":{},"number":"4.1.10.rc3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"6958130cadf8306732bd0ef09a49f689c85e8f675aa77392c2bff605dc6fe795"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-02-25T00:00:00.000Z","created_at":"2015-02-25T22:22:40.645Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2744,"metadata":{},"number":"4.1.10.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"a3cb51aa45106f533ef1ea26f887e373ebdb62ec790d9d4dedfdb6d4c77fd640"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-02-20T00:00:00.000Z","created_at":"2015-02-20T22:25:09.666Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2533,"metadata":{},"number":"4.1.10.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"d9a824b98cc7b3024d40209e6bb9bb4b5538397d63aee3307363fa97f31c658b"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-01-06T00:00:00.000Z","created_at":"2015-01-06T20:04:31.185Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":540634,"metadata":{},"number":"4.1.9","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"19df2af2a3c6cd142714aca26a54e433bf39c20f82ac7b0fc7e1bcd38eed96d3"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-01-02T00:00:00.000Z","created_at":"2015-01-02T01:11:10.973Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2866,"metadata":{},"number":"4.1.9.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"f4696d6e42b17d01a99cad05929e952dbc41f442a9bd6b1051645b9d1004bc76"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-11-16T00:00:00.000Z","created_at":"2014-11-17T16:01:13.385Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1022842,"metadata":{},"number":"4.1.8","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"20f4a46c30dac40585721caf3b4b1c961a3cf425fd1ccbc6109ccd6df723599d"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-11-19T00:00:00.000Z","created_at":"2014-11-19T19:12:12.692Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":19458,"metadata":{},"number":"4.1.7.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"cc9e81e9396ca0a4161798d349db181dde75f829c941a7ad7cebcb3c3bda8edd"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-10-29T00:00:00.000Z","created_at":"2014-10-30T18:37:49.213Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":518331,"metadata":{},"number":"4.1.7","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"20972f5ce418d5b938afa42680bcbe8c52770c0664429233fa0e567a25bd3515"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-09-11T00:00:00.000Z","created_at":"2014-09-11T17:26:04.576Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1022611,"metadata":{},"number":"4.1.6","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f351c95673cb833652deeaab5c67998ab0af9ff3c89c585abe23dafa0648efa0"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-09-08T00:00:00.000Z","created_at":"2014-09-08T18:13:12.723Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3541,"metadata":{},"number":"4.1.6.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"e8d1061e0a7c8e419baf52de0fe879ef2a54ae11d23994334746b7a416be51d9"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-08-19T00:00:00.000Z","created_at":"2014-08-19T20:52:47.110Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":4346,"metadata":{},"number":"4.1.6.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"41b06c08092941570fd7c11c51a8f546f47a2fac7a9cb7ed3b08161e66c51b8b"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-08-18T00:00:00.000Z","created_at":"2014-08-18T17:01:03.727Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1161659,"metadata":{},"number":"4.1.5","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"47e2d4a43e1b9c238d8b7c51a6ccf0461ffd3e1b270dd6af02c42ed3f694438b"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-07-02T00:00:00.000Z","created_at":"2014-07-02T19:53:35.556Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1059223,"metadata":{},"number":"4.1.4","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"54272fde189892c5e55e53646b871236d8c513a438d38ad91b9d54d64453cf31"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-07-02T00:00:00.000Z","created_at":"2014-07-02T17:06:42.181Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":21409,"metadata":{},"number":"4.1.3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"028ed6d06d8b8c0c32fc19aaa0cd1c73fe662e505180f26542fccda38ba84236"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-06-26T00:00:00.000Z","created_at":"2014-06-26T14:50:09.079Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":252210,"metadata":{},"number":"4.1.2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"7797e5e3f1f917339ecaf2d85cb71e95fea40cd3f7e8f3c9c19c884d425b34fa"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-06-23T00:00:00.000Z","created_at":"2014-06-23T17:28:46.002Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":4110,"metadata":{},"number":"4.1.2.rc3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"ab9b39b7020cfa44077d1a3921ffa3e8a670c83aed2bd417bd7b6ec4bafbc610"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-06-16T00:00:00.000Z","created_at":"2014-06-16T16:30:46.332Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":6012,"metadata":{},"number":"4.1.2.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"bf02ccda7ff7f39a2703696756c1d6b59b49ba435483ce69e60262a669e58e19"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-05-27T00:00:00.000Z","created_at":"2014-05-27T16:12:48.106Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":10457,"metadata":{},"number":"4.1.2.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"077fe073cc38440ab5ffb78d29a948f2e3239d72fa5f3952cae0f137bf1ee8bd"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-05-06T00:00:00.000Z","created_at":"2014-05-06T16:11:31.458Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1083341,"metadata":{},"number":"4.1.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"602275642419e731637c91421cf498f2994c2d9f1b94f6c713f3b7b8757b2aa5"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-04-08T00:00:00.000Z","created_at":"2014-04-08T19:21:51.275Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":593148,"metadata":{},"number":"4.1.0","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d2ce7d3965f8c5d4b9076012d52512022dc0b0a0e4a427d801e84db449e140bf"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-03-25T00:00:00.000Z","created_at":"2014-03-25T20:12:47.195Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":19407,"metadata":{},"number":"4.1.0.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"3126c2bcd5866d179d034b9d56a352508d71d3596366124e853e45cca8e6d127"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-02-18T00:00:00.000Z","created_at":"2014-02-18T20:59:23.632Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":34515,"metadata":{},"number":"4.1.0.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"66f0c65ad0a8b1482ae983fb56005ec554ea35c02a6642be1684211e9a17c001"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-02-18T00:00:00.000Z","created_at":"2014-02-18T18:52:57.614Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":4627,"metadata":{},"number":"4.1.0.beta2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"ca40954f1f9af5e8ec3108defb461ad378d5a656007facfc1854e28375fe8def"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-12-18T00:00:00.000Z","created_at":"2013-12-18T00:15:16.640Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":33007,"metadata":{},"number":"4.1.0.beta1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"d40c33fec1c604ea8607b7bc7314281bdff1baa47535621a4be00081b6ebbb69"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-01-06T00:00:00.000Z","created_at":"2015-01-06T20:08:59.935Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1698430,"metadata":{},"number":"4.0.13","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d4b3ca8517b394459fd31773c5c6877b4aded8f2c84e6f5422061d231b2af9f6"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-01-02T00:00:00.000Z","created_at":"2015-01-02T00:54:54.587Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2814,"metadata":{},"number":"4.0.13.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"76021a6be6518a7d4f6d3de94cb09259cf0e00df5f194b70aa171d2cf116b685"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-11-16T00:00:00.000Z","created_at":"2014-11-17T16:01:00.306Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":262194,"metadata":{},"number":"4.0.12","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"96f47a8a2f06df95c78ac3baea02c01eefbd214034a715055f67b193988c4aec"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-11-19T00:00:00.000Z","created_at":"2014-11-19T19:09:54.075Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":15428,"metadata":{},"number":"4.0.11.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"80e495107ea0df0c607abdf141e91fec6b091ed0d0910036408e9c69dad68013"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-10-29T00:00:00.000Z","created_at":"2014-10-30T18:37:38.192Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":62262,"metadata":{},"number":"4.0.11","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ca9da5665e2e8e124a71fb4e7dcac32e38ae3188d869cda3f8c8593aeeafeec3"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-09-11T00:00:00.000Z","created_at":"2014-09-11T17:33:15.455Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":98604,"metadata":{},"number":"4.0.10","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0c9d3fc3fb0eaccd480e1fd3786ee0714923478ade4ed4c746eaca98786e018e"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-09-08T00:00:00.000Z","created_at":"2014-09-08T17:55:45.314Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2800,"metadata":{},"number":"4.0.10.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"429ed3e39212b61d1ae1713be631d8ba1b164a98575b83a43b040197b14de409"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-08-19T00:00:00.000Z","created_at":"2014-08-19T20:48:29.471Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3317,"metadata":{},"number":"4.0.10.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"a614c8bc222ae1e92e58b39447e8a81428e129eb3b330f990edf3d6ee15fa9f9"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-08-18T00:00:00.000Z","created_at":"2014-08-18T17:03:01.087Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":120515,"metadata":{},"number":"4.0.9","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b93edde41a48108589cf0684c7fb95a684b5193768166d3fc692d0dc0ad87d17"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-07-02T00:00:00.000Z","created_at":"2014-07-02T19:42:37.603Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":195364,"metadata":{},"number":"4.0.8","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"34a589d9718b8fbbb2fa557acda14e1639d796018d29873c7912f52e67056f15"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-07-02T00:00:00.000Z","created_at":"2014-07-02T17:04:32.418Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":20306,"metadata":{},"number":"4.0.7","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"86b89e68418745706b8a0cd76d8ae3ed49f298e59278be7350a3359c5f97b2e9"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-06-26T00:00:00.000Z","created_at":"2014-06-26T16:30:13.579Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":72307,"metadata":{},"number":"4.0.6","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a1631de04f0ce6634b56801a2046af5d42f8dde474fb82ba46194e2a6de5fdce"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-06-23T00:00:00.000Z","created_at":"2014-06-23T17:24:41.466Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2775,"metadata":{},"number":"4.0.6.rc3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"65b45b5fc19be3f776808be1e281af89e7840371aff24472e6a4a5d1b28e51dc"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-06-16T00:00:00.000Z","created_at":"2014-06-16T16:16:01.642Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2888,"metadata":{},"number":"4.0.6.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"d015f058c0d28236bc0a92816a3e950d19448831cbb6d3ebce4f1736fd98a3fe"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-05-27T00:00:00.000Z","created_at":"2014-05-27T16:06:55.364Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":4336,"metadata":{},"number":"4.0.6.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"6c64e8e92c4261c1cffdf8aada0fff3924c922580160c7026be62ffd81e7ed12"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-05-06T00:00:00.000Z","created_at":"2014-05-06T16:13:27.132Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":411843,"metadata":{},"number":"4.0.5","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"22cc7501b6d4b0e7b6b215777b0faf7f8181a1d5058ef7c88c3c328227485253"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-03-14T00:00:00.000Z","created_at":"2014-03-14T17:37:07.331Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":499618,"metadata":{},"number":"4.0.4","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ead3f37942b32496cd07837a01c40acc4f8c8df72e839f3d087a2c3543d760bc"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-03-11T00:00:00.000Z","created_at":"2014-03-11T17:31:18.568Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3966,"metadata":{},"number":"4.0.4.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"43964f6a9eb6fe95f62b1ab12cec6d8f7de1e37843fc32887f46721cb1eff7c3"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-02-18T00:00:00.000Z","created_at":"2014-02-18T18:49:43.150Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":641931,"metadata":{},"number":"4.0.3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"649f8ca0cdc10d47e6bef73e098937a2a61f5aabbcf2fde930d28675021e81be"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-12-03T00:00:00.000Z","created_at":"2013-12-03T19:01:29.867Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1171137,"metadata":{},"number":"4.0.2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b7485afabce7c526eee714f7daf020cc7f18be66567a55ad806b81294cc19ffa"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-11-01T00:00:00.000Z","created_at":"2013-11-01T19:08:16.307Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":512193,"metadata":{},"number":"4.0.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e3759fcd9fd550589404ba0975857142dbdcef2bbfdf71c43a7ee372196cc76e"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-10-30T00:00:00.000Z","created_at":"2013-10-30T20:49:25.297Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3635,"metadata":{},"number":"4.0.1.rc4","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"33e52b019bb067651017f7f4e1fa8dbee84ec8c06c67e584f60effbe3f298437"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-10-23T00:00:00.000Z","created_at":"2013-10-23T21:41:08.791Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":4883,"metadata":{},"number":"4.0.1.rc3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"de966ab76954cdc4a3f187cc5ead6fefd11f139ef0dc9b8dddcf9e603117fbeb"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-10-21T00:00:00.000Z","created_at":"2013-10-21T22:01:19.341Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3862,"metadata":{},"number":"4.0.1.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"5247e609526b43ea03aa6530101181d2d4711a97b2c24e373d83dbeeefb6c9e5"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-10-17T00:00:00.000Z","created_at":"2013-10-17T16:46:23.993Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":4817,"metadata":{},"number":"4.0.1.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"3b186b3822d62ef5caaf71dfb1a495e595e3fef99397b4a88ded88d1f09ccb68"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-06-25T00:00:00.000Z","created_at":"2013-06-25T14:32:58.526Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2669182,"metadata":{},"number":"4.0.0","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"6eabebfbe7dcdabeddf69356f84cec3d78e395b08aa1de700e265f7cbff8028b"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-06-11T00:00:00.000Z","created_at":"2013-06-11T20:26:00.144Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":50422,"metadata":{},"number":"4.0.0.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":null,"sha":"da2455bd8c71eecabce7d6505b6a452fe77e2ff8ee4b6bd474b6daae96d7d5a5"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-04-29T00:00:00.000Z","created_at":"2013-04-29T15:39:05.085Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":87832,"metadata":{},"number":"4.0.0.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":null,"sha":"7363c1797b63e2ab31d9f1752a786993de71f7f3b31cd56f81c9f35cec62f586"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-02-26T00:00:00.000Z","created_at":"2013-02-26T00:05:43.566Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":64119,"metadata":{},"number":"4.0.0.beta1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":null,"sha":"3df8a03efbcb0ee25bedd11a761c8920e80ffb76b7a8c474e6fed17aaec5299f"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-09-14T00:00:00.000Z","created_at":"2016-09-14T21:19:01.962Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":6697951,"metadata":{},"number":"3.2.22.5","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c7ba428e51536d961e2fba7bbc65527901ee015ea41696ac803a97716ad58d14"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-08-11T00:00:00.000Z","created_at":"2016-08-11T19:20:46.883Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":679657,"metadata":{},"number":"3.2.22.4","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"cd62b28ac2f2e4e6eb41dd785c02eae4ea48fb198ce08d062170c86b9fefd8ad"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-08-10T00:00:00.000Z","created_at":"2016-08-11T17:34:59.710Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":183548,"metadata":{},"number":"3.2.22.3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"933b7ca70386fd8ec9693a254ffc177c82de54c7d7635e385b92a2d7179d23e8"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-02-29T00:00:00.000Z","created_at":"2016-02-29T19:24:19.757Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1092085,"metadata":{},"number":"3.2.22.2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e40902aa453b1ce4e0048221d8d1d4e8dda1f3bd58c80c23f6c38c7bd3fae9cb"},{"authors":"David
+        Heinemeier Hansson","built_at":"2016-01-25T00:00:00.000Z","created_at":"2016-01-25T19:26:12.364Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":441732,"metadata":{},"number":"3.2.22.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"55bc070a05d583ffc0028bfc6b1c5be60e9d5fc7655ebada06c5c83ae38249e9"},{"authors":"David
+        Heinemeier Hansson","built_at":"2015-06-16T00:00:00.000Z","created_at":"2015-06-16T18:06:38.294Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1399976,"metadata":{},"number":"3.2.22","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4e6341bbab6d88aa0578034474699c3793448dfbaa09d89f708304591f3b8a21"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-11-16T00:00:00.000Z","created_at":"2014-11-17T16:00:44.994Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1238717,"metadata":{},"number":"3.2.21","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d0f6904bc864307cb0236a3cc8b252d355e4536223614aee33265f23ead3c55a"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-10-29T00:00:00.000Z","created_at":"2014-10-30T18:37:26.434Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":207118,"metadata":{},"number":"3.2.20","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"38cc06efd458dde28f1ea20f3c4095d7cf2aae5a74a1689ebcc0ab7d8af88a7c"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-07-02T03:00:00.000Z","created_at":"2014-07-02T17:02:48.733Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":955786,"metadata":{},"number":"3.2.19","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"33b64cf78dfcf3206d961ce03e8fe6d260081da696e60da39d0b2a4a160fe22b"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-05-06T00:00:00.000Z","created_at":"2014-05-06T16:17:02.829Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1136017,"metadata":{},"number":"3.2.18","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b087466024542c7abebc85cb5638ba8bed302616a914996cad454bf8d6e54198"},{"authors":"David
+        Heinemeier Hansson","built_at":"2014-02-18T03:00:00.000Z","created_at":"2014-02-18T18:54:56.443Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1055101,"metadata":{},"number":"3.2.17","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8eff1bbf9f22fa943e58e9b71c6bdbe5d5d95caf022bec38ce083599961cb984"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-12-03T00:00:00.000Z","created_at":"2013-12-03T19:01:19.549Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":820736,"metadata":{},"number":"3.2.16","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"fc470010d70c7628e9e6c4bd535f85571a24cdfadf9b58560e6b2d5f3d396ab0"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-10-16T00:00:00.000Z","created_at":"2013-10-16T17:23:10.503Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":391543,"metadata":{},"number":"3.2.15","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9ed01092cb939f8c9be82138a8ba83df45260d544f86a0465893491dbdc2794c"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-10-11T00:00:00.000Z","created_at":"2013-10-11T21:17:17.374Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":8966,"metadata":{},"number":"3.2.15.rc3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"5a087619b019dc3b090155dd423e75e512ac30f5a00f129201742a553a3b0036"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-10-04T00:00:00.000Z","created_at":"2013-10-04T20:48:45.484Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":9338,"metadata":{},"number":"3.2.15.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"0e6822abce7c9a8c35ca654460f97969c00e1b7a5103f7625a3566b2bfaa6f91"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-10-03T00:00:00.000Z","created_at":"2013-10-03T18:54:09.709Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":9001,"metadata":{},"number":"3.2.15.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"32a978bcf58bf17be4ead4db931e07da8369e20689f869a91c2d12665dfac2bd"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-07-22T03:00:00.000Z","created_at":"2013-07-22T16:44:50.870Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":793536,"metadata":{},"number":"3.2.14","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d63321eb0231dbf576ba19017cf87b3e2d8b863dd6402f26f198455fd1377963"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-07-16T03:00:00.000Z","created_at":"2013-07-16T16:13:33.339Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":10224,"metadata":{},"number":"3.2.14.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":["MIT"],"requirements":null,"sha":"ee3613d278f46c0b75a9ac9e6e47b4ab2022096751c09c189a2422e188af7b06"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-07-12T03:00:00.000Z","created_at":"2013-07-13T00:25:39.110Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":9040,"metadata":{},"number":"3.2.14.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":["MIT"],"requirements":null,"sha":"f67b0755e5c94f836819ecfb2d0c935b33eb2ae1132a6bf2eb03af6bcf9f7399"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-03-18T00:00:00.000Z","created_at":"2013-03-18T17:13:33.058Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":4659431,"metadata":{},"number":"3.2.13","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":[],"requirements":null,"sha":"dfc57cb7d289513dd89a99db6f714fbdb407223160abf98293b74be07724bcb8"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-03-06T00:00:00.000Z","created_at":"2013-03-06T23:06:19.052Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":13041,"metadata":{},"number":"3.2.13.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":[],"requirements":null,"sha":"b7c97755db51ec5a89e9fd042f7bdc4126a2af9b7808ebf378f68157448bdd92"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-02-27T00:00:00.000Z","created_at":"2013-02-27T20:25:46.062Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":14418,"metadata":{},"number":"3.2.13.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":[],"requirements":null,"sha":"a5d6658c62b366916e136c3aa8ac501664e81741d0ca66b5feaa2b33207e075d"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-02-11T00:00:00.000Z","created_at":"2013-02-11T18:17:41.481Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1639888,"metadata":{},"number":"3.2.12","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":[],"requirements":null,"sha":"bff3605849350b46cceab64e0b9136cd8743d45db902160c19bbd06fc9a956ca"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-01-08T00:00:00.000Z","created_at":"2013-01-08T20:08:45.798Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1561959,"metadata":{},"number":"3.2.11","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":[],"requirements":null,"sha":"f5e02999889aa39af2c7d2c882d9e3b5c71e8adfc98236a69dadacdfbce5603e"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-12-23T00:00:00.000Z","created_at":"2013-01-02T21:20:01.186Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":129680,"metadata":{},"number":"3.2.10","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":[],"requirements":null,"sha":"a90e9d6d953b63b4ff19c99fc0a5c823537ede5ef0528cf6dce6debde4f0e1ef"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-11-12T00:00:00.000Z","created_at":"2012-11-12T15:21:34.822Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":722549,"metadata":{},"number":"3.2.9","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"8e4dcd26fe5db9ac017d0b30194190e12e0023edd93e3dd8401fe7f5e91d666a"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-11-09T00:00:00.000Z","created_at":"2012-11-09T18:00:50.077Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":11794,"metadata":{},"number":"3.2.9.rc3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"551741df96e10e832d9397b38329df1b64c00a4e0b6321b379b6ce5a9838ca4e"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-11-01T00:00:00.000Z","created_at":"2012-11-01T17:39:37.178Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":11194,"metadata":{},"number":"3.2.9.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"ccfbf907e3f84c349ee514c675ba170a832b0178b8868bf2f49300471fb29e3a"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-10-29T00:00:00.000Z","created_at":"2012-10-29T17:07:08.109Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":9923,"metadata":{},"number":"3.2.9.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"a9faa5f3d00f60d5bbe8a47ec55325be4cc17377e772b39e59be86e0dd3419c8"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-08-09T00:00:00.000Z","created_at":"2012-08-09T21:23:34.632Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1414861,"metadata":{},"number":"3.2.8","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"f671d492f91e52e203c99cd989682df89993abaca8b4861732afe1413ead7fcc"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-08-03T00:00:00.000Z","created_at":"2012-08-03T14:29:05.254Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":12654,"metadata":{},"number":"3.2.8.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"5a37f0e07cf92509861850180598fefb2cbe22e2abcf5ec05a7f4e0006206c07"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-08-01T00:00:00.000Z","created_at":"2012-08-01T20:57:56.061Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":9591,"metadata":{},"number":"3.2.8.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"a036e0620a52290a43b39a489eaf2da2d130da436172b95ccfd0ccd9c2344f4e"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-07-26T00:00:00.000Z","created_at":"2012-07-26T22:09:06.275Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":223920,"metadata":{},"number":"3.2.7","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"8aad4faaabd497b3c4f07a02b9720e3111c7fa0967cf7d4d7a9c18b88d13997f"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-07-23T00:00:00.000Z","created_at":"2012-07-23T21:45:55.204Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":9830,"metadata":{},"number":"3.2.7.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"bde8690cc0a4680b20d2d766d20bc757e24a155b5e954dc2d352089bb8711d65"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-06-12T00:00:00.000Z","created_at":"2012-06-12T21:26:21.434Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":778318,"metadata":{},"number":"3.2.6","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"55389d82ad04ea822c7236a1a877d90b18ad4defed4c0e7a2a9bb2e6bcd19ea0"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-06-01T00:00:00.000Z","created_at":"2012-06-01T03:39:04.678Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":202556,"metadata":{},"number":"3.2.5","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"d8888a6e10a1d680b9c8ba02047d2627cb23c6aefe30c058d454d07404dde73c"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-05-31T00:00:00.000Z","created_at":"2012-05-31T18:25:13.532Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":20313,"metadata":{},"number":"3.2.4","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"912f6ab1389714d1c6413af35166dddccb8dc813601ff4f6135073944a19f464"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-05-28T00:00:00.000Z","created_at":"2012-05-28T19:01:55.834Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":11296,"metadata":{},"number":"3.2.4.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"77e110499ba11b682dab2ca222b226ea7a968b20992dc342974b2790a8770c0a"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-03-30T03:00:00.000Z","created_at":"2012-03-30T22:26:20.685Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":830486,"metadata":{},"number":"3.2.3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"b8d6e5332d0473ffda078440a1692b97ad0053320fc1d041f00e133f78ff7c22"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-03-29T03:00:00.000Z","created_at":"2012-03-29T16:14:14.715Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":11350,"metadata":{},"number":"3.2.3.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"af25d80df3c66b6f46cc7b8942266316e4edb55b97107908fcf5078b7811fc5a"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-03-27T03:00:00.000Z","created_at":"2012-03-27T17:11:24.443Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":9996,"metadata":{},"number":"3.2.3.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"b8de1fa9b9de8b1d204c03eff30fe8d3020da24be73111646bba5f8e01273313"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-03-01T00:00:00.000Z","created_at":"2012-03-01T17:52:33.094Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":440535,"metadata":{},"number":"3.2.2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"c957b71fd93372a3d1aa411e8449387e415e5941afd404d4cedbf72f4840904f"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-02-22T00:00:00.000Z","created_at":"2012-02-22T21:39:35.308Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":12781,"metadata":{},"number":"3.2.2.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"4a9339f95524ea5ba61241794bc175ea486e926ffe05b627b0ae573d0082a816"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-01-26T08:00:00.000Z","created_at":"2012-01-26T23:09:41.494Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":504327,"metadata":{},"number":"3.2.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"255bc08d24e2c6fcc1c8087e5c14b51d13b632191b9bd686111ac0cd7dbda53b"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-01-20T00:00:00.000Z","created_at":"2012-01-20T16:47:48.848Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":205016,"metadata":{},"number":"3.2.0","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"f0cba07568a9ddae8e62cd170021e7ba2edc6ea0248249ca2f6d476062264c82"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-01-04T02:00:00.000Z","created_at":"2012-01-04T21:05:27.454Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":20984,"metadata":{},"number":"3.2.0.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"ec99dde4efff34839d278e5a38146494cd9e61e99983837b96f122b2fc2474fb"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-12-20T00:00:00.000Z","created_at":"2011-12-20T00:41:10.661Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":17023,"metadata":{},"number":"3.2.0.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"c28c2bde7219998d1d41e1753210b661153b4090477dfbd4f750bd350ac3c474"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-03-18T00:00:00.000Z","created_at":"2013-03-18T17:13:29.344Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":547119,"metadata":{},"number":"3.1.12","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":[],"requirements":null,"sha":"8e6ce8ddb8b69051ec8109d0439c622a986aa4da47f5156141e7a936656f958c"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-02-11T00:00:00.000Z","created_at":"2013-02-11T18:17:37.200Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":64380,"metadata":{},"number":"3.1.11","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":[],"requirements":null,"sha":"45f4a20aaff2ca71b6096e3a0ab6c770ccabae17203510b43bb26f862d9a35fa"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-01-08T00:00:00.000Z","created_at":"2013-01-08T20:08:37.727Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":99249,"metadata":{},"number":"3.1.10","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":[],"requirements":null,"sha":"1bdd1d8597d50e2b3bcea99491541855774182dbe0b39d07ed75c321c1e6b621"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-12-23T00:00:00.000Z","created_at":"2013-01-02T21:19:56.845Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":8136,"metadata":{},"number":"3.1.9","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":[],"requirements":null,"sha":"3f8187f4651afa2cc25c9adcf98cd1292ca3d868484c1cb230ef0534b5be923b"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-08-09T00:00:00.000Z","created_at":"2012-08-09T21:20:27.129Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":59061,"metadata":{},"number":"3.1.8","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"9d98892e0b34d02ba229a7978edb204d209991a9964617018613f221a5deb7ae"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-07-26T00:00:00.000Z","created_at":"2012-07-26T22:09:00.975Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":15359,"metadata":{},"number":"3.1.7","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"dc9a69eb2baf2e76e8342bf63c2f10e8cdf1935c53696e41df3923d937a7f60e"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-06-12T00:00:00.000Z","created_at":"2012-06-12T21:26:16.856Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":37858,"metadata":{},"number":"3.1.6","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"0b6aeb69bfc2b62ad32a3f51ac94b9b9f1df1175d113e53e53435b259540be25"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-05-31T00:00:00.000Z","created_at":"2012-05-31T18:25:06.617Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":15010,"metadata":{},"number":"3.1.5","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"7dc2e7e85492f697897a17b00108b3e3f8f402d0662ab94f78d78bc82be06414"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-05-28T00:00:00.000Z","created_at":"2012-05-28T19:01:51.050Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3553,"metadata":{},"number":"3.1.5.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"c0d32af5585aa8f27864d2d7d1b6bc5879e51213ff6805bfd40b247ad6b508bf"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-03-01T00:00:00.000Z","created_at":"2012-03-01T17:52:28.342Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":84769,"metadata":{},"number":"3.1.4","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"54daf5c2efb87ab97b6db0017095d9e4135384e68a007f9ed5570e8de9ffe347"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-02-22T00:00:00.000Z","created_at":"2012-02-22T21:39:29.633Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3237,"metadata":{},"number":"3.1.4.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"95d1dabe3e7e6bc786a575eabfc653f5c05e4b505227002c97da92fcd364b5d0"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-11-20T00:00:00.000Z","created_at":"2011-11-20T22:52:57.492Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":681906,"metadata":{},"number":"3.1.3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"e817252efd196b32a16b0af6a92eecd8b2e0b1cbe1511b36fab6c8acdc53e81e"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-11-18T00:00:00.000Z","created_at":"2011-11-18T01:33:32.509Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":45415,"metadata":{},"number":"3.1.2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"497d2cea86aef0dd771b06e40f34a2b9f7bdf36e1aee2c5f120efccd6779b8ca"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-11-14T00:00:00.000Z","created_at":"2011-11-14T15:49:20.198Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":5101,"metadata":{},"number":"3.1.2.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"1b98c4afc960cda211f80415a3364c8f83bcde20f2ad94fc610232568050bd37"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-11-14T00:00:00.000Z","created_at":"2011-11-14T14:17:34.523Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3035,"metadata":{},"number":"3.1.2.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"1d457b4e3a4879a97e08c1cd8fd1eea6ee9a8a96d08556d8d3333811407be597"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-10-07T02:00:00.000Z","created_at":"2011-10-07T15:30:09.628Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":600654,"metadata":{},"number":"3.1.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"42cb4042721dce66f99f4c0a746d25fe2fcddd2a6bcd8311aee82ce2c2590a71"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-10-05T02:00:00.000Z","created_at":"2011-10-06T02:31:00.452Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":6409,"metadata":{},"number":"3.1.1.rc3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"c0da874562db60d275214b5a648a3d6e217bda850390618cfd3e253fc87b75c7"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-09-29T03:00:00.000Z","created_at":"2011-09-29T22:17:03.417Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":8547,"metadata":{},"number":"3.1.1.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"f78ea13013f327c1671f259df7852ffddd6c60fa395d305eba4106db4e29dbbb"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-09-14T07:00:00.000Z","created_at":"2011-09-15T00:27:03.617Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":12666,"metadata":{},"number":"3.1.1.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"08ba139997c7e67548108f006dc36aa721d566b91f54dc4dade21cfa5a1c4b26"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-08-31T00:00:00.000Z","created_at":"2011-08-31T02:18:30.035Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":648933,"metadata":{},"number":"3.1.0","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"baceb82d8eba98f2a5a1eb9e43f14b36019968b6fbdb3dc76d6e4f40b09520ce"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-08-29T03:00:00.000Z","created_at":"2011-08-29T03:27:19.194Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":15119,"metadata":{},"number":"3.1.0.rc8","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"0037ca2b3e1bb58387e94d75453fc5225a490eb7cd27353e3a0442e4509045f9"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-08-16T00:00:00.000Z","created_at":"2011-08-16T22:33:32.921Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":25671,"metadata":{},"number":"3.1.0.rc6","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"f476858812dcf407ff4d611cbc7219cdbc2670f3e8df302d8b6aaed94bc11d3c"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-07-25T07:00:00.000Z","created_at":"2011-07-25T23:05:19.817Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":46436,"metadata":{},"number":"3.1.0.rc5","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"4ed6720e0617f19af73d5f7b76eb74bf680b06f959cd7e96ad73e48bf7c68c80"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-06-09T00:00:00.000Z","created_at":"2011-06-09T22:56:24.880Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":58267,"metadata":{},"number":"3.1.0.rc4","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"95685245f0a6614620732d864bd43b6fcb971f9f1b9ab58af931ffae9d1f1377"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-06-08T00:00:00.000Z","created_at":"2011-06-08T21:27:28.270Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":6176,"metadata":{},"number":"3.1.0.rc3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"e7e7fd177a90b923e27981d5e400d0a3f60f3ffe7e7c60a9e7bb14b582194645"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-06-07T00:00:00.000Z","created_at":"2011-06-08T00:16:57.976Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":4778,"metadata":{},"number":"3.1.0.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"16048d9b21ed4b0bb5cdb889871f560434b51c8e7f1087cf2e222e3014216ecf"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-05-21T05:00:00.000Z","created_at":"2011-05-22T02:26:25.383Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":24996,"metadata":{},"number":"3.1.0.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"2b46e1da4b9b61e992c218bc6d1e7a1d02d29d43211467b1c471b055d5daca87"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-05-04T05:00:00.000Z","created_at":"2011-05-05T01:23:18.105Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":12428,"metadata":{},"number":"3.1.0.beta1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"c431d0f391f6b83c9706512a3d36b09022e007009aa6980375f53002d00cd7ce"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-01-28T00:00:00.000Z","created_at":"2013-01-28T21:01:34.374Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":491683,"metadata":{},"number":"3.0.20","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":[],"requirements":null,"sha":"e22944d88c22d206e719bee3757fbbc0d025d00419421e5609a9a52136be3190"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-01-08T00:00:00.000Z","created_at":"2013-01-08T20:08:33.922Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":107613,"metadata":{},"number":"3.0.19","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":[],"requirements":null,"sha":"da9e6e21a032770f56c0e92f7099897a3638392f8d4a37cd572641915056c7ca"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-12-23T00:00:00.000Z","created_at":"2013-01-02T21:19:52.960Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":12660,"metadata":{},"number":"3.0.18","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":[],"requirements":null,"sha":"c96ba8e2455bc77afa663361e741897c8b495c6f626345c1db8b609348cdb122"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-08-09T00:00:00.000Z","created_at":"2012-08-09T21:16:44.882Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":84216,"metadata":{},"number":"3.0.17","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"ac0b85ef41d5f6ebb6aefb351dc6e76b900afb94b461a3c8d8ec7a63a99c64e3"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-07-26T00:00:00.000Z","created_at":"2012-07-26T22:08:54.212Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":16396,"metadata":{},"number":"3.0.16","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"7b14ba4cea871bebaed72e08cf79416422fe95120b1401c6b23a79eff9d1e54b"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-06-13T00:00:00.000Z","created_at":"2012-06-13T03:07:06.509Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":46286,"metadata":{},"number":"3.0.15","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"173991d2fc89845a1a40e72577c03570fb1ce13c0f26b81aa3b99023e17a985a"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-06-12T00:00:00.000Z","created_at":"2012-06-12T21:26:07.460Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":36886,"metadata":{},"number":"3.0.14","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"31209d39bcef559372fe8eb3c9e7769051c69591d375034d0e8eee536353e19e"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-05-31T00:00:00.000Z","created_at":"2012-05-31T18:24:59.747Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":31015,"metadata":{},"number":"3.0.13","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"a5cdefded06acd971b26f69a9576a8118e921ec9f108f335c22cfe21fc766e56"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-05-28T00:00:00.000Z","created_at":"2012-05-28T19:01:47.715Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3021,"metadata":{},"number":"3.0.13.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"38c993b39330d21ea4ba2aa8acd8d88d0219abcb42c93ddc7e82ee4b59ef7cfa"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-03-01T00:00:00.000Z","created_at":"2012-03-01T17:52:15.609Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":72725,"metadata":{},"number":"3.0.12","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"5ab5c1db3c93443b950dee6cdd6895521ca37ed52b0963950bbe6b240af041da"},{"authors":"David
+        Heinemeier Hansson","built_at":"2012-02-22T00:00:00.000Z","created_at":"2012-02-22T21:39:19.764Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3112,"metadata":{},"number":"3.0.12.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"4a4502bd401d4a66e655590e42ade5574ca57f904a4a2d412e6a662daf5cced3"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-11-18T00:00:00.000Z","created_at":"2011-11-18T01:23:23.249Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":148753,"metadata":{},"number":"3.0.11","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"7ed7792bfd4696bc049d95e4e377b682b51796b93cc91a2af42a0392bbc2e08b"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-08-16T00:00:00.000Z","created_at":"2011-08-16T22:14:17.045Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":524630,"metadata":{},"number":"3.0.10","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"834755313f61aae189be2c288702fbb0d64897d0c69ea49899e6509eb3f6601c"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-08-04T07:00:00.000Z","created_at":"2011-08-05T00:12:05.290Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3435,"metadata":{},"number":"3.0.10.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"d51cd45b0470ebc7d20767cb8154e3407b60e1579e4adcd72c5e6ca8f1154a21"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-06-16T00:00:00.000Z","created_at":"2011-06-16T10:05:11.080Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":693965,"metadata":{},"number":"3.0.9","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"91f10c3d1e0eb0f8689eaf6faa5bd8b3ab0fab43841795858d3ef04e8f4c54e6"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-06-12T00:00:00.000Z","created_at":"2011-06-12T21:30:07.555Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":4122,"metadata":{},"number":"3.0.9.rc5","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"b38a829c67b550aead716f941dce7400dc7017b034f4f7e726a2c707fcc08ebc"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-06-12T00:00:00.000Z","created_at":"2011-06-12T21:24:34.980Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":2813,"metadata":{},"number":"3.0.9.rc4","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"57edf8c61d376fd432aae8b35262d51a32448abc653c25d02054ee42b6bbab56"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-06-09T00:00:00.000Z","created_at":"2011-06-09T22:51:39.349Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3484,"metadata":{},"number":"3.0.9.rc3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"f36d75d00b0ee6e00d77a1b3e95c7480e6c64f2a86884e264f4be74883762003"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-06-08T00:00:00.000Z","created_at":"2011-06-08T21:20:17.404Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3038,"metadata":{},"number":"3.0.9.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"bccf3485ac649a8c51acca29f29e7afc1b5793558e1515c6b0a0269ad686f506"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-06-07T00:00:00.000Z","created_at":"2011-06-08T00:16:45.270Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":83552,"metadata":{},"number":"3.0.8","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"a3825a0604bd76e3a08d1f0b36066a90e2f61081a49ae0de201cebb3b017c07f"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-05-31T00:00:00.000Z","created_at":"2011-05-31T00:08:18.745Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":4055,"metadata":{},"number":"3.0.8.rc4","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"570ec6f67ab83c7710edfcb356a446b3fffe7da61cf9807e4558439bf521471d"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-05-27T00:00:00.000Z","created_at":"2011-05-27T16:32:24.502Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":4266,"metadata":{},"number":"3.0.8.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"0079f08fc880ce37ab7e9df99b7a4cdc9965823f117b326f118dccca0dbdcd09"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-05-25T00:00:00.000Z","created_at":"2011-05-26T00:11:36.891Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3653,"metadata":{},"number":"3.0.8.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"22a234acc4672efbd028fa2e41def42691ac96d7b47910da9c8fc457b2eff9f1"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-04-18T00:00:00.000Z","created_at":"2011-04-18T21:05:54.308Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":567371,"metadata":{},"number":"3.0.7","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"e4ea21b341e13eea253f5731d08e84df39b0cdf0073d2f3964dc8852fc08d677"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-04-15T03:00:00.000Z","created_at":"2011-04-15T17:33:53.132Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":4868,"metadata":{},"number":"3.0.7.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"111a6c994175a43d124e4484e100030836a6fee0f8e829c707145e9ea660fbb9"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-04-14T03:00:00.000Z","created_at":"2011-04-14T21:57:06.386Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3362,"metadata":{},"number":"3.0.7.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"02fb4df597b46a36339e9b330fa10d914b84c1abf320659bcf375e9ef85d2f16"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-04-05T07:00:00.000Z","created_at":"2011-04-05T23:05:21.745Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":182750,"metadata":{},"number":"3.0.6","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"6954253775af9586738dacc2ca46c842bf6d9641d7b8aff47799b682ba53f788"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-03-30T07:00:00.000Z","created_at":"2011-03-31T05:28:51.216Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":4256,"metadata":{},"number":"3.0.6.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"d067f53170165829b3363b77abd3aee9d19cfb20c8b9e92cbbaaf8b57dcc56dc"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-03-29T07:00:00.000Z","created_at":"2011-03-29T20:47:15.107Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":3594,"metadata":{},"number":"3.0.6.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"654c6c071e442b45359b914b5a692c2a8131c8fe0e92e4f1a2a5099b78b915ad"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-02-26T08:00:00.000Z","created_at":"2011-02-27T02:30:55.377Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":441439,"metadata":{},"number":"3.0.5","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"54fba5b3b2de73b1cb1328f3f713e4dcf9aa50487bf38a0e9014dcdb5cc31060"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-02-22T08:00:00.000Z","created_at":"2011-02-23T19:08:34.691Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":6069,"metadata":{},"number":"3.0.5.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"c8f14fe969bc8f1ac304ac373cee613d5a5d9aa396973c07f35bbe89d291d4f2"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-02-08T11:00:00.000Z","created_at":"2011-02-08T21:17:48.221Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":236634,"metadata":{},"number":"3.0.4","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"788f91450de432af7dc92759d628651a64670eb4512b0b2e53f1518408d7102b"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-01-30T11:00:00.000Z","created_at":"2011-01-30T23:00:37.572Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":5776,"metadata":{},"number":"3.0.4.rc1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"412f83f9bc0815d5fef3bb315d6d0bf3691ea70e8fe85d368cb1c2d03f0ef036"},{"authors":"David
+        Heinemeier Hansson","built_at":"2010-11-16T06:00:00.000Z","created_at":"2010-11-16T16:29:00.892Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":1822483,"metadata":{},"number":"3.0.3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"8b8d64141d764123e37d969f484a7024f8d318e5b4b58f57023b5e5910873a16"},{"authors":"David
+        Heinemeier Hansson","built_at":"2010-11-15T06:00:00.000Z","created_at":"2010-11-15T19:33:41.460Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":16743,"metadata":{},"number":"3.0.2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"26fd8f1afbe5e57da2bcb7478c0ad3e07c68d663455193804030b4853387582f"},{"authors":"David
+        Heinemeier Hansson","built_at":"2010-10-14T11:00:00.000Z","created_at":"2010-10-14T20:55:44.846Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":295005,"metadata":{},"number":"3.0.1","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"fba018f56c5a1f59cb728c99eeb5d5e8c33e2840e7659ac0ef37126fa56096af"},{"authors":"David
+        Heinemeier Hansson","built_at":"2010-08-29T05:00:00.000Z","created_at":"2010-08-29T23:11:11.490Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":475649,"metadata":{},"number":"3.0.0","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"5a9a2c14077d27d849ae660c03dd9427b8cd9c3151135968d89b0454be8c5efe"},{"authors":"David
+        Heinemeier Hansson","built_at":"2010-08-23T05:00:00.000Z","created_at":"2010-08-24T03:04:45.033Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":28744,"metadata":{},"number":"3.0.0.rc2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"230933ac5e0a471828b5c96bfe1bb1a64bc12a38272831167ac04c41c05eb17a"},{"authors":"David
+        Heinemeier Hansson","built_at":"2010-07-26T05:00:00.000Z","created_at":"2010-07-26T21:43:12.765Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":62313,"metadata":{},"number":"3.0.0.rc","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"f9d71d36335c8f1977297d798219d156925b5ff88016e31e461da7d861b7640c"},{"authors":"David
+        Heinemeier Hansson","built_at":"2010-06-08T04:00:00.000Z","created_at":"2010-06-08T22:33:16.046Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":56943,"metadata":{},"number":"3.0.0.beta4","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"7bc33c1d4d19adc966623b63145850d27acb3909a3f3f1261edaa7cb5909684c"},{"authors":"David
+        Heinemeier Hansson","built_at":"2010-04-13T07:00:00.000Z","created_at":"2010-04-13T19:23:14.932Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":37234,"metadata":{},"number":"3.0.0.beta3","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"844077429ca99abd906ea3f6cace6b8ed203a04c225cee160ebde2fb1237a2b5"},{"authors":"David
+        Heinemeier Hansson","built_at":"2010-04-01T07:00:00.000Z","created_at":"2010-04-01T21:26:26.222Z","description":"Ruby
+        on Rails is a full-stack web framework optimized for programmer happiness
+        and sustainable productivity. It encourages beautiful code by favoring convention
+        over configuration.","downloads_count":17026,"metadata":{},"number":"3.0.0.beta2","summary":"Full-stack
+        web application framework.","platform":"ruby","rubygems_version":"\u003e=
+        1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"ca4d55afc7830c9115a889b16bf1e232ea043ac8e03be985d637612f07adf9f5"},{"authors":"David
+        Heinemeier Hansson","built_at":"2010-02-04T08:00:00.000Z","created_at":"2010-02-05T03:02:19.496Z","description":"Full-stack
+        web-application framework.","downloads_count":32937,"metadata":{},"number":"3.0.0.beta","summary":"Full-stack
+        web-application framework.","platform":"ruby","rubygems_version":"\u003e 1.3.1","ruby_version":null,"prerelease":true,"licenses":null,"requirements":null,"sha":"01b687a16321b2905bdc7386d35ed99350440009926f383629a748f81cceb3ce"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-03-18T07:00:00.000Z","created_at":"2013-03-18T17:13:25.422Z","description":"    Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick\n    on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server,
+        or Oracle with eRuby- or Builder-based templates.\n","downloads_count":1100939,"metadata":{},"number":"2.3.18","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"f92ee63fdb481d5d0758db6a955f850d44f525558ccc5ad7ce4367220a72314d"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-02-11T00:00:00.000Z","created_at":"2013-02-11T18:17:30.726Z","description":"    Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick\n    on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server,
+        or Oracle with eRuby- or Builder-based templates.\n","downloads_count":95383,"metadata":{},"number":"2.3.17","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"644c7b054638c0b7e92c12dfe0574c63c5929abfb42a1cc6b9196bfdd9e5b017"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-01-28T00:00:00.000Z","created_at":"2013-01-28T21:01:30.451Z","description":"    Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick\n    on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server,
+        or Oracle with eRuby- or Builder-based templates.\n","downloads_count":66849,"metadata":{},"number":"2.3.16","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"8228c5404bddc2dd7b99495f348b40302709da577a096619f90e8c37e824060a"},{"authors":"David
+        Heinemeier Hansson","built_at":"2013-01-08T08:00:00.000Z","created_at":"2013-01-08T20:08:28.812Z","description":"    Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick\n    on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server,
+        or Oracle with eRuby- or Builder-based templates.\n","downloads_count":99703,"metadata":{},"number":"2.3.15","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"21c177e2577faa9d09319a965870ee5f03d944d2e558573df852659cd729a79e"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-08-16T00:00:00.000Z","created_at":"2011-08-16T22:01:21.962Z","description":"    Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick\n    on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server,
+        or Oracle with eRuby- or Builder-based templates.\n","downloads_count":426527,"metadata":{},"number":"2.3.14","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"d73302e2ba500ac8efef9d0397c341c0c40b055a67a5fc43503df67d1df29852"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-06-08T00:00:00.000Z","created_at":"2011-06-08T00:22:06.357Z","description":"    Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick\n    on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server,
+        or Oracle with eRuby- or Builder-based templates.\n","downloads_count":64093,"metadata":{},"number":"2.3.12","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"51c06714ba199ef678d0e7c9425c76da2a5b233dae7743e22737243ee9dc0780"},{"authors":"David
+        Heinemeier Hansson","built_at":"2011-02-08T11:00:00.000Z","created_at":"2011-02-08T21:17:36.254Z","description":"    Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick\n    on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server,
+        or Oracle with eRuby- or Builder-based templates.\n","downloads_count":337805,"metadata":{},"number":"2.3.11","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"dafba5bf713c2f035dbd3f1b594571e261a233ab022afb25c9fc12684b7cfd75"},{"authors":"David
+        Heinemeier Hansson","built_at":"2010-10-14T11:00:00.000Z","created_at":"2010-10-14T20:53:17.413Z","description":"    Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick\n    on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server,
+        or Oracle with eRuby- or Builder-based templates.\n","downloads_count":170212,"metadata":{},"number":"2.3.10","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"70f996afe90e4d3475550a6095899597b54cd058125bf31ef53af2738d5085c8"},{"authors":"David
+        Heinemeier Hansson","built_at":"2010-09-04T07:00:00.000Z","created_at":"2010-09-04T21:54:41.257Z","description":"    Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick\n    on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server,
+        or Oracle with eRuby- or Builder-based templates.\n","downloads_count":78005,"metadata":{},"number":"2.3.9","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"1716920fe21e7e9f48e385f8bd7e24c5b3ac9f3d3285cd83cee5dbe09acb2ebb"},{"authors":"David
+        Heinemeier Hansson","built_at":"2010-08-29T07:00:00.000Z","created_at":"2010-08-30T03:32:34.689Z","description":"    Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick\n    on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server,
+        or Oracle with eRuby- or Builder-based templates.\n","downloads_count":3421,"metadata":{},"number":"2.3.9.pre","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e
+        1.3.1","ruby_version":null,"prerelease":true,"licenses":null,"requirements":null,"sha":"1886d6808620db047f5cd3d28280007ad5e4faf95be2bfd8b68d56d7ae3e521e"},{"authors":"David
+        Heinemeier Hansson","built_at":"2010-05-24T07:00:00.000Z","created_at":"2010-05-25T04:53:06.895Z","description":"    Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick\n    on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server,
+        or Oracle with eRuby- or Builder-based templates.\n","downloads_count":1077377,"metadata":{},"number":"2.3.8","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"59efc4532e0886ad4912dc06a113ba2d455f7a380f972b24da8414df1dfb377d"},{"authors":"David
+        Heinemeier Hansson","built_at":"2010-05-24T07:00:00.000Z","created_at":"2010-05-24T21:17:25.987Z","description":"    Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick\n    on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server,
+        or Oracle with eRuby- or Builder-based templates.\n","downloads_count":3500,"metadata":{},"number":"2.3.8.pre1","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e
+        1.3.1","ruby_version":null,"prerelease":true,"licenses":null,"requirements":null,"sha":"5f31bdb3ddfb16859962ca5feae5dbcba10db3091991f4116b2285fcf40631ae"},{"authors":"David
+        Heinemeier Hansson","built_at":"2010-05-24T07:00:00.000Z","created_at":"2010-05-24T08:23:05.731Z","description":"    Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick\n    on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server,
+        or Oracle with eRuby- or Builder-based templates.\n","downloads_count":13358,"metadata":{},"number":"2.3.7","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"92cd367849dd21e165ccc4143f471051568588a2c89a5f873e9afdf4ea9d32cf"},{"authors":"David
+        Heinemeier Hansson","built_at":"2010-05-23T07:00:00.000Z","created_at":"2010-05-23T07:49:23.602Z","description":"    Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick\n    on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server,
+        or Oracle with eRuby- or Builder-based templates.\n","downloads_count":18320,"metadata":{},"number":"2.3.6","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"0e05a80cd707a19ea92120ea9b1c91a3711b204cd71c860964637e631eb31f9b"},{"authors":"David
+        Heinemeier Hansson","built_at":"2009-11-26T11:00:00.000Z","created_at":"2009-11-27T00:12:56.921Z","description":"    Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick\n    on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server,
+        or Oracle with eRuby- or Builder-based templates.\n","downloads_count":1178509,"metadata":{},"number":"2.3.5","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"adb5bea1831c536a64fcd420da01d5a3b3fbe21807c9dce1c458fd62bc2afa7f"},{"authors":"David
+        Heinemeier Hansson","built_at":"2009-09-03T15:00:00.000Z","created_at":"2009-09-04T17:33:48.000Z","description":"    Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick\n    on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server,
+        or Oracle with eRuby- or Builder-based templates.\n","downloads_count":252108,"metadata":{},"number":"2.3.4","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"94ffc90b6d0456feaf8610b1d0007c4d2836c0e1c88b33f89d7b8c0043c2f15c"},{"authors":"David
+        Heinemeier Hansson","built_at":"2009-07-20T05:00:00.000Z","created_at":"2009-08-05T13:21:07.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":36633,"metadata":{},"number":"2.3.3","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"50b373c47c0a59a16790f8630194e3cd732c28acfcb3ec89bc1ff83ec1f12979"},{"authors":"David
+        Heinemeier Hansson","built_at":"2009-03-15T05:00:00.000Z","created_at":"2009-07-25T18:01:49.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":132813,"metadata":{},"number":"2.3.2","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"ac61e0356987df34dbbafb803b98f153a663d3878a31f1db7333b7cd987fd044"},{"authors":"David
+        Heinemeier Hansson","built_at":"2009-09-27T14:00:00.000Z","created_at":"2009-09-28T09:25:13.132Z","description":"    Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick\n    on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server,
+        or Oracle with eRuby- or Builder-based templates.\n","downloads_count":46364,"metadata":{},"number":"2.2.3","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"ea02684c1073e42a50be2d30b4ebdef8cb35aefc29c3c250c1fc598a52790cdf"},{"authors":"David
+        Heinemeier Hansson","built_at":"2008-11-20T23:00:00.000Z","created_at":"2009-07-25T18:01:49.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":152253,"metadata":{},"number":"2.2.2","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"84fd0ee92f92088cff81d1a4bcb61306bd4b7440b8634d7ac3d1396571a2133f"},{"authors":"David
+        Heinemeier Hansson","built_at":"2008-10-22T22:00:00.000Z","created_at":"2009-07-25T18:01:50.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":72577,"metadata":{},"number":"2.1.2","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"4a55304ae08e3fcd2a2e2bb627d442e5aa9f1b1d6a542587b97ed0cee6079276"},{"authors":"David
+        Heinemeier Hansson","built_at":"2008-09-03T22:00:00.000Z","created_at":"2009-07-25T18:01:50.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":23202,"metadata":{},"number":"2.1.1","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"44f2f19ddd15f51725a5b92447adefbc9ee5a500fcb8db6e9bdb4a3a7ead7438"},{"authors":"David
+        Heinemeier Hansson","built_at":"2008-05-31T07:00:00.000Z","created_at":"2009-07-25T18:01:50.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":50430,"metadata":{},"number":"2.1.0","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"9a9a2b7c710926e83d76ed308e5863be0c9011146bc983703437820d9cd405fe"},{"authors":"David
+        Heinemeier Hansson","built_at":"2008-10-18T22:00:00.000Z","created_at":"2009-07-25T18:01:50.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":18300,"metadata":{},"number":"2.0.5","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"5e8a6e36f2537b795b7bb237e2aea18a166349e1e54e463a64beba5ae84cd406"},{"authors":"David
+        Heinemeier Hansson","built_at":"2008-09-03T22:00:00.000Z","created_at":"2009-07-25T18:01:51.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":4898,"metadata":{},"number":"2.0.4","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"85a7294bc816e6104b11b34403750f032f7e36ec15cb412cfd489b3a11e64f03"},{"authors":"David
+        Heinemeier Hansson","built_at":"2007-12-20T06:00:00.000Z","created_at":"2009-07-25T18:01:51.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":49481,"metadata":{},"number":"2.0.2","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"ae11c0c3e237c9e46feab39277cd8190f1ee36a5fced6215ed7c9327b19bddf6"},{"authors":"David
+        Heinemeier Hansson","built_at":"2007-12-07T06:00:00.000Z","created_at":"2009-07-25T18:01:51.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":6772,"metadata":{},"number":"2.0.1","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"64e35d0669cff20baf406d8e4d0ca55ecc842ce75ea8e78b9102f663af57d8c4"},{"authors":"David
+        Heinemeier Hansson","built_at":"2007-12-06T06:00:00.000Z","created_at":"2009-07-25T18:01:51.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":6024,"metadata":{},"number":"2.0.0","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"e4ed2b3b62babf3afc27d507ca6198776cb9e640f29503950e5c7900d96f468d"},{"authors":"David
+        Heinemeier Hansson","built_at":"2007-11-23T11:00:00.000Z","created_at":"2009-07-25T18:01:51.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":32880,"metadata":{},"number":"1.2.6","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"5e83cfc2a47d9c4bb5390ffee63e69b32034da281d51b2955c605dcdbecf5c79"},{"authors":"David
+        Heinemeier Hansson","built_at":"2007-10-12T05:00:00.000Z","created_at":"2009-07-25T18:01:52.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":12285,"metadata":{},"number":"1.2.5","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"6e39819f3237d50045883c6fc37a0caa360db9a68f47caa23ef772d16081d890"},{"authors":"David
+        Heinemeier Hansson","built_at":"2007-10-04T05:00:00.000Z","created_at":"2009-07-25T18:01:52.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":4983,"metadata":{},"number":"1.2.4","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"e96c057e7dc58cc08ec127d793605af977801b72162781d0e46355c17aecfc66"},{"authors":"David
+        Heinemeier Hansson","built_at":"2007-03-13T05:00:00.000Z","created_at":"2009-07-25T18:01:52.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":27749,"metadata":{},"number":"1.2.3","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"58ed2135a5b41b825350113924d34e1f36cf5fa05030c78e8d3c49614dfbf209"},{"authors":"David
+        Heinemeier Hansson","built_at":"2007-02-06T06:00:00.000Z","created_at":"2009-07-25T18:01:52.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":12308,"metadata":{},"number":"1.2.2","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"e3482caade87a05c36971a6c4920a35ec8742a639f4c6c76276c49fa99a88df6"},{"authors":"David
+        Heinemeier Hansson","built_at":"2007-01-18T06:00:00.000Z","created_at":"2009-07-25T18:01:52.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":5224,"metadata":{},"number":"1.2.1","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"4bd8daec4cdabae8d70a4d00706512d0d1d8f8415b904f3bc8e40be1f693d67e"},{"authors":"David
+        Heinemeier Hansson","built_at":"2007-01-17T06:00:00.000Z","created_at":"2009-07-25T18:01:53.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":5296,"metadata":{},"number":"1.2.0","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"df29db2e0987cfbcf237097d1a45cb0aedef6b56f6eb502b3131ced78b05f1df"},{"authors":"David
+        Heinemeier Hansson","built_at":"2006-08-10T05:00:00.000Z","created_at":"2009-07-25T18:01:54.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":12074,"metadata":{},"number":"1.1.6","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"f78cc3dfe77ceaa3cdd808735dcb81c8d3bdbd8e4d6b72ecc3a1b7fc19f1bd49"},{"authors":"David
+        Heinemeier Hansson","built_at":"2006-08-09T05:00:00.000Z","created_at":"2009-07-25T18:01:54.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":4371,"metadata":{},"number":"1.1.5","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"d2608db4e073295d471b212bdf9c332df120a49bb6de02b77ba4d7d19f7fdf72"},{"authors":"David
+        Heinemeier Hansson","built_at":"2006-06-29T05:00:00.000Z","created_at":"2009-07-25T18:01:54.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":4771,"metadata":{},"number":"1.1.4","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"dc0cd4d9bb95ddcae3ccdaa3e21ae3b0d2b4606070ea3e0944cd1bf6ec71a70f"},{"authors":"David
+        Heinemeier Hansson","built_at":"2006-06-27T05:00:00.000Z","created_at":"2009-07-25T18:01:54.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":4233,"metadata":{},"number":"1.1.3","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"90bf03ffc9852684f5839f6144d218caebf1da373258b5e85209d62b0cb7c3eb"},{"authors":"David
+        Heinemeier Hansson","built_at":"2006-04-09T05:00:00.000Z","created_at":"2009-07-25T18:01:54.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":5798,"metadata":{},"number":"1.1.2","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"1ffd33463d5ed4aa4079f46816dd08af3028f361e623be57a6dec9784263f26f"},{"authors":"David
+        Heinemeier Hansson","built_at":"2006-04-06T05:00:00.000Z","created_at":"2009-07-25T18:01:55.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":4360,"metadata":{},"number":"1.1.1","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"6c54ca011610c17c1c0ad6816480b596b008f450b875141ebd10ed65b0e4d3df"},{"authors":"David
+        Heinemeier Hansson","built_at":"2006-03-27T06:00:00.000Z","created_at":"2009-07-25T18:01:55.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":4624,"metadata":{},"number":"1.1.0","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"b4d455cb02eae13ec3b48abbd95cfeaf5c05cd092ab9fe4fd809636d1bab3e6c"},{"authors":"David
+        Heinemeier Hansson","built_at":"2005-12-13T06:00:00.000Z","created_at":"2009-07-25T18:01:55.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":5757,"metadata":{},"number":"1.0.0","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"52b06ee61c4826f545f6e4e6c33eef8f8772f6a1f5ce66a812abab2b5388aed2"},{"authors":"David
+        Heinemeier Hansson","built_at":"2005-12-07T06:00:00.000Z","created_at":"2009-07-25T18:01:56.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":4598,"metadata":{},"number":"0.14.4","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"ae161659ac9a467a782319fb960fcfe7dbc2b7e28752c9b44acf4227718271b9"},{"authors":"David
+        Heinemeier Hansson","built_at":"2005-11-06T23:00:00.000Z","created_at":"2009-07-25T18:01:56.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":4131,"metadata":{},"number":"0.14.3","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"141f70ad1d05f5f2f89ee1fc8324f99b3eb5e05dbea2eb2febf42c89efaad135"},{"authors":"David
+        Heinemeier Hansson","built_at":"2005-10-25T22:00:00.000Z","created_at":"2009-07-25T18:01:57.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":4289,"metadata":{},"number":"0.14.2","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"98d96be5c6d0da79ab33b75ea2d7472cec863fd45394baf6634925685c3ea2fd"},{"authors":"David
+        Heinemeier Hansson","built_at":"2005-10-19T04:00:00.000Z","created_at":"2009-07-25T18:01:57.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":4494,"metadata":{},"number":"0.14.1","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"7725daf25f6cd232ea3c3bc1c5693502add0e9ad10fdab33dd0fb402ab6373a2"},{"authors":"David
+        Heinemeier Hansson","built_at":"2005-07-11T04:00:00.000Z","created_at":"2009-07-25T18:01:57.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
+        with eRuby- or Builder-based templates.","downloads_count":5649,"metadata":{},"number":"0.13.1","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"b7bfea7a5dbb456f33cef9e2de59bbb08e25d7612240a8f0613b02ae1d7f2d58"},{"authors":"David
+        Heinemeier Hansson","built_at":"2005-07-06T04:00:00.000Z","created_at":"2009-07-25T18:01:57.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, or SQLite with eRuby-based templates.","downloads_count":4197,"metadata":{},"number":"0.13.0","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"30715907b5809db8c44cb438b9bda6d0bcc62451e13274edc5ea108b5c14f608"},{"authors":"David
+        Heinemeier Hansson","built_at":"2005-04-20T04:00:00.000Z","created_at":"2009-07-25T18:01:57.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, or SQLite with eRuby-based templates.","downloads_count":4532,"metadata":{},"number":"0.12.1","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"1347f1cf31a7786c92cecdea53401a1f1fc3bd3e8cf15c00d65de8109b6615eb"},{"authors":"David
+        Heinemeier Hansson","built_at":"2005-04-19T04:00:00.000Z","created_at":"2009-07-25T18:01:58.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, or SQLite with eRuby-based templates.","downloads_count":4238,"metadata":{},"number":"0.12.0","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"4f9b4eb0e2dfe2da9e8f0efd25872d2347f8b26e7091e2175516a6d626236501"},{"authors":"David
+        Heinemeier Hansson","built_at":"2005-03-27T05:00:00.000Z","created_at":"2009-07-25T18:01:58.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, or SQLite with eRuby-based templates.","downloads_count":4134,"metadata":{},"number":"0.11.1","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"e807ae18b85ef6603e839d8c32155c0379419a441c5ce390d1e31e86a929b3f3"},{"authors":"David
+        Heinemeier Hansson","built_at":"2005-03-22T05:00:00.000Z","created_at":"2009-07-25T18:01:58.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, or SQLite with eRuby-based templates.","downloads_count":4265,"metadata":{},"number":"0.11.0","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"dffce238995d10e754f1633b702e733c0a80f9b447a54048e42c77a4d1fc0734"},{"authors":"David
+        Heinemeier Hansson","built_at":"2005-03-07T05:00:00.000Z","created_at":"2009-07-25T18:01:58.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, or SQLite with eRuby-based templates.","downloads_count":4263,"metadata":{},"number":"0.10.1","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"f7b3896f3b13536b075bcf4036122ed50bac0d3b34d80d194fcdb0240a16e384"},{"authors":"David
+        Heinemeier Hansson","built_at":"2005-02-24T05:00:00.000Z","created_at":"2009-07-25T18:01:58.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, or SQLite with eRuby-based templates.","downloads_count":4344,"metadata":{},"number":"0.10.0","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"51fcc55a23e06245e97a8088d0122ac85b6ad16dcb2156d1f53499309a4c7141"},{"authors":"David
+        Heinemeier Hansson","built_at":"2005-01-25T05:00:00.000Z","created_at":"2009-07-25T18:01:55.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, or SQLite with eRuby-based templates.","downloads_count":56719,"metadata":{},"number":"0.9.5","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"8a03d2c37e6efc2ed1084c2b5189caed0522fb6a09881c8c73e28f0ffca966f2"},{"authors":"David
+        Heinemeier Hansson","built_at":"2005-01-18T05:00:00.000Z","created_at":"2009-07-25T18:01:55.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, or SQLite with eRuby-based templates.","downloads_count":4288,"metadata":{},"number":"0.9.4.1","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"81989d02f78771857da3e0136b459a5cb7d7a02ce0c540993c4febf2047a5ee9"},{"authors":"David
+        Heinemeier Hansson","built_at":"2005-01-17T05:00:00.000Z","created_at":"2009-07-25T18:01:55.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, or SQLite with eRuby-based templates.","downloads_count":4215,"metadata":{},"number":"0.9.4","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"9be6e8cfe3d937b6f46c71df1c751cb0f06d5bc06539b85d584a1439783dbfa7"},{"authors":"David
+        Heinemeier Hansson","built_at":"2005-01-04T05:00:00.000Z","created_at":"2009-07-25T18:01:55.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, or SQLite with eRuby-based templates.","downloads_count":4139,"metadata":{},"number":"0.9.3","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"5cc763df669215dc7556a7eb6e7b1437701818c1cfbcd3c0e0f405fe2d023aad"},{"authors":"","built_at":"2004-12-23T05:00:00.000Z","created_at":"2009-07-25T18:01:56.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, or SQLite with eRuby-based templates.","downloads_count":4251,"metadata":{},"number":"0.9.2","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"740c3b4fb642972e706e2d3d5ce1988326877971eb91bcf414ef992a19926394"},{"authors":"","built_at":"2004-12-17T05:00:00.000Z","created_at":"2009-07-25T18:01:56.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, or SQLite with eRuby-based templates.","downloads_count":4212,"metadata":{},"number":"0.9.1","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"e4fdddacb663ec8b7d3a01e6db74edbcd61e503c674ab2f222e78f91fb7daa01"},{"authors":"","built_at":"2004-12-16T05:00:00.000Z","created_at":"2009-07-25T18:01:56.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, or SQLite with eRuby-based templates.","downloads_count":4170,"metadata":{},"number":"0.9.0","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"4d53b8a98282c7602200345d9b92e53ba12688fb0a36b04cc10b2c42709d7824"},{"authors":"","built_at":"2004-11-18T05:00:00.000Z","created_at":"2009-07-25T18:01:56.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, or SQLite with eRuby-based templates.","downloads_count":4261,"metadata":{},"number":"0.8.5","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"f828c544ba8bc529d352f0fcb6687c7fb8809488142510e255caafda8cc8801f"},{"authors":"","built_at":"2004-10-25T04:00:00.000Z","created_at":"2009-07-25T18:01:56.000Z","description":"Rails
+        is a framework for building web-application using CGI, FCGI, mod_ruby, or
+        WEBrick on top of either MySQL, PostgreSQL, or SQLite with eRuby-based templates.","downloads_count":6377781,"metadata":{},"number":"0.8.0","summary":"Web-application
+        framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
+        0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"182794b9b4af4eff6884c979f0ae6a632ea42bf4f309cf16553b02fc4be344d3"}]'
+    http_version:
+  recorded_at: Mon, 15 May 2023 22:37:09 GMT
 recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/project/check_status/rails.yml
+++ b/spec/fixtures/vcr_cassettes/project/check_status/rails.yml
@@ -1,0 +1,78 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://rubygems.org/api/v1/versions/rails197.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Expect:
+      - ''
+  response:
+    status:
+      code: 404
+      message: ''
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - default-src 'self'; font-src 'self' https://fonts.gstatic.com; img-src 'self'
+        https://secure.gaug.es https://gravatar.com https://www.gravatar.com https://secure.gravatar.com
+        https://*.fastly-insights.com https://avatars.githubusercontent.com; object-src
+        'none'; script-src 'self' https://secure.gaug.es https://www.fastly-insights.com
+        'nonce-'; style-src 'self' https://fonts.googleapis.com; connect-src 'self'
+        https://s3-us-west-2.amazonaws.com/rubygems-dumps/ https://*.fastly-insights.com
+        https://fastly-insights.com https://api.github.com http://localhost:*; form-action
+        'self' https://github.com/login/oauth/authorize; frame-ancestors 'self'; report-uri
+        https://csp-report.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pub852fa3e2312391fafa5640b60784e660&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=service%3Arubygems.org%2Cversion%3A4d14d0ea76b245de7e23151d118aa43c7e889110%2Cenv%3Aproduction%2Ctrace_id%3A2085787286933023463
+      X-Request-Id:
+      - 527f621d-60dd-4b2c-a961-11db6ddc1681
+      X-Runtime:
+      - '0.006733'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Fri, 12 May 2023 18:45:18 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '0'
+      X-Served-By:
+      - cache-bos4637-BOS
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1683917118.813915,VS0,VE340
+      Vary:
+      - Accept-Encoding
+      Server:
+      - RubyGems.org
+      Content-Length:
+      - '32'
+    body:
+      encoding: ASCII-8BIT
+      string: This rubygem could not be found.
+    http_version:
+  recorded_at: Fri, 12 May 2023 18:45:18 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/project/check_status/rails.yml
+++ b/spec/fixtures/vcr_cassettes/project/check_status/rails.yml
@@ -2,81 +2,6 @@
 http_interactions:
 - request:
     method: get
-    uri: https://rubygems.org/api/v1/versions/rails197.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Typhoeus - https://github.com/typhoeus/typhoeus
-      Expect:
-      - ''
-  response:
-    status:
-      code: 404
-      message: ''
-    headers:
-      Content-Type:
-      - text/plain; charset=utf-8
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - '0'
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Permitted-Cross-Domain-Policies:
-      - none
-      Referrer-Policy:
-      - strict-origin-when-cross-origin
-      Cache-Control:
-      - no-cache
-      Content-Security-Policy:
-      - default-src 'self'; font-src 'self' https://fonts.gstatic.com; img-src 'self'
-        https://secure.gaug.es https://gravatar.com https://www.gravatar.com https://secure.gravatar.com
-        https://*.fastly-insights.com https://avatars.githubusercontent.com; object-src
-        'none'; script-src 'self' https://secure.gaug.es https://www.fastly-insights.com
-        'nonce-'; style-src 'self' https://fonts.googleapis.com; connect-src 'self'
-        https://s3-us-west-2.amazonaws.com/rubygems-dumps/ https://*.fastly-insights.com
-        https://fastly-insights.com https://api.github.com http://localhost:*; form-action
-        'self' https://github.com/login/oauth/authorize; frame-ancestors 'self'; report-uri
-        https://csp-report.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pub852fa3e2312391fafa5640b60784e660&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=service%3Arubygems.org%2Cversion%3A4d14d0ea76b245de7e23151d118aa43c7e889110%2Cenv%3Aproduction%2Ctrace_id%3A2085787286933023463
-      X-Request-Id:
-      - 527f621d-60dd-4b2c-a961-11db6ddc1681
-      X-Runtime:
-      - '0.006733'
-      Strict-Transport-Security:
-      - max-age=31536000
-      Accept-Ranges:
-      - bytes
-      Date:
-      - Fri, 12 May 2023 18:45:18 GMT
-      Via:
-      - 1.1 varnish
-      Age:
-      - '0'
-      X-Served-By:
-      - cache-bos4637-BOS
-      X-Cache:
-      - MISS
-      X-Cache-Hits:
-      - '0'
-      X-Timer:
-      - S1683917118.813915,VS0,VE340
-      Vary:
-      - Accept-Encoding
-      Server:
-      - RubyGems.org
-      Content-Length:
-      - '32'
-    body:
-      encoding: ASCII-8BIT
-      string: This rubygem could not be found.
-    http_version:
-  recorded_at: Fri, 12 May 2023 18:45:18 GMT
-- request:
-    method: get
     uri: https://rubygems.org/api/v1/versions/rails.json
     body:
       encoding: US-ASCII
@@ -118,31 +43,31 @@ http_interactions:
         https://s3-us-west-2.amazonaws.com/rubygems-dumps/ https://*.fastly-insights.com
         https://fastly-insights.com https://api.github.com http://localhost:*; form-action
         'self' https://github.com/login/oauth/authorize; frame-ancestors 'self'; report-uri
-        https://csp-report.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pub852fa3e2312391fafa5640b60784e660&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=service%3Arubygems.org%2Cversion%3A4d14d0ea76b245de7e23151d118aa43c7e889110%2Cenv%3Aproduction%2Ctrace_id%3A735925964818907718
+        https://csp-report.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pub852fa3e2312391fafa5640b60784e660&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=service%3Arubygems.org%2Cversion%3Adcbc508a11819fe098399d333219a6daba09cc53%2Cenv%3Aproduction%2Ctrace_id%3A649491781406118403
       X-Request-Id:
-      - faa10ed1-7805-47e0-8db4-faa331d19207
+      - 750936f3-9d42-42ef-87d5-1c7d45a0c1d4
       X-Runtime:
-      - '0.114117'
+      - '0.127487'
       Strict-Transport-Security:
       - max-age=31536000
       X-Backend:
-      - F_Rails 34.211.73.229:443
+      - F_Rails 44.229.71.21:443
       Accept-Ranges:
       - bytes
       Date:
-      - Mon, 15 May 2023 22:37:09 GMT
+      - Tue, 16 May 2023 15:24:16 GMT
       Via:
       - 1.1 varnish
       Age:
       - '0'
       X-Served-By:
-      - cache-bos4669-BOS
+      - cache-bos4673-BOS
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1684190229.017567,VS0,VE692
+      - S1684250656.182177,VS0,VE702
       Vary:
       - Accept-Encoding
       Etag:
@@ -156,55 +81,55 @@ http_interactions:
       string: '[{"authors":"David Heinemeier Hansson","built_at":"2023-03-13T00:00:00.000Z","created_at":"2023-03-13T18:53:43.517Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2267681,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.4.3","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.4.3","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.4.3/","rubygems_mfa_required":"true"},"number":"7.0.4.3","summary":"Full-stack
+        over configuration.","downloads_count":2303695,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.4.3","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.4.3","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.4.3/","rubygems_mfa_required":"true"},"number":"7.0.4.3","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5b675b237abb7328020002d06cc6c9003a09cde4b4774f989bfa440c6e93e2ed"},{"authors":"David
         Heinemeier Hansson","built_at":"2023-01-25T00:00:00.000Z","created_at":"2023-01-25T03:14:29.671Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2048405,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.4.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.4.2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.4.2/","rubygems_mfa_required":"true"},"number":"7.0.4.2","summary":"Full-stack
+        over configuration.","downloads_count":2053888,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.4.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.4.2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.4.2/","rubygems_mfa_required":"true"},"number":"7.0.4.2","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0c2e25beb5aa029a2b5ffe354ac76f61d49347c37e3422231666c56fa5c78435"},{"authors":"David
         Heinemeier Hansson","built_at":"2023-01-17T00:00:00.000Z","created_at":"2023-01-17T18:55:33.129Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":633778,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.4.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.4.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.4.1/","rubygems_mfa_required":"true"},"number":"7.0.4.1","summary":"Full-stack
+        over configuration.","downloads_count":634544,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.4.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.4.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.4.1/","rubygems_mfa_required":"true"},"number":"7.0.4.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"cee99186c0450fa500fb7aa114e504b3061e0508f3cd0f2310541b07547dc2f7"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-09-09T00:00:00.000Z","created_at":"2022-09-09T18:42:56.698Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":4296603,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.4","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.4","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.4/","rubygems_mfa_required":"true"},"number":"7.0.4","summary":"Full-stack
+        over configuration.","downloads_count":4301888,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.4","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.4","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.4/","rubygems_mfa_required":"true"},"number":"7.0.4","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e1d2dabe57de44b4baee978426aba811858c5e9ad0e258fc09157361937f5f31"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-07-12T00:00:00.000Z","created_at":"2022-07-12T17:31:41.727Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2952909,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.3.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.3.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.3.1/","rubygems_mfa_required":"true"},"number":"7.0.3.1","summary":"Full-stack
+        over configuration.","downloads_count":2954810,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.3.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.3.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.3.1/","rubygems_mfa_required":"true"},"number":"7.0.3.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0b771be1bf5c5a54c4d8118355b3d8d9a8d823e82a90c0573b48d14262254a8c"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-05-09T00:00:00.000Z","created_at":"2022-05-09T13:41:57.714Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2722131,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.3","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.3","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.3/","rubygems_mfa_required":"true"},"number":"7.0.3","summary":"Full-stack
+        over configuration.","downloads_count":2723266,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.3","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.3","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.3/","rubygems_mfa_required":"true"},"number":"7.0.3","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"7e0c3e1a97551eef4ae6d7e7fdb5109f72f6a451deab9a26fb6a6ab8ff82ae1d"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-04-26T00:00:00.000Z","created_at":"2022-04-26T19:33:25.138Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":510226,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.2.4","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.2.4","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.2.4/","rubygems_mfa_required":"true"},"number":"7.0.2.4","summary":"Full-stack
+        over configuration.","downloads_count":510446,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.2.4","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.2.4","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.2.4/","rubygems_mfa_required":"true"},"number":"7.0.2.4","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5eee151313cdb86365bdeb65f61ad012c2fa2e86df03b0cf4484a2e5eee5a601"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-03-08T00:00:00.000Z","created_at":"2022-03-08T17:50:52.496Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1268338,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.2.3","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.2.3","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.2.3/","rubygems_mfa_required":"true"},"number":"7.0.2.3","summary":"Full-stack
+        over configuration.","downloads_count":1268962,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.2.3","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.2.3","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.2.3/","rubygems_mfa_required":"true"},"number":"7.0.2.3","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ee4e24075c72dec6e02e3fcddec86399c2b4eb0466efe4ccb5f78f96d3daa283"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-02-11T00:00:00.000Z","created_at":"2022-02-11T19:44:19.017Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":831795,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.2.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.2.2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.2.2/","rubygems_mfa_required":"true"},"number":"7.0.2.2","summary":"Full-stack
+        over configuration.","downloads_count":832607,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.2.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.2.2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.2.2/","rubygems_mfa_required":"true"},"number":"7.0.2.2","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3393e21131e2120a42cf634416033e587b5dfdccdc84d1a2d2c176b847f6f17f"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-02-11T00:00:00.000Z","created_at":"2022-02-11T18:19:21.363Z","description":"Ruby
@@ -216,19 +141,19 @@ http_interactions:
         Heinemeier Hansson","built_at":"2022-02-08T00:00:00.000Z","created_at":"2022-02-08T23:13:21.486Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":102663,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.2/","rubygems_mfa_required":"true"},"number":"7.0.2","summary":"Full-stack
+        over configuration.","downloads_count":102789,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.2/","rubygems_mfa_required":"true"},"number":"7.0.2","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ef82869adc909aa7f318519d6b3e5c930a29f507e730e8b5af532d8f14d2ab72"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-01-06T00:00:00.000Z","created_at":"2022-01-06T21:55:27.202Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":535420,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.1/","rubygems_mfa_required":"true"},"number":"7.0.1","summary":"Full-stack
+        over configuration.","downloads_count":535740,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.1/","rubygems_mfa_required":"true"},"number":"7.0.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3f03f0a134807e99ae587206d25d199ed4f6f715818ef1c1ac618c845487d8f9"},{"authors":"David
         Heinemeier Hansson","built_at":"2021-12-15T00:00:00.000Z","created_at":"2021-12-15T23:45:57.959Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":252359,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.0","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.0","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.0/","rubygems_mfa_required":"true"},"number":"7.0.0","summary":"Full-stack
+        over configuration.","downloads_count":252444,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.0","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.0","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.0/","rubygems_mfa_required":"true"},"number":"7.0.0","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"1bf449e7b3e41218e5aa31e0dbf771d1a777914dd2c8861738c8a6affdcc3d5e"},{"authors":"David
         Heinemeier Hansson","built_at":"2021-12-14T00:00:00.000Z","created_at":"2021-12-14T23:04:49.725Z","description":"Ruby
@@ -246,13 +171,13 @@ http_interactions:
         Heinemeier Hansson","built_at":"2021-12-06T00:00:00.000Z","created_at":"2021-12-06T21:33:14.325Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":17612,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.0.rc1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.0.rc1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.0.rc1/","rubygems_mfa_required":"true"},"number":"7.0.0.rc1","summary":"Full-stack
+        over configuration.","downloads_count":17613,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.0.rc1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.0.rc1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.0.rc1/","rubygems_mfa_required":"true"},"number":"7.0.0.rc1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"d7a13a11304e7aa861182238660acf1f71ef234163fcc5b123f3bf50e4fd82ca"},{"authors":"David
         Heinemeier Hansson","built_at":"2021-09-15T00:00:00.000Z","created_at":"2021-09-15T23:16:26.580Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":69242,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.0.alpha2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.0.alpha2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.0.alpha2/"},"number":"7.0.0.alpha2","summary":"Full-stack
+        over configuration.","downloads_count":69245,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v7.0.0.alpha2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v7.0.0.alpha2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v7.0.0.alpha2/"},"number":"7.0.0.alpha2","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.7.0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"3b86ad7ded351a824c8a831473670f0615f4c4f061ae11d3adbf804cdd24e096"},{"authors":"David
         Heinemeier Hansson","built_at":"2021-09-15T00:00:00.000Z","created_at":"2021-09-15T21:58:08.365Z","description":"Ruby
@@ -264,61 +189,61 @@ http_interactions:
         Heinemeier Hansson","built_at":"2023-03-13T00:00:00.000Z","created_at":"2023-03-13T18:48:59.163Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2359461,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.7.3","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.7.3","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.7.3/","rubygems_mfa_required":"true"},"number":"6.1.7.3","summary":"Full-stack
+        over configuration.","downloads_count":2396450,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.7.3","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.7.3","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.7.3/","rubygems_mfa_required":"true"},"number":"6.1.7.3","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d27a251e2a55e1951cd676c19e51d359945ecd4bbef1d88cb97c9b3e1b3e9a1d"},{"authors":"David
         Heinemeier Hansson","built_at":"2023-01-25T00:00:00.000Z","created_at":"2023-01-25T03:23:38.693Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":3282602,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.7.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.7.2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.7.2/","rubygems_mfa_required":"true"},"number":"6.1.7.2","summary":"Full-stack
+        over configuration.","downloads_count":3305632,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.7.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.7.2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.7.2/","rubygems_mfa_required":"true"},"number":"6.1.7.2","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d50796f4106fe1793e048e80e11bc9aee4af1674c94a24ebe7f7b411217befac"},{"authors":"David
         Heinemeier Hansson","built_at":"2023-01-17T00:00:00.000Z","created_at":"2023-01-17T18:54:36.574Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1090402,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.7.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.7.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.7.1/","rubygems_mfa_required":"true"},"number":"6.1.7.1","summary":"Full-stack
+        over configuration.","downloads_count":1091697,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.7.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.7.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.7.1/","rubygems_mfa_required":"true"},"number":"6.1.7.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ad209c9822b494e0f0ff9faa68381bf209e4b7ca7d2e3e65f08a842e750163f7"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-09-09T00:00:00.000Z","created_at":"2022-09-09T18:39:14.216Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":3650462,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.7","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.7","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.7/","rubygems_mfa_required":"true"},"number":"6.1.7","summary":"Full-stack
+        over configuration.","downloads_count":3653166,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.7","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.7","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.7/","rubygems_mfa_required":"true"},"number":"6.1.7","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"6e3b9226fb9f82d916990b7da9a121191890ed20ac49f40e902d4e6952308006"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-07-12T00:00:00.000Z","created_at":"2022-07-12T17:29:59.374Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":8125411,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.6.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.6.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.6.1/","rubygems_mfa_required":"true"},"number":"6.1.6.1","summary":"Full-stack
+        over configuration.","downloads_count":8129467,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.6.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.6.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.6.1/","rubygems_mfa_required":"true"},"number":"6.1.6.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"17024921a3913fb341f584542b06adf6bb12977a8b92d5fce093c3996c963686"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-05-09T00:00:00.000Z","created_at":"2022-05-09T13:46:43.653Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":3045653,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.6","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.6","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.6/","rubygems_mfa_required":"true"},"number":"6.1.6","summary":"Full-stack
+        over configuration.","downloads_count":3046795,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.6","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.6","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.6/","rubygems_mfa_required":"true"},"number":"6.1.6","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"1f1dd2b3a0b91216f0ceb3d975ad33067ade51b0e9f13e97863239c1c0c09f1b"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-04-26T00:00:00.000Z","created_at":"2022-04-26T19:30:41.477Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1535445,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.5.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.5.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.5.1/","rubygems_mfa_required":"true"},"number":"6.1.5.1","summary":"Full-stack
+        over configuration.","downloads_count":1535725,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.5.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.5.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.5.1/","rubygems_mfa_required":"true"},"number":"6.1.5.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"68bfd72fd5cd1f0afc56e6f79fcd65cc13c3ce8038fe98981c8060f204e54921"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-03-10T00:00:00.000Z","created_at":"2022-03-10T21:17:17.197Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1985596,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.5","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.5","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.5/","rubygems_mfa_required":"true"},"number":"6.1.5","summary":"Full-stack
+        over configuration.","downloads_count":1987369,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.5","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.5","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.5/","rubygems_mfa_required":"true"},"number":"6.1.5","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"bbfda8082ca2d76b01fd1e78bff14e17fe07908f1ff4e028f3853b5b8c3626fb"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-03-08T00:00:00.000Z","created_at":"2022-03-08T17:49:05.430Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2976394,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.4.7","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.4.7","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.4.7/"},"number":"6.1.4.7","summary":"Full-stack
+        over configuration.","downloads_count":2977078,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.4.7","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.4.7","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.4.7/"},"number":"6.1.4.7","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c58a13335748caa55182e69afac033d864c84c2d1e7e891b754b56ea0de0974f"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-02-11T00:00:00.000Z","created_at":"2022-02-11T19:42:12.433Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2663511,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.4.6","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.4.6","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.4.6/"},"number":"6.1.4.6","summary":"Full-stack
+        over configuration.","downloads_count":2664151,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.4.6","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.4.6","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.4.6/"},"number":"6.1.4.6","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"eaa3d5cf0678a85eab88c4430aa49dc19fd79511a539aa006738f29ac5ebbb06"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-02-11T00:00:00.000Z","created_at":"2022-02-11T18:23:00.402Z","description":"Ruby
@@ -330,73 +255,73 @@ http_interactions:
         Heinemeier Hansson","built_at":"2021-12-15T00:00:00.000Z","created_at":"2021-12-15T22:54:43.260Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":3311211,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.4.4","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.4.4","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.4.4/"},"number":"6.1.4.4","summary":"Full-stack
+        over configuration.","downloads_count":3312364,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.4.4","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.4.4","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.4.4/"},"number":"6.1.4.4","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"14314547cff50bbbcaedf2c1262ba547c043f1e9e584fec960e6ba2fafa77e83"},{"authors":"David
         Heinemeier Hansson","built_at":"2021-12-14T00:00:00.000Z","created_at":"2021-12-14T23:02:52.630Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":244163,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.4.3","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.4.3","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.4.3/"},"number":"6.1.4.3","summary":"Full-stack
+        over configuration.","downloads_count":244173,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.4.3","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.4.3","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.4.3/"},"number":"6.1.4.3","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a630e9a5f2254d84d0708bf23e8e6cc2f8f8d357a1cf3369914b41cbb3c0ed76"},{"authors":"David
         Heinemeier Hansson","built_at":"2021-12-14T00:00:00.000Z","created_at":"2021-12-14T19:54:23.219Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":521328,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.4.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.4.2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.4.2/"},"number":"6.1.4.2","summary":"Full-stack
+        over configuration.","downloads_count":521338,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.4.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.4.2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.4.2/"},"number":"6.1.4.2","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"68a41a4374cb5815c558ae451337a0ecb55462976f58aef2d0a2939e1cca1c10"},{"authors":"David
         Heinemeier Hansson","built_at":"2021-08-19T00:00:00.000Z","created_at":"2021-08-19T16:27:05.901Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":8480302,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.4.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.4.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.4.1/"},"number":"6.1.4.1","summary":"Full-stack
+        over configuration.","downloads_count":8483160,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.4.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.4.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.4.1/"},"number":"6.1.4.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"7f5dd7a71046aedb6859eb4288b31b738fb8544bd9fb27574085b58cbaa8a9f8"},{"authors":"David
         Heinemeier Hansson","built_at":"2021-06-24T00:00:00.000Z","created_at":"2021-06-24T20:41:36.150Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2775800,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.4","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.4","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.4/"},"number":"6.1.4","summary":"Full-stack
+        over configuration.","downloads_count":2776954,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.4","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.4","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.4/"},"number":"6.1.4","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b0a266453e4d53beaaf911434f49868fbc6dd3f1e317149e4b160ba6981a6d4c"},{"authors":"David
         Heinemeier Hansson","built_at":"2021-05-05T00:00:00.000Z","created_at":"2021-05-05T15:47:12.170Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":4950767,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.3.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.3.2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.3.2/"},"number":"6.1.3.2","summary":"Full-stack
+        over configuration.","downloads_count":4951396,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.3.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.3.2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.3.2/"},"number":"6.1.3.2","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"36680669c708bec0a4fb3cdcbae65df62fd99a2a94b0b1f60732ad8322bd963a"},{"authors":"David
         Heinemeier Hansson","built_at":"2021-03-26T00:00:00.000Z","created_at":"2021-03-26T18:08:37.957Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2278248,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.3.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.3.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.3.1/"},"number":"6.1.3.1","summary":"Full-stack
+        over configuration.","downloads_count":2279489,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.3.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.3.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.3.1/"},"number":"6.1.3.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"68889774d4716a7817f32ad18eefd2a5737966539cde5308c0536ef784e786fa"},{"authors":"David
         Heinemeier Hansson","built_at":"2021-02-17T00:00:00.000Z","created_at":"2021-02-17T18:43:25.690Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1014060,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.3","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.3","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.3/"},"number":"6.1.3","summary":"Full-stack
+        over configuration.","downloads_count":1014207,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.3","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.3","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.3/"},"number":"6.1.3","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"7f097f7c565c7ce6c9a0c07345c3af61f9776d65b9bee2fda72718a53db3aa41"},{"authors":"David
         Heinemeier Hansson","built_at":"2021-02-10T00:00:00.000Z","created_at":"2021-02-10T20:46:54.673Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":226998,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.2.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.2.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.2.1/"},"number":"6.1.2.1","summary":"Full-stack
+        over configuration.","downloads_count":227013,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.2.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.2.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.2.1/"},"number":"6.1.2.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"32409615eb41eb7719a82715c6d167757f18d9080a6ba7fa7fcf6e1b59f52112"},{"authors":"David
         Heinemeier Hansson","built_at":"2021-02-09T00:00:00.000Z","created_at":"2021-02-09T21:30:59.508Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":38552,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.2/"},"number":"6.1.2","summary":"Full-stack
+        over configuration.","downloads_count":38553,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.2/"},"number":"6.1.2","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e62c90c4a62f0d177161e0df05d7ba417010858fa418affdb2d93981e407a04e"},{"authors":"David
         Heinemeier Hansson","built_at":"2021-01-07T00:00:00.000Z","created_at":"2021-01-07T23:00:39.767Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":706318,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.1/"},"number":"6.1.1","summary":"Full-stack
+        over configuration.","downloads_count":706350,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.1/"},"number":"6.1.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b7710f82e68af72db1ffa30ff3d67437e8fb91c26255659f3c2602964b834a64"},{"authors":"David
         Heinemeier Hansson","built_at":"2020-12-09T00:00:00.000Z","created_at":"2020-12-09T19:58:25.767Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":687427,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.0","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.0","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.0/"},"number":"6.1.0","summary":"Full-stack
+        over configuration.","downloads_count":687671,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.1.0","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.1.0","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.1.0/"},"number":"6.1.0","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e66d0b9a1dd8640c5a98da5b4ebd7ef5d1e01be67477f910e0cf514fa89c221b"},{"authors":"David
         Heinemeier Hansson","built_at":"2020-12-01T00:00:00.000Z","created_at":"2020-12-01T22:02:12.587Z","description":"Ruby
@@ -414,43 +339,43 @@ http_interactions:
         Heinemeier Hansson","built_at":"2023-01-17T00:00:00.000Z","created_at":"2023-01-17T18:53:31.767Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":847699,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.6.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.6.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.6.1/","rubygems_mfa_required":"true"},"number":"6.0.6.1","summary":"Full-stack
+        over configuration.","downloads_count":853702,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.6.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.6.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.6.1/","rubygems_mfa_required":"true"},"number":"6.0.6.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"069df2abdb0ec0baccd226af4e82ce82102223d6aad9c3c05daf8c42f2a2fa74"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-09-09T00:00:00.000Z","created_at":"2022-09-09T18:32:26.797Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1153747,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.6","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.6","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.6/","rubygems_mfa_required":"true"},"number":"6.0.6","summary":"Full-stack
+        over configuration.","downloads_count":1156327,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.6","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.6","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.6/","rubygems_mfa_required":"true"},"number":"6.0.6","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4591c0b0434f57678efa71ef4133ae7e2577a0a2131a069f5213e7a296c609e1"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-07-12T00:00:00.000Z","created_at":"2022-07-12T17:28:31.607Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1781357,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.5.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.5.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.5.1/","rubygems_mfa_required":"true"},"number":"6.0.5.1","summary":"Full-stack
+        over configuration.","downloads_count":1782714,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.5.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.5.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.5.1/","rubygems_mfa_required":"true"},"number":"6.0.5.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"2abcfe2eff00e3c5d83e91bd6efcff5a03c16499c918b341354ef9e69188904a"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-05-09T00:00:00.000Z","created_at":"2022-05-09T13:55:52.176Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":910179,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.5","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.5","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.5/","rubygems_mfa_required":"true"},"number":"6.0.5","summary":"Full-stack
+        over configuration.","downloads_count":910778,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.5","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.5","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.5/","rubygems_mfa_required":"true"},"number":"6.0.5","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e810af40d58ba99ca9fda7e446ed19e93da83da748224dd9277c4c2999556ed7"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-04-26T00:00:00.000Z","created_at":"2022-04-26T19:27:17.853Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2702744,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.4.8","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.4.8","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.4.8/"},"number":"6.0.4.8","summary":"Full-stack
+        over configuration.","downloads_count":2705154,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.4.8","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.4.8","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.4.8/"},"number":"6.0.4.8","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"2d0ab1ec42beda9c60e979c9759e7ea9332cc8128650173f6e128495b74d1917"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-03-08T00:00:00.000Z","created_at":"2022-03-08T17:47:49.182Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1421406,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.4.7","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.4.7","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.4.7/"},"number":"6.0.4.7","summary":"Full-stack
+        over configuration.","downloads_count":1421905,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.4.7","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.4.7","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.4.7/"},"number":"6.0.4.7","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"cb2eccd564ac30e9efccc33f7bab0408cdaffc0d862ef41be275e8a3fa4a2be5"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-02-11T00:00:00.000Z","created_at":"2022-02-11T19:40:17.360Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1157499,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.4.6","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.4.6","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.4.6/"},"number":"6.0.4.6","summary":"Full-stack
+        over configuration.","downloads_count":1157582,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.4.6","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.4.6","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.4.6/"},"number":"6.0.4.6","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"6034231cb496dcd4467fccfa2792ee921347eba1d666b866f8f3b530b72b1620"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-02-11T00:00:00.000Z","created_at":"2022-02-11T18:25:30.490Z","description":"Ruby
@@ -462,79 +387,79 @@ http_interactions:
         Heinemeier Hansson","built_at":"2021-12-15T00:00:00.000Z","created_at":"2021-12-15T22:48:07.861Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":951777,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.4.4","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.4.4","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.4.4/"},"number":"6.0.4.4","summary":"Full-stack
+        over configuration.","downloads_count":952129,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.4.4","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.4.4","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.4.4/"},"number":"6.0.4.4","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5d3a7faac56f22fbe50c69bcaef1a87c6b99bcbfa74ab2de973e67c2bbdc31bf"},{"authors":"David
         Heinemeier Hansson","built_at":"2021-12-14T00:00:00.000Z","created_at":"2021-12-14T23:01:12.359Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":330326,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.4.3","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.4.3","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.4.3/"},"number":"6.0.4.3","summary":"Full-stack
+        over configuration.","downloads_count":330330,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.4.3","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.4.3","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.4.3/"},"number":"6.0.4.3","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"33b7a4b723ca8e3b4ba55ac31d244e0270a44dfb0714432ffdc32d5508195a5d"},{"authors":"David
         Heinemeier Hansson","built_at":"2021-12-14T00:00:00.000Z","created_at":"2021-12-14T20:11:34.368Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":76762,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.4.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.4.2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.4.2/"},"number":"6.0.4.2","summary":"Full-stack
+        over configuration.","downloads_count":76763,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.4.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.4.2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.4.2/"},"number":"6.0.4.2","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0b23a2522d0d06ec67934a125fce3699a8011467c2e32cc73bf456bb41b2d03b"},{"authors":"David
         Heinemeier Hansson","built_at":"2021-08-19T00:00:00.000Z","created_at":"2021-08-19T16:24:04.111Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2215141,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.4.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.4.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.4.1/"},"number":"6.0.4.1","summary":"Full-stack
+        over configuration.","downloads_count":2215496,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.4.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.4.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.4.1/"},"number":"6.0.4.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"62f6b50573e2afc305575f580ed72783512874464726d8e52fe8c10b981d1ee0"},{"authors":"David
         Heinemeier Hansson","built_at":"2021-06-15T00:00:00.000Z","created_at":"2021-06-15T20:18:42.690Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1037582,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.4","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.4","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.4/"},"number":"6.0.4","summary":"Full-stack
+        over configuration.","downloads_count":1038080,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.4","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.4","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.4/"},"number":"6.0.4","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4fcf7ceeae044e95be52efd5a3f94ec14872643121a461187424246fdd0df7cb"},{"authors":"David
         Heinemeier Hansson","built_at":"2021-05-05T00:00:00.000Z","created_at":"2021-05-05T16:02:39.448Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":4464676,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.3.7","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.3.7","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.3.7/"},"number":"6.0.3.7","summary":"Full-stack
+        over configuration.","downloads_count":4465327,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.3.7","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.3.7","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.3.7/"},"number":"6.0.3.7","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"41e295498229ae1134c052b2529df7835bd5639b92e54a30979b4b0d45601a6f"},{"authors":"David
         Heinemeier Hansson","built_at":"2021-03-26T00:00:00.000Z","created_at":"2021-03-26T17:34:24.038Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":3524387,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.3.6","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.3.6","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.3.6/"},"number":"6.0.3.6","summary":"Full-stack
+        over configuration.","downloads_count":3528248,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.3.6","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.3.6","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.3.6/"},"number":"6.0.3.6","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"790a078dad5832c6b93c460cd9f530f85cf3233a4306135713e97c9f30e9bc06"},{"authors":"David
         Heinemeier Hansson","built_at":"2021-02-10T00:00:00.000Z","created_at":"2021-02-10T20:40:58.384Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2918660,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.3.5","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.3.5","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.3.5/"},"number":"6.0.3.5","summary":"Full-stack
+        over configuration.","downloads_count":2918829,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.3.5","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.3.5","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.3.5/"},"number":"6.0.3.5","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0a914868970c2f8cf3ca5e6e331337d630d8994a4bdbe62a919258fcb274fb05"},{"authors":"David
         Heinemeier Hansson","built_at":"2020-10-07T00:00:00.000Z","created_at":"2020-10-07T16:51:45.423Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":7788126,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.3.4","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.3.4","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.3.4/"},"number":"6.0.3.4","summary":"Full-stack
+        over configuration.","downloads_count":7788519,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.3.4","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.3.4","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.3.4/"},"number":"6.0.3.4","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"af3b76d0641875e903a6d1006b5556d3a8070cbeaa416bc50025df729f9b446f"},{"authors":"David
         Heinemeier Hansson","built_at":"2020-09-09T00:00:00.000Z","created_at":"2020-09-09T18:40:40.945Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":3114509,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.3.3","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.3.3","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.3.3/"},"number":"6.0.3.3","summary":"Full-stack
+        over configuration.","downloads_count":3114622,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.3.3","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.3.3","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.3.3/"},"number":"6.0.3.3","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c470ef45cd2ef9c0742c5f4d1fbd2b24e2bea05c5e9122fb9e5d8fb0348f1ae3"},{"authors":"David
         Heinemeier Hansson","built_at":"2020-06-17T00:00:00.000Z","created_at":"2020-06-17T14:55:22.792Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":4124456,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.3.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.3.2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.3.2/"},"number":"6.0.3.2","summary":"Full-stack
+        over configuration.","downloads_count":4125239,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.3.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.3.2","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.3.2/"},"number":"6.0.3.2","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5daa748fe3983204fc44f00697fa75cd8c0310b35d37ba85c317141d4123aa8e"},{"authors":"David
         Heinemeier Hansson","built_at":"2020-05-18T00:00:00.000Z","created_at":"2020-05-18T15:47:58.979Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":3332348,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.3.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.3.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.3.1/"},"number":"6.0.3.1","summary":"Full-stack
+        over configuration.","downloads_count":3332581,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.3.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.3.1","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.3.1/"},"number":"6.0.3.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"846a0d06fba09378298d97efd01595596ee2d6841602da4f14a0e1f400136ab2"},{"authors":"David
         Heinemeier Hansson","built_at":"2020-05-06T00:00:00.000Z","created_at":"2020-05-06T18:06:19.228Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":723314,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.3","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.3","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.3/"},"number":"6.0.3","summary":"Full-stack
+        over configuration.","downloads_count":723418,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.3","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.3","mailing_list_uri":"https://discuss.rubyonrails.org/c/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.3/"},"number":"6.0.3","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"399039af4ca160751f87505e13d1a000dfb65e15e4d86601eb34070b85fc73e7"},{"authors":"David
         Heinemeier Hansson","built_at":"2020-05-01T00:00:00.000Z","created_at":"2020-05-01T17:19:16.854Z","description":"Ruby
@@ -546,19 +471,19 @@ http_interactions:
         Heinemeier Hansson","built_at":"2020-03-19T00:00:00.000Z","created_at":"2020-03-19T16:44:43.643Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2114224,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.2.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.2.2","mailing_list_uri":"https://groups.google.com/forum/#!forum/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.2.2/"},"number":"6.0.2.2","summary":"Full-stack
+        over configuration.","downloads_count":2114401,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.2.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.2.2","mailing_list_uri":"https://groups.google.com/forum/#!forum/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.2.2/"},"number":"6.0.2.2","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4b789dc6d942e133032485169aa30553482b528ffea5dd52a3bab853fca0c822"},{"authors":"David
         Heinemeier Hansson","built_at":"2019-12-18T00:00:00.000Z","created_at":"2019-12-18T19:09:59.411Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":3421502,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.2.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.2.1","mailing_list_uri":"https://groups.google.com/forum/#!forum/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.2.1/"},"number":"6.0.2.1","summary":"Full-stack
+        over configuration.","downloads_count":3422002,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.2.1","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.2.1","mailing_list_uri":"https://groups.google.com/forum/#!forum/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.2.1/"},"number":"6.0.2.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"32a07bc27a22c80752847936aa52497c5d97de9c577b1120a2e897dda77f93b0"},{"authors":"David
         Heinemeier Hansson","built_at":"2019-12-13T00:00:00.000Z","created_at":"2019-12-13T18:22:04.637Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":831843,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.2","mailing_list_uri":"https://groups.google.com/forum/#!forum/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.2/"},"number":"6.0.2","summary":"Full-stack
+        over configuration.","downloads_count":831892,"metadata":{"changelog_uri":"https://github.com/rails/rails/releases/tag/v6.0.2","bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.2","mailing_list_uri":"https://groups.google.com/forum/#!forum/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.2/"},"number":"6.0.2","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b5223754088b3adfca6608a1901fbd7813b4b994af4ec514accd0b3b5ce05d0b"},{"authors":"David
         Heinemeier Hansson","built_at":"2019-12-09T00:00:00.000Z","created_at":"2019-12-09T16:14:24.296Z","description":"Ruby
@@ -576,31 +501,31 @@ http_interactions:
         Heinemeier Hansson","built_at":"2019-11-05T00:00:00.000Z","created_at":"2019-11-05T14:41:11.133Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1139270,"metadata":{"bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.1","mailing_list_uri":"https://groups.google.com/forum/#!forum/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.1/"},"number":"6.0.1","summary":"Full-stack
+        over configuration.","downloads_count":1139373,"metadata":{"bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.1","mailing_list_uri":"https://groups.google.com/forum/#!forum/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.1/"},"number":"6.0.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"87c242b5dbac85026ef3fe1278a51bee6d81913fb631465c4bfee2e8e8759ec8"},{"authors":"David
         Heinemeier Hansson","built_at":"2019-10-31T00:00:00.000Z","created_at":"2019-10-31T20:12:42.982Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":3523,"metadata":{"bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.1.rc1","mailing_list_uri":"https://groups.google.com/forum/#!forum/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.1.rc1/"},"number":"6.0.1.rc1","summary":"Full-stack
+        over configuration.","downloads_count":3525,"metadata":{"bug_tracker_uri":"https://github.com/rails/rails/issues","source_code_uri":"https://github.com/rails/rails/tree/v6.0.1.rc1","mailing_list_uri":"https://groups.google.com/forum/#!forum/rubyonrails-talk","documentation_uri":"https://api.rubyonrails.org/v6.0.1.rc1/"},"number":"6.0.1.rc1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"eee594a0a944fc2d182a29a440c2bca62b8e55ec63ada2a77cfe003d6447e4ed"},{"authors":"David
         Heinemeier Hansson","built_at":"2019-08-16T00:00:00.000Z","created_at":"2019-08-16T18:01:50.039Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2151814,"metadata":{},"number":"6.0.0","summary":"Full-stack
+        over configuration.","downloads_count":2152031,"metadata":{},"number":"6.0.0","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"dcb924cb0e7ec85c9773f9711caac1fd7c8f3791eb42d389dd6967d02545fdc2"},{"authors":"David
         Heinemeier Hansson","built_at":"2019-07-22T00:00:00.000Z","created_at":"2019-07-22T21:13:05.492Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":120762,"metadata":{},"number":"6.0.0.rc2","summary":"Full-stack
+        over configuration.","downloads_count":120766,"metadata":{},"number":"6.0.0.rc2","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"8ccb7e5a01880ec88de4d729de358c9ca0534777b1789467aef80dc54812cc9d"},{"authors":"David
         Heinemeier Hansson","built_at":"2019-04-24T00:00:00.000Z","created_at":"2019-04-24T18:51:47.763Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":305535,"metadata":{},"number":"6.0.0.rc1","summary":"Full-stack
+        over configuration.","downloads_count":305554,"metadata":{},"number":"6.0.0.rc1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.5.0","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"7b9b4224a0ccfaf63d66234679afc6485accb7ac7bd06cce67a49dd2945115ce"},{"authors":"David
         Heinemeier Hansson","built_at":"2019-03-13T00:00:00.000Z","created_at":"2019-03-13T17:03:33.751Z","description":"Ruby
@@ -624,37 +549,37 @@ http_interactions:
         Heinemeier Hansson","built_at":"2022-07-12T00:00:00.000Z","created_at":"2022-07-12T17:26:29.354Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":5502903,"metadata":{},"number":"5.2.8.1","summary":"Full-stack
+        over configuration.","downloads_count":5511041,"metadata":{},"number":"5.2.8.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"cf18751a5e603cc1996536de8109459da9998c843dc5381ab8f87680a793c4cb"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-05-09T00:00:00.000Z","created_at":"2022-05-09T14:04:34.858Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1359292,"metadata":{},"number":"5.2.8","summary":"Full-stack
+        over configuration.","downloads_count":1360337,"metadata":{},"number":"5.2.8","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8910529ca26e845b7d0e4448f844f07f0b929b29c8d733f1217e914aa3f80421"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-04-26T00:00:00.000Z","created_at":"2022-04-26T19:23:33.623Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1643576,"metadata":{},"number":"5.2.7.1","summary":"Full-stack
+        over configuration.","downloads_count":1643751,"metadata":{},"number":"5.2.7.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a917d368f804a06aba6a2538c42b68d7a908337be51d527ef5db83d8dc0bfa7e"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-03-10T00:00:00.000Z","created_at":"2022-03-11T00:01:27.495Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":861889,"metadata":{},"number":"5.2.7","summary":"Full-stack
+        over configuration.","downloads_count":862180,"metadata":{},"number":"5.2.7","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b650a8f5a0a896555b4539b9f523024a64c605fb849de92affea803a9c6b0ee6"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-03-08T00:00:00.000Z","created_at":"2022-03-08T17:46:06.998Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":787142,"metadata":{},"number":"5.2.6.3","summary":"Full-stack
+        over configuration.","downloads_count":787335,"metadata":{},"number":"5.2.6.3","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d621ec624f3da36cb05483e6048759bbce13be1f092135ca39276b2da71526a5"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-02-11T00:00:00.000Z","created_at":"2022-02-11T19:37:40.891Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1452052,"metadata":{},"number":"5.2.6.2","summary":"Full-stack
+        over configuration.","downloads_count":1452170,"metadata":{},"number":"5.2.6.2","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c0ebe849cca73a5e053e673376349eb46674770dfb4ee46e4152c8314ea3eb39"},{"authors":"David
         Heinemeier Hansson","built_at":"2022-02-11T00:00:00.000Z","created_at":"2022-02-11T18:44:20.296Z","description":"Ruby
@@ -666,55 +591,55 @@ http_interactions:
         Heinemeier Hansson","built_at":"2021-05-05T00:00:00.000Z","created_at":"2021-05-05T17:09:14.109Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":8086166,"metadata":{},"number":"5.2.6","summary":"Full-stack
+        over configuration.","downloads_count":8087932,"metadata":{},"number":"5.2.6","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ccdef9f57c2c0f67faae9d5b6d155f5e61b033f944499ea09d6383e6626d27dc"},{"authors":"David
         Heinemeier Hansson","built_at":"2021-03-26T00:00:00.000Z","created_at":"2021-03-26T17:21:08.771Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2728146,"metadata":{},"number":"5.2.5","summary":"Full-stack
+        over configuration.","downloads_count":2729235,"metadata":{},"number":"5.2.5","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4c14aa2558250f2dbb85d4a5c6046159ff7cf285b86c367d9dae3eabcd501adc"},{"authors":"David
         Heinemeier Hansson","built_at":"2021-05-05T00:00:00.000Z","created_at":"2021-05-05T15:29:45.600Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2444399,"metadata":{},"number":"5.2.4.6","summary":"Full-stack
+        over configuration.","downloads_count":2445083,"metadata":{},"number":"5.2.4.6","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"cb1369b8e341092cc154ef9ebb9b3a57801366ec32506d5166b9b2a6530eda7d"},{"authors":"David
         Heinemeier Hansson","built_at":"2021-02-10T00:00:00.000Z","created_at":"2021-02-10T20:36:47.152Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1741721,"metadata":{},"number":"5.2.4.5","summary":"Full-stack
+        over configuration.","downloads_count":1741889,"metadata":{},"number":"5.2.4.5","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"cd4dd4b224e58a8bc03c3fb182fd748dda2f36abfae6ecd8db145a8c5da8fadb"},{"authors":"David
         Heinemeier Hansson","built_at":"2020-09-09T00:00:00.000Z","created_at":"2020-09-09T18:40:04.077Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":5372159,"metadata":{},"number":"5.2.4.4","summary":"Full-stack
+        over configuration.","downloads_count":5372372,"metadata":{},"number":"5.2.4.4","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"005bdf45d254f7e315f157eb0ceff38584fb41b772234e889eccaea50b1caf2c"},{"authors":"David
         Heinemeier Hansson","built_at":"2020-05-18T00:00:00.000Z","created_at":"2020-05-18T15:43:14.514Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":5232323,"metadata":{},"number":"5.2.4.3","summary":"Full-stack
+        over configuration.","downloads_count":5232599,"metadata":{},"number":"5.2.4.3","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f29c6b2dea33410c2988f17f42b69531871e3ba71b446558da46af045f7503fb"},{"authors":"David
         Heinemeier Hansson","built_at":"2020-03-19T00:00:00.000Z","created_at":"2020-03-19T16:38:05.377Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2175514,"metadata":{},"number":"5.2.4.2","summary":"Full-stack
+        over configuration.","downloads_count":2175601,"metadata":{},"number":"5.2.4.2","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"44ab2836290ef259ed12fc6a24c1e62e317a534b79c37c0d1a8ec7ef893513f5"},{"authors":"David
         Heinemeier Hansson","built_at":"2019-12-18T00:00:00.000Z","created_at":"2019-12-18T19:04:02.693Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2169961,"metadata":{},"number":"5.2.4.1","summary":"Full-stack
+        over configuration.","downloads_count":2170057,"metadata":{},"number":"5.2.4.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"402c80f8533052bb9f62e9c61aad9a559b96c04961ddda93151852b8f8572885"},{"authors":"David
         Heinemeier Hansson","built_at":"2019-11-27T00:00:00.000Z","created_at":"2019-11-27T15:48:34.344Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1049726,"metadata":{},"number":"5.2.4","summary":"Full-stack
+        over configuration.","downloads_count":1049809,"metadata":{},"number":"5.2.4","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3abc0d1c5a6a87821ed73d0f523fbb63e09610dbdfd7f8b948e14a15f7749481"},{"authors":"David
         Heinemeier Hansson","built_at":"2019-11-23T00:00:00.000Z","created_at":"2019-11-23T00:29:26.852Z","description":"Ruby
@@ -726,7 +651,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2019-03-28T00:00:00.000Z","created_at":"2019-03-28T03:02:40.948Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":13537497,"metadata":{},"number":"5.2.3","summary":"Full-stack
+        over configuration.","downloads_count":13538233,"metadata":{},"number":"5.2.3","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f9b51b66a91d556d63d36d04449ecc23867683f99531db21eb7a263be2d7ecdc"},{"authors":"David
         Heinemeier Hansson","built_at":"2019-03-22T00:00:00.000Z","created_at":"2019-03-22T03:35:22.787Z","description":"Ruby
@@ -738,13 +663,13 @@ http_interactions:
         Heinemeier Hansson","built_at":"2019-03-13T00:00:00.000Z","created_at":"2019-03-13T16:54:48.659Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":3807436,"metadata":{},"number":"5.2.2.1","summary":"Full-stack
+        over configuration.","downloads_count":3807631,"metadata":{},"number":"5.2.2.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e9d64c83adc309c84e1561f2842474b16906cb812756084d08763d3e7de6b5cb"},{"authors":"David
         Heinemeier Hansson","built_at":"2018-12-04T00:00:00.000Z","created_at":"2018-12-04T18:15:02.233Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":5303290,"metadata":{},"number":"5.2.2","summary":"Full-stack
+        over configuration.","downloads_count":5304001,"metadata":{},"number":"5.2.2","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d9ff5d9be16ee277dfc8f3c760bf171aa497d8685ec5c8988fba21a3dbd72cd5"},{"authors":"David
         Heinemeier Hansson","built_at":"2018-11-28T00:00:00.000Z","created_at":"2018-11-28T22:55:23.827Z","description":"Ruby
@@ -756,13 +681,13 @@ http_interactions:
         Heinemeier Hansson","built_at":"2018-11-27T00:00:00.000Z","created_at":"2018-11-27T20:14:16.796Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":522722,"metadata":{},"number":"5.2.1.1","summary":"Full-stack
+        over configuration.","downloads_count":522727,"metadata":{},"number":"5.2.1.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b5e1fe216d108d6908e23aaaed563dcf8fae7ec92c4ea776607732785bad8f10"},{"authors":"David
         Heinemeier Hansson","built_at":"2018-08-07T00:00:00.000Z","created_at":"2018-08-07T21:44:52.020Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":3888067,"metadata":{},"number":"5.2.1","summary":"Full-stack
+        over configuration.","downloads_count":3888311,"metadata":{},"number":"5.2.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"776cfea45140972f1780236748f7cfe72cf95c032056812128433273c366078c"},{"authors":"David
         Heinemeier Hansson","built_at":"2018-07-30T00:00:00.000Z","created_at":"2018-07-30T20:22:38.749Z","description":"Ruby
@@ -774,7 +699,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2018-04-09T00:00:00.000Z","created_at":"2018-04-09T20:07:04.834Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":5154398,"metadata":{},"number":"5.2.0","summary":"Full-stack
+        over configuration.","downloads_count":5155379,"metadata":{},"number":"5.2.0","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"035dde6374845b5a17bb2c024fb60dfe46e78a04d47cfe22c81e6c5912b51686"},{"authors":"David
         Heinemeier Hansson","built_at":"2018-03-20T00:00:00.000Z","created_at":"2018-03-20T17:54:58.165Z","description":"Ruby
@@ -804,7 +729,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2019-03-28T00:00:00.000Z","created_at":"2019-03-28T02:48:31.504Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":12565650,"metadata":{},"number":"5.1.7","summary":"Full-stack
+        over configuration.","downloads_count":12568034,"metadata":{},"number":"5.1.7","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8d7f527c446de3f99ec506e6a680c42c38979a44b37beb15f7d451a33e74dcf5"},{"authors":"David
         Heinemeier Hansson","built_at":"2019-03-22T00:00:00.000Z","created_at":"2019-03-22T04:13:43.625Z","description":"Ruby
@@ -816,25 +741,25 @@ http_interactions:
         Heinemeier Hansson","built_at":"2019-03-13T00:00:00.000Z","created_at":"2019-03-13T16:46:09.784Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2096728,"metadata":{},"number":"5.1.6.2","summary":"Full-stack
+        over configuration.","downloads_count":2096837,"metadata":{},"number":"5.1.6.2","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8e721f8e6c7ea0dfd6dbf7fe215f2c40b1de5d104b6cf5d1e1313dc02be640e9"},{"authors":"David
         Heinemeier Hansson","built_at":"2018-11-27T00:00:00.000Z","created_at":"2018-11-27T20:11:47.585Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1099416,"metadata":{},"number":"5.1.6.1","summary":"Full-stack
+        over configuration.","downloads_count":1099454,"metadata":{},"number":"5.1.6.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"f64f110ff439f10616e87e35dee23aeb0932e77869c64b3e2239b1332db5c863"},{"authors":"David
         Heinemeier Hansson","built_at":"2018-03-29T00:00:00.000Z","created_at":"2018-03-29T18:29:03.149Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":4261858,"metadata":{},"number":"5.1.6","summary":"Full-stack
+        over configuration.","downloads_count":4262046,"metadata":{},"number":"5.1.6","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b8301a87151de3feb7cbdf57a66842bb668493f4cec464fd0f67d4c7173b6051"},{"authors":"David
         Heinemeier Hansson","built_at":"2018-02-14T00:00:00.000Z","created_at":"2018-02-14T20:02:02.541Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2761192,"metadata":{},"number":"5.1.5","summary":"Full-stack
+        over configuration.","downloads_count":2761657,"metadata":{},"number":"5.1.5","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"fee9771fc53f3060875267a6789aea9e35975e5c344ff5c3175e27be92a01561"},{"authors":"David
         Heinemeier Hansson","built_at":"2018-02-01T00:00:00.000Z","created_at":"2018-02-01T19:00:37.520Z","description":"Ruby
@@ -846,7 +771,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2017-09-08T00:00:00.000Z","created_at":"2017-09-08T00:52:07.791Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":7015093,"metadata":{},"number":"5.1.4","summary":"Full-stack
+        over configuration.","downloads_count":7015350,"metadata":{},"number":"5.1.4","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"5cc2192045678789e5e7b289476af8bc0a79210ee6713886200cb303ed6f98b8"},{"authors":"David
         Heinemeier Hansson","built_at":"2017-08-24T00:00:00.000Z","created_at":"2017-08-24T19:37:37.728Z","description":"Ruby
@@ -858,7 +783,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2017-08-03T00:00:00.000Z","created_at":"2017-08-03T19:15:15.370Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1036912,"metadata":{},"number":"5.1.3","summary":"Full-stack
+        over configuration.","downloads_count":1036937,"metadata":{},"number":"5.1.3","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"28c73c5aba5ce71d4bcd6af273be3e565ab7a49abd22fd511dc79fcb36329d19"},{"authors":"David
         Heinemeier Hansson","built_at":"2017-07-31T00:00:00.000Z","created_at":"2017-07-31T19:12:53.241Z","description":"Ruby
@@ -882,7 +807,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2017-06-26T00:00:00.000Z","created_at":"2017-06-26T21:51:41.161Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1375398,"metadata":{},"number":"5.1.2","summary":"Full-stack
+        over configuration.","downloads_count":1375439,"metadata":{},"number":"5.1.2","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4ee8ea1a2760cafbd70fbc878fd0c4ad2fec105082719c818934b39fd4ff0e9b"},{"authors":"David
         Heinemeier Hansson","built_at":"2017-06-20T00:00:00.000Z","created_at":"2017-06-20T17:03:49.322Z","description":"Ruby
@@ -894,19 +819,19 @@ http_interactions:
         Heinemeier Hansson","built_at":"2017-05-12T00:00:00.000Z","created_at":"2017-05-12T20:11:39.743Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1112539,"metadata":{},"number":"5.1.1","summary":"Full-stack
+        over configuration.","downloads_count":1112714,"metadata":{},"number":"5.1.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"175e79dd0770470e4ff7055989ae136fee9cbb4b3145bcb00a5c4783e941aed7"},{"authors":"David
         Heinemeier Hansson","built_at":"2017-04-27T00:00:00.000Z","created_at":"2017-04-27T21:00:47.670Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":506976,"metadata":{},"number":"5.1.0","summary":"Full-stack
+        over configuration.","downloads_count":507032,"metadata":{},"number":"5.1.0","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d843e2d2c61987f1fb7877cd98bc5d1f2704ad4eee9adf9c1455858769b6ec32"},{"authors":"David
         Heinemeier Hansson","built_at":"2017-04-21T00:00:00.000Z","created_at":"2017-04-21T01:31:13.442Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":29814,"metadata":{},"number":"5.1.0.rc2","summary":"Full-stack
+        over configuration.","downloads_count":29817,"metadata":{},"number":"5.1.0.rc2","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"3c9dc0e1df91b756fe83ce6d7f3184fd27a3c60fc101588a59a30b390308be2b"},{"authors":"David
         Heinemeier Hansson","built_at":"2017-03-20T00:00:00.000Z","created_at":"2017-03-20T18:57:56.595Z","description":"Ruby
@@ -924,25 +849,25 @@ http_interactions:
         Heinemeier Hansson","built_at":"2019-03-13T00:00:00.000Z","created_at":"2019-03-13T16:44:05.926Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":6762145,"metadata":{},"number":"5.0.7.2","summary":"Full-stack
+        over configuration.","downloads_count":6763658,"metadata":{},"number":"5.0.7.2","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3ce2eac8fa58ce138e3e2a2fa9b544c8f43128e0c24d0a1d8d751b3a515bb82a"},{"authors":"David
         Heinemeier Hansson","built_at":"2018-11-27T00:00:00.000Z","created_at":"2018-11-27T20:09:36.347Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":895309,"metadata":{},"number":"5.0.7.1","summary":"Full-stack
+        over configuration.","downloads_count":895660,"metadata":{},"number":"5.0.7.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3ce11ed1acf1eea4b4b35b4516251e81a5cbbd889227432b232409cb9c658a2e"},{"authors":"David
         Heinemeier Hansson","built_at":"2018-03-29T00:00:00.000Z","created_at":"2018-03-29T18:18:14.388Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2018695,"metadata":{},"number":"5.0.7","summary":"Full-stack
+        over configuration.","downloads_count":2018766,"metadata":{},"number":"5.0.7","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"76815a2a7e99c83b53ea52325c5bbc5ca15e25ecdfb741ea329ca153cf11ff84"},{"authors":"David
         Heinemeier Hansson","built_at":"2017-09-08T00:00:00.000Z","created_at":"2017-09-08T00:47:42.201Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":3172886,"metadata":{},"number":"5.0.6","summary":"Full-stack
+        over configuration.","downloads_count":3172954,"metadata":{},"number":"5.0.6","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a86663f8d0d4dd0cb07272394a6d0c7d250be617c6efe77edd2ebc9c9d139746"},{"authors":"David
         Heinemeier Hansson","built_at":"2017-08-24T00:00:00.000Z","created_at":"2017-08-24T19:21:20.599Z","description":"Ruby
@@ -954,7 +879,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2017-07-31T00:00:00.000Z","created_at":"2017-07-31T19:05:29.060Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":525695,"metadata":{},"number":"5.0.5","summary":"Full-stack
+        over configuration.","downloads_count":525705,"metadata":{},"number":"5.0.5","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"15e2c25872e5dc2069b0d7bf4535eb4887e77d49166ccfba5871a904c18957b1"},{"authors":"David
         Heinemeier Hansson","built_at":"2017-07-25T00:00:00.000Z","created_at":"2017-07-25T20:26:10.369Z","description":"Ruby
@@ -972,7 +897,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2017-06-19T00:00:00.000Z","created_at":"2017-06-19T21:58:56.501Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":593894,"metadata":{},"number":"5.0.4","summary":"Full-stack
+        over configuration.","downloads_count":593897,"metadata":{},"number":"5.0.4","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"956e9bd0acf86701b139432eb3c9e6bc6d2f51e7cccec9a5dcf9c7d3cb14d87d"},{"authors":"David
         Heinemeier Hansson","built_at":"2017-06-14T00:00:00.000Z","created_at":"2017-06-14T20:49:29.610Z","description":"Ruby
@@ -984,13 +909,13 @@ http_interactions:
         Heinemeier Hansson","built_at":"2017-05-12T00:00:00.000Z","created_at":"2017-05-12T20:08:33.226Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":745257,"metadata":{},"number":"5.0.3","summary":"Full-stack
+        over configuration.","downloads_count":745314,"metadata":{},"number":"5.0.3","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"fba5f99999f1b01367010f0d85a28b5d992d5866766fbc3d485bce8e14915f2b"},{"authors":"David
         Heinemeier Hansson","built_at":"2017-03-01T00:00:00.000Z","created_at":"2017-03-01T23:13:53.219Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2264429,"metadata":{},"number":"5.0.2","summary":"Full-stack
+        over configuration.","downloads_count":2264463,"metadata":{},"number":"5.0.2","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"49c6c350286e2f177df5c2214f9668f0866d87411ab5a63e051e25eb64453f70"},{"authors":"David
         Heinemeier Hansson","built_at":"2017-02-25T00:00:00.000Z","created_at":"2017-02-25T00:55:48.618Z","description":"Ruby
@@ -1002,7 +927,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2016-12-21T00:00:00.000Z","created_at":"2016-12-21T00:07:46.527Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2757641,"metadata":{},"number":"5.0.1","summary":"Full-stack
+        over configuration.","downloads_count":2757727,"metadata":{},"number":"5.0.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"3f9acd2c489c9eed11ff200a37cb32784cf15ddc5e561657d50b847ced3c361d"},{"authors":"David
         Heinemeier Hansson","built_at":"2016-12-09T00:00:00.000Z","created_at":"2016-12-09T19:13:12.953Z","description":"Ruby
@@ -1020,13 +945,13 @@ http_interactions:
         Heinemeier Hansson","built_at":"2016-08-10T00:00:00.000Z","created_at":"2016-08-11T17:35:27.196Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2441218,"metadata":{},"number":"5.0.0.1","summary":"Full-stack
+        over configuration.","downloads_count":2441252,"metadata":{},"number":"5.0.0.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b51cf641a376e16166587cfe41f46e37bd3a510c13a8b79f0682985c1603e4d8"},{"authors":"David
         Heinemeier Hansson","built_at":"2016-06-30T00:00:00.000Z","created_at":"2016-06-30T21:32:45.255Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1009329,"metadata":{},"number":"5.0.0","summary":"Full-stack
+        over configuration.","downloads_count":1009384,"metadata":{},"number":"5.0.0","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 2.2.2","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"2e7be2dd453d6ccd7561cc21c5d60a4042f7b3455325f1d9e8dc3d7f79e2d5ef"},{"authors":"David
         Heinemeier Hansson","built_at":"2016-06-22T00:00:00.000Z","created_at":"2016-06-22T20:03:41.237Z","description":"Ruby
@@ -1080,7 +1005,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2020-05-15T00:00:00.000Z","created_at":"2020-05-15T18:35:36.370Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":3173077,"metadata":{},"number":"4.2.11.3","summary":"Full-stack
+        over configuration.","downloads_count":3174258,"metadata":{},"number":"4.2.11.3","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"7502ee83259abce924803052e34f3a9d072b01050e41e2ae94a22ddfd16d9686"},{"authors":"David
         Heinemeier Hansson","built_at":"2020-05-15T00:00:00.000Z","created_at":"2020-05-15T16:30:58.148Z","description":"Ruby
@@ -1092,19 +1017,19 @@ http_interactions:
         Heinemeier Hansson","built_at":"2019-03-11T00:00:00.000Z","created_at":"2019-03-13T16:37:43.380Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":7279887,"metadata":{},"number":"4.2.11.1","summary":"Full-stack
+        over configuration.","downloads_count":7280887,"metadata":{},"number":"4.2.11.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b4b6536187eab61696358d851e043d60be3fc8313da67815467bb4968a8e9bfb"},{"authors":"David
         Heinemeier Hansson","built_at":"2018-11-27T00:00:00.000Z","created_at":"2018-11-27T20:07:25.845Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2783283,"metadata":{},"number":"4.2.11","summary":"Full-stack
+        over configuration.","downloads_count":2784244,"metadata":{},"number":"4.2.11","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"dd12ffea8f548accec41ae1ef6add3cf9f1e00275744f92da60a713a0b0d1766"},{"authors":"David
         Heinemeier Hansson","built_at":"2017-09-27T00:00:00.000Z","created_at":"2017-09-27T14:29:42.567Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":7230862,"metadata":{},"number":"4.2.10","summary":"Full-stack
+        over configuration.","downloads_count":7231172,"metadata":{},"number":"4.2.10","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"141067e1dd4ec59d7a49e54936b68d8e44d8616515625dcf0387405a276d6b97"},{"authors":"David
         Heinemeier Hansson","built_at":"2017-09-20T00:00:00.000Z","created_at":"2017-09-20T19:42:33.297Z","description":"Ruby
@@ -1116,7 +1041,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2017-06-26T00:00:00.000Z","created_at":"2017-06-26T21:30:56.077Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":14299205,"metadata":{},"number":"4.2.9","summary":"Full-stack
+        over configuration.","downloads_count":14299250,"metadata":{},"number":"4.2.9","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"eaaa4c1cafb3f9bd9f8dd58dd142522e398a5ad0d03abf2e3de364a63d4b7d1a"},{"authors":"David
         Heinemeier Hansson","built_at":"2017-06-19T00:00:00.000Z","created_at":"2017-06-19T22:28:22.086Z","description":"Ruby
@@ -1134,25 +1059,25 @@ http_interactions:
         Heinemeier Hansson","built_at":"2017-02-21T00:00:00.000Z","created_at":"2017-02-21T16:08:53.220Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":5393223,"metadata":{},"number":"4.2.8","summary":"Full-stack
+        over configuration.","downloads_count":5393640,"metadata":{},"number":"4.2.8","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"90552099146e785e66cf90ede51dca0c1814440026eef2f8c418aebffc70eb36"},{"authors":"David
         Heinemeier Hansson","built_at":"2017-02-10T00:00:00.000Z","created_at":"2017-02-10T02:46:51.222Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":8165,"metadata":{},"number":"4.2.8.rc1","summary":"Full-stack
+        over configuration.","downloads_count":8166,"metadata":{},"number":"4.2.8.rc1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"5405ee45ce29c39a4bde749ac32bb4940e88fea5da3cc1c88f3f5bd5accae76f"},{"authors":"David
         Heinemeier Hansson","built_at":"2016-08-10T00:00:00.000Z","created_at":"2016-08-11T17:35:16.160Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":6370069,"metadata":{},"number":"4.2.7.1","summary":"Full-stack
+        over configuration.","downloads_count":6370264,"metadata":{},"number":"4.2.7.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9414bef218365d548c5e42080e70364ad2809d6263856f591ba2e393a3096dab"},{"authors":"David
         Heinemeier Hansson","built_at":"2016-07-13T00:00:00.000Z","created_at":"2016-07-13T02:57:05.601Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":862695,"metadata":{},"number":"4.2.7","summary":"Full-stack
+        over configuration.","downloads_count":862703,"metadata":{},"number":"4.2.7","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"76dbbc22ac7fc20edb2fb653a9517590537073ef57669c2da8f3d32ff1767c0c"},{"authors":"David
         Heinemeier Hansson","built_at":"2016-07-01T00:00:00.000Z","created_at":"2016-07-01T00:33:36.424Z","description":"Ruby
@@ -1164,7 +1089,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2016-03-07T00:00:00.000Z","created_at":"2016-03-07T22:33:22.563Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":4544414,"metadata":{},"number":"4.2.6","summary":"Full-stack
+        over configuration.","downloads_count":4544516,"metadata":{},"number":"4.2.6","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a199258c0d2bae09993a6932c49df254fd66428899d1823b8c5285de02e5bc33"},{"authors":"David
         Heinemeier Hansson","built_at":"2016-03-01T00:00:00.000Z","created_at":"2016-03-01T18:37:54.172Z","description":"Ruby
@@ -1176,19 +1101,19 @@ http_interactions:
         Heinemeier Hansson","built_at":"2016-02-29T00:00:00.000Z","created_at":"2016-02-29T19:17:10.564Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":973148,"metadata":{},"number":"4.2.5.2","summary":"Full-stack
+        over configuration.","downloads_count":973157,"metadata":{},"number":"4.2.5.2","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"aa93c1b9eb8b535eee58280504e30237f88217699fe9bb016e458e5122eefa2e"},{"authors":"David
         Heinemeier Hansson","built_at":"2016-01-25T00:00:00.000Z","created_at":"2016-01-25T19:26:41.410Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1516387,"metadata":{},"number":"4.2.5.1","summary":"Full-stack
+        over configuration.","downloads_count":1516398,"metadata":{},"number":"4.2.5.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0bb3795fc6d971522f2681dea730b49be880809012939a8a570bd086b583460e"},{"authors":"David
         Heinemeier Hansson","built_at":"2015-11-12T00:00:00.000Z","created_at":"2015-11-12T17:06:55.226Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2253953,"metadata":{},"number":"4.2.5","summary":"Full-stack
+        over configuration.","downloads_count":2254047,"metadata":{},"number":"4.2.5","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"6248f75d4ecbcaa004166aa2b1484f87b7e956013853e905e49b68f29397b565"},{"authors":"David
         Heinemeier Hansson","built_at":"2015-11-05T00:00:00.000Z","created_at":"2015-11-05T03:02:33.340Z","description":"Ruby
@@ -1206,7 +1131,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2015-08-24T00:00:00.000Z","created_at":"2015-08-24T18:27:12.716Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2470918,"metadata":{},"number":"4.2.4","summary":"Full-stack
+        over configuration.","downloads_count":2470995,"metadata":{},"number":"4.2.4","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"1c33dd7c280d1c5dc4235509f774d673bac1d3f2e8c53b1353f677e7578ffc5a"},{"authors":"David
         Heinemeier Hansson","built_at":"2015-08-14T00:00:00.000Z","created_at":"2015-08-14T15:21:15.566Z","description":"Ruby
@@ -1218,7 +1143,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2015-06-25T00:00:00.000Z","created_at":"2015-06-25T21:30:57.890Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1951117,"metadata":{},"number":"4.2.3","summary":"Full-stack
+        over configuration.","downloads_count":1951136,"metadata":{},"number":"4.2.3","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"6a19b32cf92ac3585c2effbf5356642e84349abf55ee82827313ec3c7ce34870"},{"authors":"David
         Heinemeier Hansson","built_at":"2015-06-22T00:00:00.000Z","created_at":"2015-06-22T14:23:17.788Z","description":"Ruby
@@ -1230,13 +1155,13 @@ http_interactions:
         Heinemeier Hansson","built_at":"2015-06-16T00:00:00.000Z","created_at":"2015-06-16T18:03:17.061Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":926254,"metadata":{},"number":"4.2.2","summary":"Full-stack
+        over configuration.","downloads_count":926261,"metadata":{},"number":"4.2.2","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"60826c698420631bd4b623c8eb305510a428e507c202885b4cc52551293901c1"},{"authors":"David
         Heinemeier Hansson","built_at":"2015-03-19T00:00:00.000Z","created_at":"2015-03-19T16:42:01.191Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2621786,"metadata":{},"number":"4.2.1","summary":"Full-stack
+        over configuration.","downloads_count":2621813,"metadata":{},"number":"4.2.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"6b5f7d3a4a9eb2f181bab4a657315dbe08d0be218eae6017bef8a45dede211cb"},{"authors":"David
         Heinemeier Hansson","built_at":"2015-03-12T00:00:00.000Z","created_at":"2015-03-12T21:25:52.551Z","description":"Ruby
@@ -1266,7 +1191,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2014-12-20T00:00:00.000Z","created_at":"2014-12-20T00:15:37.476Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":33746310,"metadata":{},"number":"4.2.0","summary":"Full-stack
+        over configuration.","downloads_count":33761206,"metadata":{},"number":"4.2.0","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d394a78b2237145fffff3b7556ae64006139a7d1c04bc66b0bd39bbd5e4d3088"},{"authors":"David
         Heinemeier Hansson","built_at":"2014-12-13T00:00:00.000Z","created_at":"2014-12-13T02:58:44.762Z","description":"Ruby
@@ -1278,7 +1203,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2014-12-05T00:00:00.000Z","created_at":"2014-12-05T23:20:12.824Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":19328,"metadata":{},"number":"4.2.0.rc2","summary":"Full-stack
+        over configuration.","downloads_count":19329,"metadata":{},"number":"4.2.0.rc2","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"466ee46b83645d96721cd0ce8f04a7523ebdbea9d662236f5d65628c05765750"},{"authors":"David
         Heinemeier Hansson","built_at":"2014-11-28T00:00:00.000Z","created_at":"2014-11-28T17:53:27.822Z","description":"Ruby
@@ -1314,7 +1239,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2016-07-12T00:00:00.000Z","created_at":"2016-07-12T22:20:56.527Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1337721,"metadata":{},"number":"4.1.16","summary":"Full-stack
+        over configuration.","downloads_count":1337852,"metadata":{},"number":"4.1.16","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a19899f82c0a03a08cd2629636b75b582e0a64d908bda84c57e9cb70ac7adbd3"},{"authors":"David
         Heinemeier Hansson","built_at":"2016-07-02T00:00:00.000Z","created_at":"2016-07-02T02:15:20.923Z","description":"Ruby
@@ -1326,7 +1251,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2016-03-07T00:00:00.000Z","created_at":"2016-03-07T22:37:14.594Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":437073,"metadata":{},"number":"4.1.15","summary":"Full-stack
+        over configuration.","downloads_count":437090,"metadata":{},"number":"4.1.15","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9c94775ade272961c3bfae2a5a4ff2cddc319e48fd269d8e779240e2c94677d1"},{"authors":"David
         Heinemeier Hansson","built_at":"2016-03-01T00:00:00.000Z","created_at":"2016-03-01T18:43:40.764Z","description":"Ruby
@@ -1344,7 +1269,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2016-01-25T00:00:00.000Z","created_at":"2016-01-25T19:26:27.339Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":275661,"metadata":{},"number":"4.1.14.1","summary":"Full-stack
+        over configuration.","downloads_count":275686,"metadata":{},"number":"4.1.14.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"bde7704f906e5cf7dd4b098231a6e6471ac1b13ce1ac4940a320144be37f778d"},{"authors":"David
         Heinemeier Hansson","built_at":"2015-11-12T00:00:00.000Z","created_at":"2015-11-12T18:20:40.613Z","description":"Ruby
@@ -1386,19 +1311,19 @@ http_interactions:
         Heinemeier Hansson","built_at":"2015-06-22T00:00:00.000Z","created_at":"2015-06-22T14:05:08.486Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":6476,"metadata":{},"number":"4.1.12.rc1","summary":"Full-stack
+        over configuration.","downloads_count":6477,"metadata":{},"number":"4.1.12.rc1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":true,"licenses":["MIT"],"requirements":[],"sha":"84332f3ea6d94852fdd77fb1e0da3e6fb103c769436298fa2d2811e790c72404"},{"authors":"David
         Heinemeier Hansson","built_at":"2015-06-16T00:00:00.000Z","created_at":"2015-06-16T18:00:13.043Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":311659,"metadata":{},"number":"4.1.11","summary":"Full-stack
+        over configuration.","downloads_count":311661,"metadata":{},"number":"4.1.11","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"eb7a9f8c5cb838e16f934e53f71f14e14ac2ef646939134a59eb65b3e209102b"},{"authors":"David
         Heinemeier Hansson","built_at":"2015-03-19T00:00:00.000Z","created_at":"2015-03-19T16:50:27.388Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":384473,"metadata":{},"number":"4.1.10","summary":"Full-stack
+        over configuration.","downloads_count":384487,"metadata":{},"number":"4.1.10","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9f81f8b716ba76ea768b1c0ed4a185a3f7647b384fc297c26c2b51be82856fd3"},{"authors":"David
         Heinemeier Hansson","built_at":"2015-03-12T00:00:00.000Z","created_at":"2015-03-12T21:32:52.724Z","description":"Ruby
@@ -1428,7 +1353,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2015-01-06T00:00:00.000Z","created_at":"2015-01-06T20:04:31.185Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":540634,"metadata":{},"number":"4.1.9","summary":"Full-stack
+        over configuration.","downloads_count":540637,"metadata":{},"number":"4.1.9","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"19df2af2a3c6cd142714aca26a54e433bf39c20f82ac7b0fc7e1bcd38eed96d3"},{"authors":"David
         Heinemeier Hansson","built_at":"2015-01-02T00:00:00.000Z","created_at":"2015-01-02T01:11:10.973Z","description":"Ruby
@@ -1440,7 +1365,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2014-11-16T00:00:00.000Z","created_at":"2014-11-17T16:01:13.385Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1022842,"metadata":{},"number":"4.1.8","summary":"Full-stack
+        over configuration.","downloads_count":1022856,"metadata":{},"number":"4.1.8","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"20f4a46c30dac40585721caf3b4b1c961a3cf425fd1ccbc6109ccd6df723599d"},{"authors":"David
         Heinemeier Hansson","built_at":"2014-11-19T00:00:00.000Z","created_at":"2014-11-19T19:12:12.692Z","description":"Ruby
@@ -1452,7 +1377,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2014-10-29T00:00:00.000Z","created_at":"2014-10-30T18:37:49.213Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":518331,"metadata":{},"number":"4.1.7","summary":"Full-stack
+        over configuration.","downloads_count":518334,"metadata":{},"number":"4.1.7","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"20972f5ce418d5b938afa42680bcbe8c52770c0664429233fa0e567a25bd3515"},{"authors":"David
         Heinemeier Hansson","built_at":"2014-09-11T00:00:00.000Z","created_at":"2014-09-11T17:26:04.576Z","description":"Ruby
@@ -1476,25 +1401,25 @@ http_interactions:
         Heinemeier Hansson","built_at":"2014-08-18T00:00:00.000Z","created_at":"2014-08-18T17:01:03.727Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1161659,"metadata":{},"number":"4.1.5","summary":"Full-stack
+        over configuration.","downloads_count":1161661,"metadata":{},"number":"4.1.5","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"47e2d4a43e1b9c238d8b7c51a6ccf0461ffd3e1b270dd6af02c42ed3f694438b"},{"authors":"David
         Heinemeier Hansson","built_at":"2014-07-02T00:00:00.000Z","created_at":"2014-07-02T19:53:35.556Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1059223,"metadata":{},"number":"4.1.4","summary":"Full-stack
+        over configuration.","downloads_count":1059233,"metadata":{},"number":"4.1.4","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"54272fde189892c5e55e53646b871236d8c513a438d38ad91b9d54d64453cf31"},{"authors":"David
         Heinemeier Hansson","built_at":"2014-07-02T00:00:00.000Z","created_at":"2014-07-02T17:06:42.181Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":21409,"metadata":{},"number":"4.1.3","summary":"Full-stack
+        over configuration.","downloads_count":21411,"metadata":{},"number":"4.1.3","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"028ed6d06d8b8c0c32fc19aaa0cd1c73fe662e505180f26542fccda38ba84236"},{"authors":"David
         Heinemeier Hansson","built_at":"2014-06-26T00:00:00.000Z","created_at":"2014-06-26T14:50:09.079Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":252210,"metadata":{},"number":"4.1.2","summary":"Full-stack
+        over configuration.","downloads_count":252268,"metadata":{},"number":"4.1.2","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"7797e5e3f1f917339ecaf2d85cb71e95fea40cd3f7e8f3c9c19c884d425b34fa"},{"authors":"David
         Heinemeier Hansson","built_at":"2014-06-23T00:00:00.000Z","created_at":"2014-06-23T17:28:46.002Z","description":"Ruby
@@ -1518,13 +1443,13 @@ http_interactions:
         Heinemeier Hansson","built_at":"2014-05-06T00:00:00.000Z","created_at":"2014-05-06T16:11:31.458Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1083341,"metadata":{},"number":"4.1.1","summary":"Full-stack
+        over configuration.","downloads_count":1083343,"metadata":{},"number":"4.1.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"602275642419e731637c91421cf498f2994c2d9f1b94f6c713f3b7b8757b2aa5"},{"authors":"David
         Heinemeier Hansson","built_at":"2014-04-08T00:00:00.000Z","created_at":"2014-04-08T19:21:51.275Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":593148,"metadata":{},"number":"4.1.0","summary":"Full-stack
+        over configuration.","downloads_count":593168,"metadata":{},"number":"4.1.0","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d2ce7d3965f8c5d4b9076012d52512022dc0b0a0e4a427d801e84db449e140bf"},{"authors":"David
         Heinemeier Hansson","built_at":"2014-03-25T00:00:00.000Z","created_at":"2014-03-25T20:12:47.195Z","description":"Ruby
@@ -1554,7 +1479,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2015-01-06T00:00:00.000Z","created_at":"2015-01-06T20:08:59.935Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1698430,"metadata":{},"number":"4.0.13","summary":"Full-stack
+        over configuration.","downloads_count":1698758,"metadata":{},"number":"4.0.13","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d4b3ca8517b394459fd31773c5c6877b4aded8f2c84e6f5422061d231b2af9f6"},{"authors":"David
         Heinemeier Hansson","built_at":"2015-01-02T00:00:00.000Z","created_at":"2015-01-02T00:54:54.587Z","description":"Ruby
@@ -1584,7 +1509,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2014-09-11T00:00:00.000Z","created_at":"2014-09-11T17:33:15.455Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":98604,"metadata":{},"number":"4.0.10","summary":"Full-stack
+        over configuration.","downloads_count":98607,"metadata":{},"number":"4.0.10","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"0c9d3fc3fb0eaccd480e1fd3786ee0714923478ade4ed4c746eaca98786e018e"},{"authors":"David
         Heinemeier Hansson","built_at":"2014-09-08T00:00:00.000Z","created_at":"2014-09-08T17:55:45.314Z","description":"Ruby
@@ -1608,7 +1533,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2014-07-02T00:00:00.000Z","created_at":"2014-07-02T19:42:37.603Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":195364,"metadata":{},"number":"4.0.8","summary":"Full-stack
+        over configuration.","downloads_count":195366,"metadata":{},"number":"4.0.8","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"34a589d9718b8fbbb2fa557acda14e1639d796018d29873c7912f52e67056f15"},{"authors":"David
         Heinemeier Hansson","built_at":"2014-07-02T00:00:00.000Z","created_at":"2014-07-02T17:04:32.418Z","description":"Ruby
@@ -1620,7 +1545,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2014-06-26T00:00:00.000Z","created_at":"2014-06-26T16:30:13.579Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":72307,"metadata":{},"number":"4.0.6","summary":"Full-stack
+        over configuration.","downloads_count":72308,"metadata":{},"number":"4.0.6","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"a1631de04f0ce6634b56801a2046af5d42f8dde474fb82ba46194e2a6de5fdce"},{"authors":"David
         Heinemeier Hansson","built_at":"2014-06-23T00:00:00.000Z","created_at":"2014-06-23T17:24:41.466Z","description":"Ruby
@@ -1644,13 +1569,13 @@ http_interactions:
         Heinemeier Hansson","built_at":"2014-05-06T00:00:00.000Z","created_at":"2014-05-06T16:13:27.132Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":411843,"metadata":{},"number":"4.0.5","summary":"Full-stack
+        over configuration.","downloads_count":411844,"metadata":{},"number":"4.0.5","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"22cc7501b6d4b0e7b6b215777b0faf7f8181a1d5058ef7c88c3c328227485253"},{"authors":"David
         Heinemeier Hansson","built_at":"2014-03-14T00:00:00.000Z","created_at":"2014-03-14T17:37:07.331Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":499618,"metadata":{},"number":"4.0.4","summary":"Full-stack
+        over configuration.","downloads_count":499619,"metadata":{},"number":"4.0.4","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"ead3f37942b32496cd07837a01c40acc4f8c8df72e839f3d087a2c3543d760bc"},{"authors":"David
         Heinemeier Hansson","built_at":"2014-03-11T00:00:00.000Z","created_at":"2014-03-11T17:31:18.568Z","description":"Ruby
@@ -1662,19 +1587,19 @@ http_interactions:
         Heinemeier Hansson","built_at":"2014-02-18T00:00:00.000Z","created_at":"2014-02-18T18:49:43.150Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":641931,"metadata":{},"number":"4.0.3","summary":"Full-stack
+        over configuration.","downloads_count":641932,"metadata":{},"number":"4.0.3","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"649f8ca0cdc10d47e6bef73e098937a2a61f5aabbcf2fde930d28675021e81be"},{"authors":"David
         Heinemeier Hansson","built_at":"2013-12-03T00:00:00.000Z","created_at":"2013-12-03T19:01:29.867Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1171137,"metadata":{},"number":"4.0.2","summary":"Full-stack
+        over configuration.","downloads_count":1171157,"metadata":{},"number":"4.0.2","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b7485afabce7c526eee714f7daf020cc7f18be66567a55ad806b81294cc19ffa"},{"authors":"David
         Heinemeier Hansson","built_at":"2013-11-01T00:00:00.000Z","created_at":"2013-11-01T19:08:16.307Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":512193,"metadata":{},"number":"4.0.1","summary":"Full-stack
+        over configuration.","downloads_count":512221,"metadata":{},"number":"4.0.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e3759fcd9fd550589404ba0975857142dbdcef2bbfdf71c43a7ee372196cc76e"},{"authors":"David
         Heinemeier Hansson","built_at":"2013-10-30T00:00:00.000Z","created_at":"2013-10-30T20:49:25.297Z","description":"Ruby
@@ -1704,7 +1629,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2013-06-25T00:00:00.000Z","created_at":"2013-06-25T14:32:58.526Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":2669182,"metadata":{},"number":"4.0.0","summary":"Full-stack
+        over configuration.","downloads_count":2669271,"metadata":{},"number":"4.0.0","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.8.11","ruby_version":"\u003e= 1.9.3","prerelease":false,"licenses":["MIT"],"requirements":null,"sha":"6eabebfbe7dcdabeddf69356f84cec3d78e395b08aa1de700e265f7cbff8028b"},{"authors":"David
         Heinemeier Hansson","built_at":"2013-06-11T00:00:00.000Z","created_at":"2013-06-11T20:26:00.144Z","description":"Ruby
@@ -1728,13 +1653,13 @@ http_interactions:
         Heinemeier Hansson","built_at":"2016-09-14T00:00:00.000Z","created_at":"2016-09-14T21:19:01.962Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":6697951,"metadata":{},"number":"3.2.22.5","summary":"Full-stack
+        over configuration.","downloads_count":6698530,"metadata":{},"number":"3.2.22.5","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"c7ba428e51536d961e2fba7bbc65527901ee015ea41696ac803a97716ad58d14"},{"authors":"David
         Heinemeier Hansson","built_at":"2016-08-11T00:00:00.000Z","created_at":"2016-08-11T19:20:46.883Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":679657,"metadata":{},"number":"3.2.22.4","summary":"Full-stack
+        over configuration.","downloads_count":679686,"metadata":{},"number":"3.2.22.4","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"cd62b28ac2f2e4e6eb41dd785c02eae4ea48fb198ce08d062170c86b9fefd8ad"},{"authors":"David
         Heinemeier Hansson","built_at":"2016-08-10T00:00:00.000Z","created_at":"2016-08-11T17:34:59.710Z","description":"Ruby
@@ -1746,25 +1671,25 @@ http_interactions:
         Heinemeier Hansson","built_at":"2016-02-29T00:00:00.000Z","created_at":"2016-02-29T19:24:19.757Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1092085,"metadata":{},"number":"3.2.22.2","summary":"Full-stack
+        over configuration.","downloads_count":1092113,"metadata":{},"number":"3.2.22.2","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"e40902aa453b1ce4e0048221d8d1d4e8dda1f3bd58c80c23f6c38c7bd3fae9cb"},{"authors":"David
         Heinemeier Hansson","built_at":"2016-01-25T00:00:00.000Z","created_at":"2016-01-25T19:26:12.364Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":441732,"metadata":{},"number":"3.2.22.1","summary":"Full-stack
+        over configuration.","downloads_count":441735,"metadata":{},"number":"3.2.22.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"55bc070a05d583ffc0028bfc6b1c5be60e9d5fc7655ebada06c5c83ae38249e9"},{"authors":"David
         Heinemeier Hansson","built_at":"2015-06-16T00:00:00.000Z","created_at":"2015-06-16T18:06:38.294Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1399976,"metadata":{},"number":"3.2.22","summary":"Full-stack
+        over configuration.","downloads_count":1400060,"metadata":{},"number":"3.2.22","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"4e6341bbab6d88aa0578034474699c3793448dfbaa09d89f708304591f3b8a21"},{"authors":"David
         Heinemeier Hansson","built_at":"2014-11-16T00:00:00.000Z","created_at":"2014-11-17T16:00:44.994Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1238717,"metadata":{},"number":"3.2.21","summary":"Full-stack
+        over configuration.","downloads_count":1238743,"metadata":{},"number":"3.2.21","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d0f6904bc864307cb0236a3cc8b252d355e4536223614aee33265f23ead3c55a"},{"authors":"David
         Heinemeier Hansson","built_at":"2014-10-29T00:00:00.000Z","created_at":"2014-10-30T18:37:26.434Z","description":"Ruby
@@ -1776,31 +1701,31 @@ http_interactions:
         Heinemeier Hansson","built_at":"2014-07-02T03:00:00.000Z","created_at":"2014-07-02T17:02:48.733Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":955786,"metadata":{},"number":"3.2.19","summary":"Full-stack
+        over configuration.","downloads_count":955792,"metadata":{},"number":"3.2.19","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"33b64cf78dfcf3206d961ce03e8fe6d260081da696e60da39d0b2a4a160fe22b"},{"authors":"David
         Heinemeier Hansson","built_at":"2014-05-06T00:00:00.000Z","created_at":"2014-05-06T16:17:02.829Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1136017,"metadata":{},"number":"3.2.18","summary":"Full-stack
+        over configuration.","downloads_count":1136034,"metadata":{},"number":"3.2.18","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"b087466024542c7abebc85cb5638ba8bed302616a914996cad454bf8d6e54198"},{"authors":"David
         Heinemeier Hansson","built_at":"2014-02-18T03:00:00.000Z","created_at":"2014-02-18T18:54:56.443Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1055101,"metadata":{},"number":"3.2.17","summary":"Full-stack
+        over configuration.","downloads_count":1055115,"metadata":{},"number":"3.2.17","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"8eff1bbf9f22fa943e58e9b71c6bdbe5d5d95caf022bec38ce083599961cb984"},{"authors":"David
         Heinemeier Hansson","built_at":"2013-12-03T00:00:00.000Z","created_at":"2013-12-03T19:01:19.549Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":820736,"metadata":{},"number":"3.2.16","summary":"Full-stack
+        over configuration.","downloads_count":820753,"metadata":{},"number":"3.2.16","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"fc470010d70c7628e9e6c4bd535f85571a24cdfadf9b58560e6b2d5f3d396ab0"},{"authors":"David
         Heinemeier Hansson","built_at":"2013-10-16T00:00:00.000Z","created_at":"2013-10-16T17:23:10.503Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":391543,"metadata":{},"number":"3.2.15","summary":"Full-stack
+        over configuration.","downloads_count":391556,"metadata":{},"number":"3.2.15","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"9ed01092cb939f8c9be82138a8ba83df45260d544f86a0465893491dbdc2794c"},{"authors":"David
         Heinemeier Hansson","built_at":"2013-10-11T00:00:00.000Z","created_at":"2013-10-11T21:17:17.374Z","description":"Ruby
@@ -1824,7 +1749,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2013-07-22T03:00:00.000Z","created_at":"2013-07-22T16:44:50.870Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":793536,"metadata":{},"number":"3.2.14","summary":"Full-stack
+        over configuration.","downloads_count":793537,"metadata":{},"number":"3.2.14","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":["MIT"],"requirements":[],"sha":"d63321eb0231dbf576ba19017cf87b3e2d8b863dd6402f26f198455fd1377963"},{"authors":"David
         Heinemeier Hansson","built_at":"2013-07-16T03:00:00.000Z","created_at":"2013-07-16T16:13:33.339Z","description":"Ruby
@@ -1842,7 +1767,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2013-03-18T00:00:00.000Z","created_at":"2013-03-18T17:13:33.058Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":4659431,"metadata":{},"number":"3.2.13","summary":"Full-stack
+        over configuration.","downloads_count":4659458,"metadata":{},"number":"3.2.13","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":[],"requirements":null,"sha":"dfc57cb7d289513dd89a99db6f714fbdb407223160abf98293b74be07724bcb8"},{"authors":"David
         Heinemeier Hansson","built_at":"2013-03-06T00:00:00.000Z","created_at":"2013-03-06T23:06:19.052Z","description":"Ruby
@@ -1860,13 +1785,13 @@ http_interactions:
         Heinemeier Hansson","built_at":"2013-02-11T00:00:00.000Z","created_at":"2013-02-11T18:17:41.481Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1639888,"metadata":{},"number":"3.2.12","summary":"Full-stack
+        over configuration.","downloads_count":1639896,"metadata":{},"number":"3.2.12","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":[],"requirements":null,"sha":"bff3605849350b46cceab64e0b9136cd8743d45db902160c19bbd06fc9a956ca"},{"authors":"David
         Heinemeier Hansson","built_at":"2013-01-08T00:00:00.000Z","created_at":"2013-01-08T20:08:45.798Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":1561959,"metadata":{},"number":"3.2.11","summary":"Full-stack
+        over configuration.","downloads_count":1561962,"metadata":{},"number":"3.2.11","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":[],"requirements":null,"sha":"f5e02999889aa39af2c7d2c882d9e3b5c71e8adfc98236a69dadacdfbce5603e"},{"authors":"David
         Heinemeier Hansson","built_at":"2012-12-23T00:00:00.000Z","created_at":"2013-01-02T21:20:01.186Z","description":"Ruby
@@ -1920,7 +1845,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2012-07-26T00:00:00.000Z","created_at":"2012-07-26T22:09:06.275Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":223920,"metadata":{},"number":"3.2.7","summary":"Full-stack
+        over configuration.","downloads_count":223921,"metadata":{},"number":"3.2.7","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"8aad4faaabd497b3c4f07a02b9720e3111c7fa0967cf7d4d7a9c18b88d13997f"},{"authors":"David
         Heinemeier Hansson","built_at":"2012-07-23T00:00:00.000Z","created_at":"2012-07-23T21:45:55.204Z","description":"Ruby
@@ -1932,13 +1857,13 @@ http_interactions:
         Heinemeier Hansson","built_at":"2012-06-12T00:00:00.000Z","created_at":"2012-06-12T21:26:21.434Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":778318,"metadata":{},"number":"3.2.6","summary":"Full-stack
+        over configuration.","downloads_count":778322,"metadata":{},"number":"3.2.6","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"55389d82ad04ea822c7236a1a877d90b18ad4defed4c0e7a2a9bb2e6bcd19ea0"},{"authors":"David
         Heinemeier Hansson","built_at":"2012-06-01T00:00:00.000Z","created_at":"2012-06-01T03:39:04.678Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":202556,"metadata":{},"number":"3.2.5","summary":"Full-stack
+        over configuration.","downloads_count":202561,"metadata":{},"number":"3.2.5","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"d8888a6e10a1d680b9c8ba02047d2627cb23c6aefe30c058d454d07404dde73c"},{"authors":"David
         Heinemeier Hansson","built_at":"2012-05-31T00:00:00.000Z","created_at":"2012-05-31T18:25:13.532Z","description":"Ruby
@@ -1956,7 +1881,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2012-03-30T03:00:00.000Z","created_at":"2012-03-30T22:26:20.685Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":830486,"metadata":{},"number":"3.2.3","summary":"Full-stack
+        over configuration.","downloads_count":830493,"metadata":{},"number":"3.2.3","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"b8d6e5332d0473ffda078440a1692b97ad0053320fc1d041f00e133f78ff7c22"},{"authors":"David
         Heinemeier Hansson","built_at":"2012-03-29T03:00:00.000Z","created_at":"2012-03-29T16:14:14.715Z","description":"Ruby
@@ -1974,7 +1899,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2012-03-01T00:00:00.000Z","created_at":"2012-03-01T17:52:33.094Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":440535,"metadata":{},"number":"3.2.2","summary":"Full-stack
+        over configuration.","downloads_count":440537,"metadata":{},"number":"3.2.2","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"c957b71fd93372a3d1aa411e8449387e415e5941afd404d4cedbf72f4840904f"},{"authors":"David
         Heinemeier Hansson","built_at":"2012-02-22T00:00:00.000Z","created_at":"2012-02-22T21:39:35.308Z","description":"Ruby
@@ -1986,13 +1911,13 @@ http_interactions:
         Heinemeier Hansson","built_at":"2012-01-26T08:00:00.000Z","created_at":"2012-01-26T23:09:41.494Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":504327,"metadata":{},"number":"3.2.1","summary":"Full-stack
+        over configuration.","downloads_count":504328,"metadata":{},"number":"3.2.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"255bc08d24e2c6fcc1c8087e5c14b51d13b632191b9bd686111ac0cd7dbda53b"},{"authors":"David
         Heinemeier Hansson","built_at":"2012-01-20T00:00:00.000Z","created_at":"2012-01-20T16:47:48.848Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":205016,"metadata":{},"number":"3.2.0","summary":"Full-stack
+        over configuration.","downloads_count":205017,"metadata":{},"number":"3.2.0","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"f0cba07568a9ddae8e62cd170021e7ba2edc6ea0248249ca2f6d476062264c82"},{"authors":"David
         Heinemeier Hansson","built_at":"2012-01-04T02:00:00.000Z","created_at":"2012-01-04T21:05:27.454Z","description":"Ruby
@@ -2010,13 +1935,13 @@ http_interactions:
         Heinemeier Hansson","built_at":"2013-03-18T00:00:00.000Z","created_at":"2013-03-18T17:13:29.344Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":547119,"metadata":{},"number":"3.1.12","summary":"Full-stack
+        over configuration.","downloads_count":547123,"metadata":{},"number":"3.1.12","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":[],"requirements":null,"sha":"8e6ce8ddb8b69051ec8109d0439c622a986aa4da47f5156141e7a936656f958c"},{"authors":"David
         Heinemeier Hansson","built_at":"2013-02-11T00:00:00.000Z","created_at":"2013-02-11T18:17:37.200Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":64380,"metadata":{},"number":"3.1.11","summary":"Full-stack
+        over configuration.","downloads_count":64381,"metadata":{},"number":"3.1.11","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":[],"requirements":null,"sha":"45f4a20aaff2ca71b6096e3a0ab6c770ccabae17203510b43bb26f862d9a35fa"},{"authors":"David
         Heinemeier Hansson","built_at":"2013-01-08T00:00:00.000Z","created_at":"2013-01-08T20:08:37.727Z","description":"Ruby
@@ -2076,7 +2001,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2011-11-20T00:00:00.000Z","created_at":"2011-11-20T22:52:57.492Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":681906,"metadata":{},"number":"3.1.3","summary":"Full-stack
+        over configuration.","downloads_count":681907,"metadata":{},"number":"3.1.3","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"e817252efd196b32a16b0af6a92eecd8b2e0b1cbe1511b36fab6c8acdc53e81e"},{"authors":"David
         Heinemeier Hansson","built_at":"2011-11-18T00:00:00.000Z","created_at":"2011-11-18T01:33:32.509Z","description":"Ruby
@@ -2100,13 +2025,13 @@ http_interactions:
         Heinemeier Hansson","built_at":"2011-10-07T02:00:00.000Z","created_at":"2011-10-07T15:30:09.628Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":600654,"metadata":{},"number":"3.1.1","summary":"Full-stack
+        over configuration.","downloads_count":600661,"metadata":{},"number":"3.1.1","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"42cb4042721dce66f99f4c0a746d25fe2fcddd2a6bcd8311aee82ce2c2590a71"},{"authors":"David
         Heinemeier Hansson","built_at":"2011-10-05T02:00:00.000Z","created_at":"2011-10-06T02:31:00.452Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":6409,"metadata":{},"number":"3.1.1.rc3","summary":"Full-stack
+        over configuration.","downloads_count":6410,"metadata":{},"number":"3.1.1.rc3","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"c0da874562db60d275214b5a648a3d6e217bda850390618cfd3e253fc87b75c7"},{"authors":"David
         Heinemeier Hansson","built_at":"2011-09-29T03:00:00.000Z","created_at":"2011-09-29T22:17:03.417Z","description":"Ruby
@@ -2124,7 +2049,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2011-08-31T00:00:00.000Z","created_at":"2011-08-31T02:18:30.035Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":648933,"metadata":{},"number":"3.1.0","summary":"Full-stack
+        over configuration.","downloads_count":648935,"metadata":{},"number":"3.1.0","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"baceb82d8eba98f2a5a1eb9e43f14b36019968b6fbdb3dc76d6e4f40b09520ce"},{"authors":"David
         Heinemeier Hansson","built_at":"2011-08-29T03:00:00.000Z","created_at":"2011-08-29T03:27:19.194Z","description":"Ruby
@@ -2178,7 +2103,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2013-01-28T00:00:00.000Z","created_at":"2013-01-28T21:01:34.374Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":491683,"metadata":{},"number":"3.0.20","summary":"Full-stack
+        over configuration.","downloads_count":491732,"metadata":{},"number":"3.0.20","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":[],"requirements":null,"sha":"e22944d88c22d206e719bee3757fbbc0d025d00419421e5609a9a52136be3190"},{"authors":"David
         Heinemeier Hansson","built_at":"2013-01-08T00:00:00.000Z","created_at":"2013-01-08T20:08:33.922Z","description":"Ruby
@@ -2262,13 +2187,13 @@ http_interactions:
         Heinemeier Hansson","built_at":"2011-06-16T00:00:00.000Z","created_at":"2011-06-16T10:05:11.080Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":693965,"metadata":{},"number":"3.0.9","summary":"Full-stack
+        over configuration.","downloads_count":693966,"metadata":{},"number":"3.0.9","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"91f10c3d1e0eb0f8689eaf6faa5bd8b3ab0fab43841795858d3ef04e8f4c54e6"},{"authors":"David
         Heinemeier Hansson","built_at":"2011-06-12T00:00:00.000Z","created_at":"2011-06-12T21:30:07.555Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":4122,"metadata":{},"number":"3.0.9.rc5","summary":"Full-stack
+        over configuration.","downloads_count":4123,"metadata":{},"number":"3.0.9.rc5","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"b38a829c67b550aead716f941dce7400dc7017b034f4f7e726a2c707fcc08ebc"},{"authors":"David
         Heinemeier Hansson","built_at":"2011-06-12T00:00:00.000Z","created_at":"2011-06-12T21:24:34.980Z","description":"Ruby
@@ -2292,7 +2217,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2011-06-07T00:00:00.000Z","created_at":"2011-06-08T00:16:45.270Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":83552,"metadata":{},"number":"3.0.8","summary":"Full-stack
+        over configuration.","downloads_count":83553,"metadata":{},"number":"3.0.8","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"a3825a0604bd76e3a08d1f0b36066a90e2f61081a49ae0de201cebb3b017c07f"},{"authors":"David
         Heinemeier Hansson","built_at":"2011-05-31T00:00:00.000Z","created_at":"2011-05-31T00:08:18.745Z","description":"Ruby
@@ -2316,7 +2241,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2011-04-18T00:00:00.000Z","created_at":"2011-04-18T21:05:54.308Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":567371,"metadata":{},"number":"3.0.7","summary":"Full-stack
+        over configuration.","downloads_count":567372,"metadata":{},"number":"3.0.7","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"e4ea21b341e13eea253f5731d08e84df39b0cdf0073d2f3964dc8852fc08d677"},{"authors":"David
         Heinemeier Hansson","built_at":"2011-04-15T03:00:00.000Z","created_at":"2011-04-15T17:33:53.132Z","description":"Ruby
@@ -2394,7 +2319,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2010-08-29T05:00:00.000Z","created_at":"2010-08-29T23:11:11.490Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":475649,"metadata":{},"number":"3.0.0","summary":"Full-stack
+        over configuration.","downloads_count":475651,"metadata":{},"number":"3.0.0","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":false,"licenses":null,"requirements":null,"sha":"5a9a2c14077d27d849ae660c03dd9427b8cd9c3151135968d89b0454be8c5efe"},{"authors":"David
         Heinemeier Hansson","built_at":"2010-08-23T05:00:00.000Z","created_at":"2010-08-24T03:04:45.033Z","description":"Ruby
@@ -2406,13 +2331,13 @@ http_interactions:
         Heinemeier Hansson","built_at":"2010-07-26T05:00:00.000Z","created_at":"2010-07-26T21:43:12.765Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":62313,"metadata":{},"number":"3.0.0.rc","summary":"Full-stack
+        over configuration.","downloads_count":62314,"metadata":{},"number":"3.0.0.rc","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"f9d71d36335c8f1977297d798219d156925b5ff88016e31e461da7d861b7640c"},{"authors":"David
         Heinemeier Hansson","built_at":"2010-06-08T04:00:00.000Z","created_at":"2010-06-08T22:33:16.046Z","description":"Ruby
         on Rails is a full-stack web framework optimized for programmer happiness
         and sustainable productivity. It encourages beautiful code by favoring convention
-        over configuration.","downloads_count":56943,"metadata":{},"number":"3.0.0.beta4","summary":"Full-stack
+        over configuration.","downloads_count":56944,"metadata":{},"number":"3.0.0.beta4","summary":"Full-stack
         web application framework.","platform":"ruby","rubygems_version":"\u003e=
         1.3.6","ruby_version":"\u003e= 1.8.7","prerelease":true,"licenses":null,"requirements":null,"sha":"7bc33c1d4d19adc966623b63145850d27acb3909a3f3f1261edaa7cb5909684c"},{"authors":"David
         Heinemeier Hansson","built_at":"2010-04-13T07:00:00.000Z","created_at":"2010-04-13T19:23:14.932Z","description":"Ruby
@@ -2433,7 +2358,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2013-03-18T07:00:00.000Z","created_at":"2013-03-18T17:13:25.422Z","description":"    Rails
         is a framework for building web-application using CGI, FCGI, mod_ruby, or
         WEBrick\n    on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server,
-        or Oracle with eRuby- or Builder-based templates.\n","downloads_count":1100939,"metadata":{},"number":"2.3.18","summary":"Web-application
+        or Oracle with eRuby- or Builder-based templates.\n","downloads_count":1100946,"metadata":{},"number":"2.3.18","summary":"Web-application
         framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
         0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"f92ee63fdb481d5d0758db6a955f850d44f525558ccc5ad7ce4367220a72314d"},{"authors":"David
         Heinemeier Hansson","built_at":"2013-02-11T00:00:00.000Z","created_at":"2013-02-11T18:17:30.726Z","description":"    Rails
@@ -2451,13 +2376,13 @@ http_interactions:
         Heinemeier Hansson","built_at":"2013-01-08T08:00:00.000Z","created_at":"2013-01-08T20:08:28.812Z","description":"    Rails
         is a framework for building web-application using CGI, FCGI, mod_ruby, or
         WEBrick\n    on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server,
-        or Oracle with eRuby- or Builder-based templates.\n","downloads_count":99703,"metadata":{},"number":"2.3.15","summary":"Web-application
+        or Oracle with eRuby- or Builder-based templates.\n","downloads_count":99704,"metadata":{},"number":"2.3.15","summary":"Web-application
         framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
         0","ruby_version":null,"prerelease":false,"licenses":[],"requirements":null,"sha":"21c177e2577faa9d09319a965870ee5f03d944d2e558573df852659cd729a79e"},{"authors":"David
         Heinemeier Hansson","built_at":"2011-08-16T00:00:00.000Z","created_at":"2011-08-16T22:01:21.962Z","description":"    Rails
         is a framework for building web-application using CGI, FCGI, mod_ruby, or
         WEBrick\n    on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server,
-        or Oracle with eRuby- or Builder-based templates.\n","downloads_count":426527,"metadata":{},"number":"2.3.14","summary":"Web-application
+        or Oracle with eRuby- or Builder-based templates.\n","downloads_count":426532,"metadata":{},"number":"2.3.14","summary":"Web-application
         framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
         0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"d73302e2ba500ac8efef9d0397c341c0c40b055a67a5fc43503df67d1df29852"},{"authors":"David
         Heinemeier Hansson","built_at":"2011-06-08T00:00:00.000Z","created_at":"2011-06-08T00:22:06.357Z","description":"    Rails
@@ -2493,7 +2418,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2010-05-24T07:00:00.000Z","created_at":"2010-05-25T04:53:06.895Z","description":"    Rails
         is a framework for building web-application using CGI, FCGI, mod_ruby, or
         WEBrick\n    on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server,
-        or Oracle with eRuby- or Builder-based templates.\n","downloads_count":1077377,"metadata":{},"number":"2.3.8","summary":"Web-application
+        or Oracle with eRuby- or Builder-based templates.\n","downloads_count":1077380,"metadata":{},"number":"2.3.8","summary":"Web-application
         framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
         0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"59efc4532e0886ad4912dc06a113ba2d455f7a380f972b24da8414df1dfb377d"},{"authors":"David
         Heinemeier Hansson","built_at":"2010-05-24T07:00:00.000Z","created_at":"2010-05-24T21:17:25.987Z","description":"    Rails
@@ -2517,7 +2442,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2009-11-26T11:00:00.000Z","created_at":"2009-11-27T00:12:56.921Z","description":"    Rails
         is a framework for building web-application using CGI, FCGI, mod_ruby, or
         WEBrick\n    on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server,
-        or Oracle with eRuby- or Builder-based templates.\n","downloads_count":1178509,"metadata":{},"number":"2.3.5","summary":"Web-application
+        or Oracle with eRuby- or Builder-based templates.\n","downloads_count":1178513,"metadata":{},"number":"2.3.5","summary":"Web-application
         framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
         0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"adb5bea1831c536a64fcd420da01d5a3b3fbe21807c9dce1c458fd62bc2afa7f"},{"authors":"David
         Heinemeier Hansson","built_at":"2009-09-03T15:00:00.000Z","created_at":"2009-09-04T17:33:48.000Z","description":"    Rails
@@ -2535,7 +2460,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2009-03-15T05:00:00.000Z","created_at":"2009-07-25T18:01:49.000Z","description":"Rails
         is a framework for building web-application using CGI, FCGI, mod_ruby, or
         WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
-        with eRuby- or Builder-based templates.","downloads_count":132813,"metadata":{},"number":"2.3.2","summary":"Web-application
+        with eRuby- or Builder-based templates.","downloads_count":132818,"metadata":{},"number":"2.3.2","summary":"Web-application
         framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
         0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"ac61e0356987df34dbbafb803b98f153a663d3878a31f1db7333b7cd987fd044"},{"authors":"David
         Heinemeier Hansson","built_at":"2009-09-27T14:00:00.000Z","created_at":"2009-09-28T09:25:13.132Z","description":"    Rails
@@ -2547,13 +2472,13 @@ http_interactions:
         Heinemeier Hansson","built_at":"2008-11-20T23:00:00.000Z","created_at":"2009-07-25T18:01:49.000Z","description":"Rails
         is a framework for building web-application using CGI, FCGI, mod_ruby, or
         WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
-        with eRuby- or Builder-based templates.","downloads_count":152253,"metadata":{},"number":"2.2.2","summary":"Web-application
+        with eRuby- or Builder-based templates.","downloads_count":152254,"metadata":{},"number":"2.2.2","summary":"Web-application
         framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
         0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"84fd0ee92f92088cff81d1a4bcb61306bd4b7440b8634d7ac3d1396571a2133f"},{"authors":"David
         Heinemeier Hansson","built_at":"2008-10-22T22:00:00.000Z","created_at":"2009-07-25T18:01:50.000Z","description":"Rails
         is a framework for building web-application using CGI, FCGI, mod_ruby, or
         WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
-        with eRuby- or Builder-based templates.","downloads_count":72577,"metadata":{},"number":"2.1.2","summary":"Web-application
+        with eRuby- or Builder-based templates.","downloads_count":72578,"metadata":{},"number":"2.1.2","summary":"Web-application
         framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
         0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"4a55304ae08e3fcd2a2e2bb627d442e5aa9f1b1d6a542587b97ed0cee6079276"},{"authors":"David
         Heinemeier Hansson","built_at":"2008-09-03T22:00:00.000Z","created_at":"2009-07-25T18:01:50.000Z","description":"Rails
@@ -2583,7 +2508,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2007-12-20T06:00:00.000Z","created_at":"2009-07-25T18:01:51.000Z","description":"Rails
         is a framework for building web-application using CGI, FCGI, mod_ruby, or
         WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
-        with eRuby- or Builder-based templates.","downloads_count":49481,"metadata":{},"number":"2.0.2","summary":"Web-application
+        with eRuby- or Builder-based templates.","downloads_count":49482,"metadata":{},"number":"2.0.2","summary":"Web-application
         framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
         0","ruby_version":null,"prerelease":false,"licenses":null,"requirements":null,"sha":"ae11c0c3e237c9e46feab39277cd8190f1ee36a5fced6215ed7c9327b19bddf6"},{"authors":"David
         Heinemeier Hansson","built_at":"2007-12-07T06:00:00.000Z","created_at":"2009-07-25T18:01:51.000Z","description":"Rails
@@ -2643,7 +2568,7 @@ http_interactions:
         Heinemeier Hansson","built_at":"2006-08-10T05:00:00.000Z","created_at":"2009-07-25T18:01:54.000Z","description":"Rails
         is a framework for building web-application using CGI, FCGI, mod_ruby, or
         WEBrick on top of either MySQL, PostgreSQL, SQLite, DB2, SQL Server, or Oracle
-        with eRuby- or Builder-based templates.","downloads_count":12074,"metadata":{},"number":"1.1.6","summary":"Web-application
+        with eRuby- or Builder-based templates.","downloads_count":12075,"metadata":{},"number":"1.1.6","summary":"Web-application
         framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
         0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"f78cc3dfe77ceaa3cdd808735dcb81c8d3bdbd8e4d6b72ecc3a1b7fc19f1bd49"},{"authors":"David
         Heinemeier Hansson","built_at":"2006-08-09T05:00:00.000Z","created_at":"2009-07-25T18:01:54.000Z","description":"Rails
@@ -2755,7 +2680,7 @@ http_interactions:
         0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"51fcc55a23e06245e97a8088d0122ac85b6ad16dcb2156d1f53499309a4c7141"},{"authors":"David
         Heinemeier Hansson","built_at":"2005-01-25T05:00:00.000Z","created_at":"2009-07-25T18:01:55.000Z","description":"Rails
         is a framework for building web-application using CGI, FCGI, mod_ruby, or
-        WEBrick on top of either MySQL, PostgreSQL, or SQLite with eRuby-based templates.","downloads_count":56719,"metadata":{},"number":"0.9.5","summary":"Web-application
+        WEBrick on top of either MySQL, PostgreSQL, or SQLite with eRuby-based templates.","downloads_count":56806,"metadata":{},"number":"0.9.5","summary":"Web-application
         framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
         0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"8a03d2c37e6efc2ed1084c2b5189caed0522fb6a09881c8c73e28f0ffca966f2"},{"authors":"David
         Heinemeier Hansson","built_at":"2005-01-18T05:00:00.000Z","created_at":"2009-07-25T18:01:55.000Z","description":"Rails
@@ -2794,5 +2719,5 @@ http_interactions:
         framework with template engine, control-flow layer, and ORM.","platform":"ruby","rubygems_version":"\u003e=
         0","ruby_version":"\u003e 0.0.0","prerelease":false,"licenses":null,"requirements":null,"sha":"182794b9b4af4eff6884c979f0ae6a632ea42bf4f309cf16553b02fc4be344d3"}]'
     http_version:
-  recorded_at: Mon, 15 May 2023 22:37:09 GMT
+  recorded_at: Tue, 16 May 2023 15:24:16 GMT
 recorded_with: VCR 4.0.0

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -304,6 +304,20 @@ describe Project, type: :model do
           end
         end
       end
+
+      context "when package manager cannot have entire package deprecated" do
+        let!(:project) { Project.create(platform: "Rubygems", name: "rails", status: "Removed") }
+
+        it "should mark the project no longer removed" do
+          VCR.use_cassette("project/check_status/rails") do
+            project.check_status
+
+            project.reload
+
+            expect(project.status).to eq(nil)
+          end
+        end
+      end
     end
   end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -289,6 +289,22 @@ describe Project, type: :model do
         end
       end
     end
+
+    context "removed project no longer removed" do
+      context "when package manager can have entire package deprecated" do
+        let!(:project) { Project.create(platform: "NPM", name: "react", status: "Removed") }
+
+        it "should mark the project no longer removed" do
+          VCR.use_cassette("project/check_status/react") do
+            project.check_status
+
+            project.reload
+
+            expect(project.status).to eq(nil)
+          end
+        end
+      end
+    end
   end
 
   describe "DeletedProject management" do

--- a/spec/workers/check_repo_status_worker_spec.rb
+++ b/spec/workers/check_repo_status_worker_spec.rb
@@ -9,9 +9,8 @@ describe CheckRepoStatusWorker do
 
   it "should check repo status" do
     repo_full_name = "rails/rails"
-    removed = true
     host_type = "GitHub"
-    expect(Repository).to receive(:check_status).with(host_type, repo_full_name, removed)
-    subject.perform(host_type, repo_full_name, removed)
+    expect(Repository).to receive(:check_status).with(host_type, repo_full_name)
+    subject.perform(host_type, repo_full_name)
   end
 end

--- a/spec/workers/check_status_worker_spec.rb
+++ b/spec/workers/check_status_worker_spec.rb
@@ -8,22 +8,8 @@ describe CheckStatusWorker do
   end
 
   it "should check repo status" do
-    uri_ignoring_trailing_id = lambda do |request1, request2|
-      uri1 = request1.uri
-      uri2 = request2.uri
-      # capture all versions matching "rails" with sequence
-      regexp_trail_id = /rails\d+.json/
-      if uri1.match(regexp_trail_id)
-        r1_without_id = uri1.gsub(regexp_trail_id, "")
-        r2_without_id = uri2.gsub(regexp_trail_id, "")
-        uri1.match(regexp_trail_id) && uri2.match(regexp_trail_id) && r1_without_id == r2_without_id
-      else
-        uri1 == uri2
-      end
-    end
-
-    VCR.use_cassette("project/check_status/rails", match_requests_on: [:method, uri_ignoring_trailing_id]) do
-      project = create(:project)
+    VCR.use_cassette("project/check_status/rails") do
+      project = create(:project, name: "rails")
       expect(Project).to receive(:find_by_id).with(project.id).and_return(project)
       subject.perform(project.id)
     end

--- a/spec/workers/check_status_worker_spec.rb
+++ b/spec/workers/check_status_worker_spec.rb
@@ -8,7 +8,21 @@ describe CheckStatusWorker do
   end
 
   it "should check repo status" do
-    VCR.use_cassette("project/check_status/rails") do
+    uri_ignoring_trailing_id = lambda do |request1, request2|
+      uri1 = request1.uri
+      uri2 = request2.uri
+      # capture all versions matching "rails" with sequence
+      regexp_trail_id = /rails\d+.json/
+      if uri1.match(regexp_trail_id)
+        r1_without_id = uri1.gsub(regexp_trail_id, "")
+        r2_without_id = uri2.gsub(regexp_trail_id, "")
+        uri1.match(regexp_trail_id) && uri2.match(regexp_trail_id) && r1_without_id == r2_without_id
+      else
+        uri1 == uri2
+      end
+    end
+
+    VCR.use_cassette("project/check_status/rails", match_requests_on: [:method, uri_ignoring_trailing_id]) do
       project = create(:project)
       expect(Project).to receive(:find_by_id).with(project.id).and_return(project)
       subject.perform(project.id)

--- a/spec/workers/check_status_worker_spec.rb
+++ b/spec/workers/check_status_worker_spec.rb
@@ -8,10 +8,10 @@ describe CheckStatusWorker do
   end
 
   it "should check repo status" do
-    project = create(:project)
-    removed = false
-    expect(Project).to receive(:find_by_id).with(project.id).and_return(project)
-    expect(project).to receive(:check_status).with(removed)
-    subject.perform(project.id, removed)
+    VCR.use_cassette("project/check_status/rails") do
+      project = create(:project)
+      expect(Project).to receive(:find_by_id).with(project.id).and_return(project)
+      subject.perform(project.id)
+    end
   end
 end


### PR DESCRIPTION
This removes the `deprecated_or_removed` parameter from `Project#check_status` (and associated methods) in an effort to simplify this method and ensure data is being updated properly.

Packages can still have the status set to `nil` if we find a correction to the data, but will no longer have a way to manually pass a flag to force a status reset.

Updating the specs after this change was triggering a new HTTP request, so I added a new VCR cassette to cover this.
