### PR TITLE
Remove ignored deprecated_or_removed parameter from CheckStatusWorker.perform

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -229,7 +229,7 @@ class Project < ApplicationRecord
     return unless platform_class_exists?
 
     sync_classes.each { |sync_class| PackageManagerDownloadWorker.perform_async(sync_class.name, name, nil, "project", 0, force_sync_dependencies) }
-    CheckStatusWorker.perform_async(id, status == "Removed" || status == "Deprecated")
+    CheckStatusWorker.perform_async(id)
   end
 
   def sync_classes

--- a/app/workers/check_status_worker.rb
+++ b/app/workers/check_status_worker.rb
@@ -4,7 +4,7 @@ class CheckStatusWorker
   include Sidekiq::Worker
   sidekiq_options queue: :status, unique: :until_executed
 
-  def perform(project_id, _ignored = nil)
+  def perform(project_id)
     Project.find_by_id(project_id).try(:check_status)
   end
 end

--- a/app/workers/check_status_worker.rb
+++ b/app/workers/check_status_worker.rb
@@ -4,7 +4,7 @@ class CheckStatusWorker
   include Sidekiq::Worker
   sidekiq_options queue: :status, unique: :until_executed
 
-  def perform(project_id)
+  def perform(project_id, _ignored = nil)
     Project.find_by_id(project_id).try(:check_status)
   end
 end

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -77,7 +77,7 @@ namespace :projects do
     # Check if removed/deprecated projects are still deprecated/removed
     PLATFORMS_FOR_STATUS_CHECKS.each do |platform|
       Project.platform(platform).removed_or_deprecated.select("id").find_each do |project|
-        CheckStatusWorker.perform_async(project.id, true)
+        CheckStatusWorker.perform_async(project.id)
       end
     end
 


### PR DESCRIPTION
What I believe is the appropriate fix for the patch introduced [here](https://github.com/librariesio/libraries.io/commit/3593fd23d715dd80fe80be656be5d469fe3612c7).

~Removed ignored parameter from method signature~, and removes it from other calls of this method. I did not see any other calls that were being made incorrectly in searching through the code.