### PR TITLE
Repository#sync_manifests: ignore manifests that had errors while parsing, and log a message.

### DIFF
--- a/app/models/concerns/repo_manifests.rb
+++ b/app/models/concerns/repo_manifests.rb
@@ -50,8 +50,14 @@ module RepoManifests
   def sync_manifest(m)
     args = { platform: m[:platform], kind: m[:kind], filepath: m[:path], sha: m[:sha] }
 
-    unless manifests.find_by(args)
+    unless manifests.where(args).exists?
+      if m[:dependencies].nil?
+        Rails.logger.info "RepoManifests#sync_manifest error from parsed manifest: repository_id=#{id} path=#{m[:platform]} kind=#{m[:kind]} manifest=#{m[:path]} sha=#{m[:sha]} error=#{m[:error_message]}" 
+        return
+      end
+
       manifest = manifests.create(args)
+      
       dependencies = m[:dependencies].map(&:with_indifferent_access).uniq { |dep| [dep[:name].try(:strip), dep[:requirement], dep[:type]] }
       dependencies.each do |dep|
         platform = manifest.platform


### PR DESCRIPTION
Fixes a noisy bug where a parsed manifest has an error and `dependencies` is nil instead of an array.

```
undefined method `map' for nil:NilClass
app/models/concerns/repo_manifests.rb:55:in `sync_manifest': undefined method `map' for nil:NilClass (NoMethodError)
    from app/models/concerns/repo_manifests.rb:13:in `block in download_manifests'
    from app/models/concerns/repo_manifests.rb:13:in `each'
    from app/models/concerns/repo_manifests.rb:13:in `download_manifests'
    from app/models/repository.rb:291:in `update_all_info'
```