### PR TITLE
Add optional field to dependencies for maven, add optional to DependencySerializer

### DIFF
--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -146,6 +146,7 @@ module PackageManager
           project_name: dep[:name],
           requirements: dep[:requirement],
           kind: dep[:type],
+          optional: dep.key?(:optional) ? dep[:optional] : false,
           platform: formatted_name,
         }
       end

--- a/app/serializers/dependency_serializer.rb
+++ b/app/serializers/dependency_serializer.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class DependencySerializer < ActiveModel::Serializer
-  attributes :project_name, :name, :platform, :requirements, :latest_stable,
-             :latest, :deprecated, :outdated, :filepath, :kind, :normalized_licenses
+  attributes :project_name, :name, :platform, :requirements, :latest_stable, :latest,
+             :deprecated, :outdated, :filepath, :kind, :optional, :normalized_licenses
 
   def normalized_licenses
     object.project.try(:normalized_licenses)

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -173,6 +173,7 @@ describe "Api::ProjectsController" do
               outdated: dependency.outdated,
               filepath: dependency.filepath,
               kind: dependency.kind,
+              optional: dependency.optional,
               normalized_licenses: dependency.project.normalized_licenses,
             }
           end,
@@ -225,6 +226,7 @@ describe "Api::ProjectsController" do
             "outdated": dependency.outdated,
             "filepath": dependency.filepath,
             "kind": dependency.kind,
+            "optional": dependency.optional,
             "normalized_licenses": dependency.project.normalized_licenses,
           }
         end,
@@ -273,6 +275,7 @@ describe "Api::ProjectsController" do
                 "outdated": dependency.outdated,
                 "filepath": dependency.filepath,
                 "kind": dependency.kind,
+                "optional": dependency.optional,
                 "normalized_licenses": dependency.project.normalized_licenses,
               }
             end,
@@ -294,6 +297,7 @@ describe "Api::ProjectsController" do
                 "outdated": dependency.outdated,
                 "filepath": dependency.filepath,
                 "kind": dependency.kind,
+                "optional": dependency.optional,
                 "normalized_licenses": dependency.project.normalized_licenses,
               }
             end,

--- a/spec/serializers/dependency_serializer_spec.rb
+++ b/spec/serializers/dependency_serializer_spec.rb
@@ -9,6 +9,7 @@ describe DependencySerializer do
     expect(subject.attributes.keys).to eql(%i[project_name name platform
                                               requirements latest_stable
                                               latest deprecated outdated
-                                              filepath kind normalized_licenses])
+                                              filepath kind optional
+                                              normalized_licenses])
   end
 end


### PR DESCRIPTION
Uses the new `optional` field (added [here](https://github.com/librariesio/bibliothecary/pull/572) and [here](https://github.com/librariesio/libraries.io/pull/3121)) to add this to the `Dependency.optional` for Maven records.

Adds the `Dependency.optional` field to `DependencySerializer` so it is present in API responses.