### PR TITLE
add manifest:kind_counter task

### DIFF
--- a/lib/tasks/manifest.rake
+++ b/lib/tasks/manifest.rake
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module ManifestKindCounting
+  def self.build_project_where_clause(packages)
+    project_table = Project.arel_table
+
+    packages.reduce(Arel::Nodes::False.new) do |clause, package|
+      clause.or(
+        project_table.grouping(
+          project_table.lower(project_table[:platform]).eq(package[0].downcase).and(
+            project_table[:name].eq(package[1])
+          )
+        )
+      )
+    end
+  end
+end
+
+namespace :manifest do
+  desc "Tests a sampling of project's versions to count occurrences of different manifest kinds"
+  task :kind_counter, %i[package_list output_file] => :environment do |_t, args|
+    raise "Provide package_list csv file with columns [package_platform, package_name]" unless args[:package_list].present?
+
+    output_file = args[:output_file] || File.join(__dir__, "output", "manifest_kind_count.json")
+
+    packages = CSV.read(args[:package_list])
+
+    global_tallies = { cursor: 0 }.with_indifferent_access
+
+    previous_tallies = File.exist?(output_file) && File.read(output_file)
+    if previous_tallies.present?
+      global_tallies = JSON.parse(previous_tallies).with_indifferent_access
+      packages = packages[global_tallies[:cursor]..]
+    end
+
+    slice_size = 1000
+
+    packages&.each_slice(slice_size) do |packages_slice|
+      repository_ids = Project
+                         .where(ManifestKindCounting.build_project_where_clause(packages_slice))
+                         .limit(slice_size)
+                         .distinct
+                         .pluck(:repository_id)
+                         .compact
+                         .join(",")
+
+      ActiveRecord::Base.connection.execute(
+        <<-SQL
+            select
+              platform,
+              kinds,
+              count(*)
+            from
+              (
+                select
+                  lower(platform) as platform,
+                  array_agg(
+                    distinct kind
+                    order by
+                      kind asc
+                  ) as kinds
+                from
+                  manifests
+                where
+                  repository_id in (#{repository_ids})
+                group by
+                  platform,
+                  repository_id
+              ) as platform_kinds
+            group by
+              platform,
+              kinds
+            order by
+              platform,
+              kinds;
+        SQL
+      ).each do |platform_kind_count|
+        platform = platform_kind_count["platform"]
+        kind = platform_kind_count["kinds"]
+        count = platform_kind_count["count"]
+
+        global_tallies[platform] ||= {}
+        global_tallies[platform][kind] ||= 0
+
+        global_tallies[platform][kind] += count
+      end
+    end
+
+    global_tallies[:cursor] = global_tallies[:cursor] + slice_size
+
+    File.write(
+      output_file,
+      JSON.pretty_generate(global_tallies)
+    )
+  end
+end


### PR DESCRIPTION
Add task for counting the kinds of manifests present for the repositories associated with the packages in the package list.

There are a number of reasons this won't be exactly accurate
* There are `Manifest` records which belong to a `Repository` and the path is for a file in a test directory
* Projects are *:1 associated to Repositories, and Manifests are also *:1 associated to repositories. In a multi-project repo setup, this will cause all of the repo's manifests to get counted for each of the projects.
* Also related to a multi-project setup - the final count will only report on whether only a manifest, only a lockfile or both a manifest and lockfile were found in the entire repository. Meaning that if even one project has both, the entire repository will counted as having both (and so will every other project).
  * afaict, the only way to fix this would be to associate Manifests with Projects, but that's probably more effort than it's worth for this counter.