### PR TITLE
Include Maintenance Stats in Repository Detail API

### DIFF
--- a/app/models/repository_maintenance_stat.rb
+++ b/app/models/repository_maintenance_stat.rb
@@ -18,4 +18,6 @@
 #
 class RepositoryMaintenanceStat < ApplicationRecord
   belongs_to :repository
+
+  API_FIELDS = %i[category value updated_at].freeze
 end

--- a/app/serializers/optimized_project_serializer.rb
+++ b/app/serializers/optimized_project_serializer.rb
@@ -26,12 +26,6 @@ class OptimizedProjectSerializer
     status
   ].freeze
 
-  MAINTENANCE_STAT_ATTRIBUTES = %w[
-    category
-    value
-    updated_at
-  ].freeze
-
   def initialize(projects, requested_name_map, internal_key = false)
     @projects = projects
     @requested_name_map = requested_name_map
@@ -77,9 +71,9 @@ class OptimizedProjectSerializer
     @maintenance_stats ||= Datadog::Tracing.trace("optimized_project_serializer#maintenance_stats") do |_span, _trace|
       RepositoryMaintenanceStat
         .where(repository_id: @projects.map { |p| p.repository&.id }.compact)
-        .pluck(*MAINTENANCE_STAT_ATTRIBUTES, :repository_id)
+        .pluck(*RepositoryMaintenanceStat::API_FIELDS, :repository_id)
         .each_with_object(Hash.new { |h, k| h[k] = [] }) do |row, stats|
-          stats[row[-1]] << MAINTENANCE_STAT_ATTRIBUTES.zip(row).to_h
+          stats[row[-1]] << RepositoryMaintenanceStat::API_FIELDS.zip(row).to_h
         end
     end
   end

--- a/spec/requests/api/repositories_spec.rb
+++ b/spec/requests/api/repositories_spec.rb
@@ -4,6 +4,12 @@ require "rails_helper"
 
 describe "Api::RepositoriesController" do
   let!(:repository) { create(:repository) }
+  let!(:maintenance_stat) { create(:repository_maintenance_stat, repository: repository) }
+  let(:internal_user) { create(:user) }
+
+  before do
+    internal_user.current_api_key.update_attribute(:is_internal, true)
+  end
 
   describe "GET /api/github/:owner/:name/dependencies", type: :request do
     it "renders successfully" do
@@ -25,10 +31,17 @@ describe "Api::RepositoriesController" do
 
   describe "GET /api/github/:owner/:name", type: :request do
     it "renders successfully" do
-      get "/api/github/#{repository.full_name}"
+      get "/api/github/#{repository.full_name}", params: { api_key: internal_user.api_key }
       expect(response).to have_http_status(:success)
       expect(response.content_type).to eq("application/json")
-      expect(json.to_json).to be_json_eql repository.to_json({ except: %i[id repository_organisation_id repository_user_id], methods: %i[github_contributions_count github_id] })
+      expect(json.to_json).to be_json_eql(
+        repository.to_json({
+                             except: %i[id repository_organisation_id repository_user_id],
+                             methods: %i[github_contributions_count github_id],
+                           })
+      ).excluding("maintenance_stats") # exclude maintenance stats since those are not included in the serializer
+
+      expect(json["maintenance_stats"].to_json).to be_json_eql([maintenance_stat.attributes.symbolize_keys.slice(*RepositoryMaintenanceStat::API_FIELDS)].to_json)
     end
   end
 end


### PR DESCRIPTION
We have the stats being returned when querying for a package, but the stats are tied to the repository directly so this allows us to query for stats per repository instead of per package with a possibly incorrect repository URL.