### PR TITLE
[fix] Allow for implicit tailing zero in pypi prerelease/development versions

### DIFF
--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -10,7 +10,7 @@ module PackageManager
     COLOR = "#3572A5"
     ENTIRE_PACKAGE_CAN_BE_DEPRECATED = true
     SUPPORTS_SINGLE_VERSION_UPDATE = true
-    PYPI_PRERELEASE = /(a|b|rc|dev)[0-9]+$/.freeze
+    PYPI_PRERELEASE = /(a|b|rc|dev)[0-9]*$/.freeze
     # Adapted from https://peps.python.org/pep-0508/#names to include extras
     PEP_508_NAME_REGEX = /[A-Z0-9][A-Z0-9._-]*[A-Z0-9]|[A-Z0-9]/i.freeze
     PEP_508_NAME_WITH_EXTRAS_REGEX = /(^#{PEP_508_NAME_REGEX}\s*(?:\[#{PEP_508_NAME_REGEX}(?:,\s*#{PEP_508_NAME_REGEX})*\])?)/i.freeze

--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -10,7 +10,7 @@ module PackageManager
     COLOR = "#3572A5"
     ENTIRE_PACKAGE_CAN_BE_DEPRECATED = true
     SUPPORTS_SINGLE_VERSION_UPDATE = true
-    PYPI_PRERELEASE = /(a|b|rc|dev)[0-9]*$/.freeze
+    PYPI_PRERELEASE = /(a|b|rc|dev)[-_.]?[0-9]*$/.freeze
     # Adapted from https://peps.python.org/pep-0508/#names to include extras
     PEP_508_NAME_REGEX = /[A-Z0-9][A-Z0-9._-]*[A-Z0-9]|[A-Z0-9]/i.freeze
     PEP_508_NAME_WITH_EXTRAS_REGEX = /(^#{PEP_508_NAME_REGEX}\s*(?:\[#{PEP_508_NAME_REGEX}(?:,\s*#{PEP_508_NAME_REGEX})*\])?)/i.freeze

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -96,6 +96,7 @@ describe PackageManager::Pypi do
             "0.0.1" => [{}],
             "0.0.2" => [{}],
             "0.0.3" => [{}],
+            "0.0.3a" => [{ "yanked" => true, "yanked_reason" => "This package is deprecated" }],
             "0.0.3a1" => [{ "yanked" => true, "yanked_reason" => "This package is deprecated" }],
           },
         }


### PR DESCRIPTION
https://peps.python.org/pep-0440/#implicit-pre-release-number

In Libraries, this should only affect fetching deprecation info, but trying to keep this consistent across services