### PR TITLE
Remove Parentheses from PyPI API Dependency Requirements When Parsing Results

### DIFF
--- a/app/models/concerns/dependency_checks.rb
+++ b/app/models/concerns/dependency_checks.rb
@@ -23,7 +23,7 @@ module DependencyChecks
       numbers = requirements.split("<= v")
       ">=#{numbers[0].strip} #{numbers[1].strip}"
     when "pypi"
-      requirements&.remove(/[()]/)
+      requirements&.remove(/[()]/) # remove parentheses surrounding version requirement
     else
       requirements
     end

--- a/app/models/concerns/dependency_checks.rb
+++ b/app/models/concerns/dependency_checks.rb
@@ -22,6 +22,8 @@ module DependencyChecks
     when "elm"
       numbers = requirements.split("<= v")
       ">=#{numbers[0].strip} #{numbers[1].strip}"
+    when "pypi"
+      requirements&.remove(/[()]/)
     else
       requirements
     end

--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -151,7 +151,9 @@ module PackageManager
       name, requirement = dep.split(PEP_508_NAME_WITH_EXTRAS_REGEX, 2).last(2)
       version, environment_markers = requirement.split(";").map(&:strip)
 
-      [name.remove(/\s/), version || "", environment_markers || ""]
+      # remove whitespace from name
+      # remove parentheses surrounding version requirement
+      [name.remove(/\s/), version&.remove(/[()]/) || "", environment_markers || ""]
     end
 
     def self.dependencies(name, version, _mapped_project = nil)

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -164,9 +164,9 @@ describe PackageManager::Pypi do
           described_class.dependencies("isort", "5.12.0")
         ).to match_array(
           [
-            ["colorama", "(>=0.4.3)", "extra == \"colors\""],
+            ["colorama", ">=0.4.3", "extra == \"colors\""],
             ["pip-api", "*", "extra == \"requirements-deprecated-finder\""],
-            ["pip-shims", "(>=0.5.2)", "extra == \"pipfile-deprecated-finder\""],
+            ["pip-shims", ">=0.5.2", "extra == \"pipfile-deprecated-finder\""],
             ["pipreqs", "*", "extra == \"pipfile-deprecated-finder\" or extra == \"requirements-deprecated-finder\""],
             ["requirementslib", "*", "extra == \"pipfile-deprecated-finder\""],
             ["setuptools", "*", "extra == \"plugins\""],
@@ -232,13 +232,13 @@ describe PackageManager::Pypi do
       [
         "foo (<6,>=3.0.2); extra == 'use_chardet_on_py3'",
         "foo",
-        "(<6,>=3.0.2)",
+        "<6,>=3.0.2",
         "extra == 'use_chardet_on_py3'",
       ],
       [
         "bar (>=3.2,<4.0) ; extra == \"django\" or extra == 'channels'",
         "bar",
-        "(>=3.2,<4.0)",
+        ">=3.2,<4.0",
         "extra == \"django\" or extra == 'channels'",
       ],
       [
@@ -250,7 +250,7 @@ describe PackageManager::Pypi do
       [
         "foo(>=12.0.0) ; extra == \"debug\" or extra == \"debug-server\" and os_name == \"nt\"",
         "foo",
-        "(>=12.0.0)",
+        ">=12.0.0",
         "extra == \"debug\" or extra == \"debug-server\" and os_name == \"nt\"",
       ],
       [

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -139,12 +139,12 @@ describe PackageManager::Pypi do
           described_class.dependencies("requests", "2.28.2")
         ).to match_array(
           [
-            ["charset-normalizer", "(<4,>=2)"],
-            ["idna", "(<4,>=2.5)"],
-            ["urllib3", "(<1.27,>=1.21.1)"],
-            ["certifi", "(>=2017.4.17)"],
-            ["PySocks", "(!=1.5.7,>=1.5.6)", "extra == 'socks'", true],
-            ["chardet", "(<6,>=3.0.2)", "extra == 'use_chardet_on_py3'", true],
+            ["charset-normalizer", "<4,>=2"],
+            ["idna", "<4,>=2.5"],
+            ["urllib3", "<1.27,>=1.21.1"],
+            ["certifi", ">=2017.4.17"],
+            ["PySocks", "!=1.5.7,>=1.5.6", "extra == 'socks'", true],
+            ["chardet", "<6,>=3.0.2", "extra == 'use_chardet_on_py3'", true],
           ].map do |name, requirements, kind = "runtime", optional = false|
             {
               project_name: name,

--- a/spec/models/tree_resolver_spec.rb
+++ b/spec/models/tree_resolver_spec.rb
@@ -106,8 +106,8 @@ RSpec.describe TreeResolver do
       two = create(:project, name: "two", platform: platform)
       one_version = create(:version, project: one, number: "1.0.0")
       two_version = create(:version, project: two, number: "1.2.0")
-      one_dependency = create(:dependency, version: root_version, project: one, project_name: one.name, platform: platform, requirements: "(> 0)")
-      two_dependency = create(:dependency, version: root_version, project: two, project_name: two.name, platform: platform, requirements: "(> 0, >= 1.1)")
+      one_dependency = create(:dependency, version: root_version, project: one, project_name: one.name, platform: platform, requirements: "(>0)")
+      two_dependency = create(:dependency, version: root_version, project: two, project_name: two.name, platform: platform, requirements: "(>0,<1.3)")
 
       expected_tree = {
         version: { "number": root_version.number },
@@ -118,14 +118,14 @@ RSpec.describe TreeResolver do
           {
             version: { "number": one_version.number },
             dependency: { "platform": one_dependency.platform, "project_name": one_dependency.project_name, "kind": "runtime" },
-            requirements: "(> 0)",
+            requirements: "(>0)",
             normalized_licenses: ["MIT"],
             dependencies: [],
           },
           {
             version: { "number": two_version.number },
             dependency: { "platform": two_dependency.platform, "project_name": two_dependency.project_name, "kind": "runtime" },
-            requirements: "(> 0, >= 1.1)",
+            requirements: "(>0,<1.3)",
             normalized_licenses: ["MIT"],
             dependencies: [],
           },


### PR DESCRIPTION
Dependency version requirements being returned from the PyPI API often have parentheses surrounding them which breaks the tree resolver when trying to find the latest version that fulfills each requirement. This PR would strip the parentheses from the requirements text before saving the dependency rows. We can run a backfill to fix old data or leave the fix in `dependency_checks.rb` to remove them when calling `semantic_requirements` on a `Dependency`.