### PR TITLE
fix: Reduce some mismatched casing bugs on platform names

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -125,7 +125,7 @@ class Project < ApplicationRecord
   scope :least_recently_updated_stats, -> { joins(:repository_maintenance_stats).group("projects.id").where.not(repository: nil).order(Arel.sql("max(repository_maintenance_stats.updated_at) ASC")) }
   scope :no_existing_stats, -> { includes(:repository_maintenance_stats).where(repository_maintenance_stats: { id: nil }).where.not(repository: nil) }
 
-  scope :platform, ->(platform) { where(platform: PackageManager::Base.format_name(platform)) }
+  scope :platform, ->(platforms) { where(platform: Array.wrap(platforms).map { |platform| PackageManager::Base.format_name(platform) }) }
   scope :lower_platform, ->(platform) { where("lower(projects.platform) = ?", platform.try(:downcase)) }
   scope :lower_name, ->(name) { where("lower(projects.name) = ?", name.try(:downcase)) }
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -29,6 +29,21 @@ FactoryBot.define do
     keywords_array  { ["web"] }
     repository_url
     repository { nil }
+
+    trait :rubygems do
+      platform { "Rubygems" }
+      language { "Ruby" }
+    end
+
+    trait :npm do
+      platform { "NPM" }
+      language { "JavaScript" }
+    end
+
+    trait :maven do
+      platform { "Maven" }
+      language { "Java" }
+    end
   end
 
   factory :platform do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -450,4 +450,44 @@ describe Project, type: :model do
       )
     end
   end
+
+  describe "::platform" do
+    subject(:scoped_collection) { described_class.platform(given_platforms) }
+
+    let!(:ruby1) { create(:project, :rubygems) }
+    let!(:ruby2) { create(:project, :rubygems) }
+    let!(:npm1) { create(:project, :npm) }
+
+    context "mismatched case" do
+      let(:given_platforms) { "RubyGems" }
+
+      it "includes all matches" do
+        expect(scoped_collection).to match_array([ruby1, ruby2])
+      end
+    end
+
+    context "exact case" do
+      let(:given_platforms) { "Rubygems" }
+
+      it "includes all matches" do
+        expect(scoped_collection).to match_array([ruby1, ruby2])
+      end
+    end
+
+    context "other" do
+      let(:given_platforms) { "foo" }
+
+      it "is empty" do
+        expect(scoped_collection).to be_empty
+      end
+    end
+
+    context "multiple" do
+      let(:given_platforms) { %w[RubyGems NPm] }
+
+      it "can match any" do
+        expect(scoped_collection).to match_array([ruby1, ruby2, npm1])
+      end
+    end
+  end
 end


### PR DESCRIPTION
We do a lot of querying by platform, especially in these rake tasks. Given the mixed case format for platform names in use, I wanted to make it harder to do the wrong thing. This updates the `Project::platform` scope to accept a string or array of strings, so it can easily replace much of the manual `where(platform: "YoudBetterGetTheseCapsRight")` calls.