### PR TITLE
Add Indexes to dependency and repository_dependency on created_at date

### DIFF
--- a/app/models/dependency.rb
+++ b/app/models/dependency.rb
@@ -17,8 +17,9 @@
 #
 # Indexes
 #
-#  index_dependencies_on_project_id  (project_id)
-#  index_dependencies_on_version_id  (version_id)
+#  index_dependencies_on_created_at_date  (((created_at)::date))
+#  index_dependencies_on_project_id       (project_id)
+#  index_dependencies_on_version_id       (version_id)
 #
 class Dependency < ApplicationRecord
   include DependencyChecks

--- a/app/models/dependency.rb
+++ b/app/models/dependency.rb
@@ -17,9 +17,9 @@
 #
 # Indexes
 #
-#  index_dependencies_on_created_at_date  (((created_at)::date))
-#  index_dependencies_on_project_id       (project_id)
-#  index_dependencies_on_version_id       (version_id)
+#  index_dependencies_on_project_created_at_date  (project_id, ((created_at)::date))
+#  index_dependencies_on_project_id               (project_id)
+#  index_dependencies_on_version_id               (version_id)
 #
 class Dependency < ApplicationRecord
   include DependencyChecks

--- a/app/models/repository_dependency.rb
+++ b/app/models/repository_dependency.rb
@@ -18,9 +18,10 @@
 #
 # Indexes
 #
-#  index_repository_dependencies_on_manifest_id    (manifest_id)
-#  index_repository_dependencies_on_project_id     (project_id)
-#  index_repository_dependencies_on_repository_id  (repository_id)
+#  index_repository_dependencies_on_created_at_date  (((created_at)::date))
+#  index_repository_dependencies_on_manifest_id      (manifest_id)
+#  index_repository_dependencies_on_project_id       (project_id)
+#  index_repository_dependencies_on_repository_id    (repository_id)
 #
 class RepositoryDependency < ApplicationRecord
   include DependencyChecks

--- a/app/models/repository_dependency.rb
+++ b/app/models/repository_dependency.rb
@@ -18,10 +18,10 @@
 #
 # Indexes
 #
-#  index_repository_dependencies_on_created_at_date  (((created_at)::date))
-#  index_repository_dependencies_on_manifest_id      (manifest_id)
-#  index_repository_dependencies_on_project_id       (project_id)
-#  index_repository_dependencies_on_repository_id    (repository_id)
+#  index_repository_dependencies_on_manifest_id              (manifest_id)
+#  index_repository_dependencies_on_project_created_at_date  (project_id, ((created_at)::date))
+#  index_repository_dependencies_on_project_id               (project_id)
+#  index_repository_dependencies_on_repository_id            (repository_id)
 #
 class RepositoryDependency < ApplicationRecord
   include DependencyChecks

--- a/db/migrate/20230705195409_add_created_at_index_to_dependencies.rb
+++ b/db/migrate/20230705195409_add_created_at_index_to_dependencies.rb
@@ -2,23 +2,23 @@ class AddCreatedAtIndexToDependencies < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
   def up
-    unless index_name_exists?(:dependencies, "index_dependencies_on_created_at_date")
-      add_index :dependencies, "(created_at::date)", name: "index_dependencies_on_created_at_date", algorithm: :concurrently
+    unless index_name_exists?(:dependencies, "index_dependencies_on_project_created_at_date")
+      add_index :dependencies, "project_id, (created_at::date)", name: "index_dependencies_on_project_created_at_date", algorithm: :concurrently
     end
 
-    unless index_name_exists?(:repository_dependencies, "index_repository_dependencies_on_created_at_date")
-      add_index :repository_dependencies, "(created_at::date)", name: "index_repository_dependencies_on_created_at_date", algorithm: :concurrently
+    unless index_name_exists?(:repository_dependencies, "index_repository_dependencies_on_project_created_at_date")
+      add_index :repository_dependencies, "project_id, (created_at::date)", name: "index_repository_dependencies_on_project_created_at_date", algorithm: :concurrently
     end
 
   end
 
   def down
-    if index_name_exists?(:dependencies, "index_dependencies_on_created_at_date")
-      remove_index :dependencies, "(created_at::date)"
+    if index_name_exists?(:dependencies, "index_dependencies_on_project_created_at_date")
+      remove_index :dependencies, name: "index_dependencies_on_project_created_at_date"
     end
 
-    if index_name_exists?(:repository_dependencies, "index_repository_dependencies_on_created_at_date")
-      remove_index :repository_dependencies, "(created_at::date)"
+    if index_name_exists?(:repository_dependencies, "index_repository_dependencies_on_project_created_at_date")
+      remove_index :repository_dependencies, name: "index_repository_dependencies_on_project_created_at_date"
     end
   end
 end

--- a/db/migrate/20230705195409_add_created_at_index_to_dependencies.rb
+++ b/db/migrate/20230705195409_add_created_at_index_to_dependencies.rb
@@ -1,0 +1,24 @@
+class AddCreatedAtIndexToDependencies < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def up
+    unless index_name_exists?(:dependencies, "index_dependencies_on_created_at_date")
+      add_index :dependencies, "(created_at::date)", name: "index_dependencies_on_created_at_date", algorithm: :concurrently
+    end
+
+    unless index_name_exists?(:repository_dependencies, "index_repository_dependencies_on_created_at_date")
+      add_index :repository_dependencies, "(created_at::date)", name: "index_repository_dependencies_on_created_at_date", algorithm: :concurrently
+    end
+
+  end
+
+  def down
+    if index_name_exists?(:dependencies, "index_dependencies_on_created_at_date")
+      remove_index :dependencies, "(created_at::date)"
+    end
+
+    if index_name_exists?(:repository_dependencies, "index_repository_dependencies_on_created_at_date")
+      remove_index :repository_dependencies, "(created_at::date)"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_16_150532) do
+ActiveRecord::Schema.define(version: 2023_07_05_195409) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -65,6 +65,7 @@ ActiveRecord::Schema.define(version: 2023_05_16_150532) do
     t.string "requirements"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index "((created_at)::date)", name: "index_dependencies_on_created_at_date"
     t.index ["project_id"], name: "index_dependencies_on_project_id"
     t.index ["version_id"], name: "index_dependencies_on_version_id"
   end
@@ -278,6 +279,7 @@ ActiveRecord::Schema.define(version: 2023_05_16_150532) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "repository_id"
+    t.index "((created_at)::date)", name: "index_repository_dependencies_on_created_at_date"
     t.index ["manifest_id"], name: "index_repository_dependencies_on_manifest_id"
     t.index ["project_id"], name: "index_repository_dependencies_on_project_id"
     t.index ["repository_id"], name: "index_repository_dependencies_on_repository_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -65,7 +65,7 @@ ActiveRecord::Schema.define(version: 2023_07_05_195409) do
     t.string "requirements"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index "((created_at)::date)", name: "index_dependencies_on_created_at_date"
+    t.index "project_id, ((created_at)::date)", name: "index_dependencies_on_project_created_at_date"
     t.index ["project_id"], name: "index_dependencies_on_project_id"
     t.index ["version_id"], name: "index_dependencies_on_version_id"
   end
@@ -279,7 +279,7 @@ ActiveRecord::Schema.define(version: 2023_07_05_195409) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "repository_id"
-    t.index "((created_at)::date)", name: "index_repository_dependencies_on_created_at_date"
+    t.index "project_id, ((created_at)::date)", name: "index_repository_dependencies_on_project_created_at_date"
     t.index ["manifest_id"], name: "index_repository_dependencies_on_manifest_id"
     t.index ["project_id"], name: "index_repository_dependencies_on_project_id"
     t.index ["repository_id"], name: "index_repository_dependencies_on_repository_id"

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -17,8 +17,8 @@ namespace :projects do
   desc "Link dependencies to projects"
   task link_dependencies: :environment do
     exit if ENV["READ_ONLY"].present?
-    Dependency.where("created_at > ?", 1.day.ago).without_project_id.with_project_name.find_each(&:update_project_id)
-    RepositoryDependency.where("created_at > ?", 1.day.ago).without_project_id.with_project_name.find_each(&:update_project_id)
+    Dependency.where("created_at::date > date(?)", 1.day.ago).without_project_id.with_project_name.find_each(&:update_project_id)
+    RepositoryDependency.where("created_at::date > date(?)", 1.day.ago).without_project_id.with_project_name.find_each(&:update_project_id)
   end
 
   # rake projects:check_status[100,5]


### PR DESCRIPTION
This PR is to help out the [Projects Dependencies Link](https://github.com/librariesio/libraries.io/blob/d68a5ffb6f032d1ab9f91c3c7bf35ce45a32d973/lib/tasks/projects.rake#L17-L22) daily job which has been failing to complete for a while now. The main reason this job fails is that it is impossible to query the `dependencies` table because of its large size and it is querying an unindexed column. The PR adds an index for `created_at` and scopes the values down to remove the time portion and index it as a Date so that values are grouped up a bit in the index and updates the jobs to query by Date and instead of DateTime.

This migration is something that should be run manually outside of our normal deployment since it will take some time for the database to add the indexes.