### PR TITLE
Remove unneeded key from version hash assignment

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -149,7 +149,6 @@ module PackageManager
         :number,
         :published_at,
         :runtime_dependencies_count,
-        :spdx_expression,
         :original_license,
         :repository_sources,
         :status


### PR DESCRIPTION
This `spdx_expression` key is never set by any PackageManager, and its continued inclusion in the code could cause confusion as to where the SPDX license for a version is being set.