### PR TITLE
Project: send a webhook event when projects are updated

### DIFF
--- a/app/models/web_hook.rb
+++ b/app/models/web_hook.rb
@@ -4,19 +4,21 @@
 #
 # Table name: web_hooks
 #
-#  id            :integer          not null, primary key
-#  last_response :string
-#  last_sent_at  :datetime
-#  shared_secret :string
-#  url           :string
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  repository_id :integer
-#  user_id       :integer
+#  id                  :integer          not null, primary key
+#  all_project_updates :boolean          default(FALSE), not null
+#  last_response       :string
+#  last_sent_at        :datetime
+#  shared_secret       :string
+#  url                 :string
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  repository_id       :integer
+#  user_id             :integer
 #
 # Indexes
 #
-#  index_web_hooks_on_repository_id  (repository_id)
+#  index_web_hooks_on_all_project_updates  (all_project_updates)
+#  index_web_hooks_on_repository_id        (repository_id)
 #
 class WebHook < ApplicationRecord
   belongs_to :repository
@@ -25,6 +27,8 @@ class WebHook < ApplicationRecord
   validates :url, format: URI::DEFAULT_PARSER.make_regexp(%w[http https])
 
   before_save :clear_timestamps
+
+  scope :receives_all_project_updates, -> { where(all_project_updates: true) }
 
   def clear_timestamps
     return unless url_changed?
@@ -50,6 +54,19 @@ class WebHook < ApplicationRecord
                    published_at: version_or_tag.published_at,
                    requirements: requirements,
                    project: project.as_json(only: %i[name platform description homepage language repository_url stars latest_release_published_at normalized_licenses]),
+                 },
+                 # Right now the sidekiq job that calls send_new_version calls it for
+                 # multiple hooks in one job, so raising an error would include multiple
+                 # hooks in the same retry. For all new hooks we add, we should not have
+                 # this behavior.
+                 ignore_errors: true)
+  end
+
+  def send_project_updated(project)
+    serialized = ProjectUpdatedSerializer.new(project).as_json
+    send_payload({
+                   event: "project_updated",
+                   project: serialized
                  })
   end
 
@@ -72,8 +89,11 @@ class WebHook < ApplicationRecord
                           })
   end
 
-  def send_payload(data)
+  def send_payload(data, ignore_errors: false)
     response = request(data).run
     update(last_sent_at: Time.now.utc, last_response: response.response_code)
+    unless response.success? || ignore_errors
+      raise StandardError, "webhook #{id} failed; timed_out=#{response.timed_out?} code=#{response.code}"
+    end
   end
 end

--- a/app/serializers/project_updated_serializer.rb
+++ b/app/serializers/project_updated_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ProjectUpdatedSerializer < ActiveModel::Serializer
+  attributes %i[
+    name
+    platform
+    updated_at
+  ]
+end

--- a/app/workers/project_updated_worker.rb
+++ b/app/workers/project_updated_worker.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ProjectUpdatedWorker
+  include Sidekiq::Worker
+  # retries of 10 is about 7 hours, should often be enough to fix an outage, and
+  # if it goes longer than that we just miss some events. We don't want to let
+  # the backlog get too outrageous.
+  sidekiq_options queue: :small, retries: 10, unique: :until_executed
+
+  def perform(project_id, web_hook_id)
+    project = Project.find(project_id)
+    web_hook = WebHook.find(web_hook_id)
+    web_hook.send_project_updated(project)
+  end
+end

--- a/db/migrate/20230712143940_add_project_updated_to_web_hook.rb
+++ b/db/migrate/20230712143940_add_project_updated_to_web_hook.rb
@@ -1,0 +1,6 @@
+class AddProjectUpdatedToWebHook < ActiveRecord::Migration[5.2]
+  def change
+    add_column :web_hooks, :all_project_updates, :boolean, default: false, null: false
+    add_index :web_hooks, ["all_project_updates"]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -420,7 +420,9 @@ ActiveRecord::Schema.define(version: 2023_07_12_195318) do
     t.datetime "last_sent_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "all_project_updates", default: false, null: false
     t.string "shared_secret"
+    t.index ["all_project_updates"], name: "index_web_hooks_on_all_project_updates"
     t.index ["repository_id"], name: "index_web_hooks_on_repository_id"
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -194,6 +194,7 @@ FactoryBot.define do
     repository
     user
     url { "http://google.com" }
+    all_project_updates { false }
   end
 
   factory :api_key do

--- a/spec/workers/project_updated_worker_spec.rb
+++ b/spec/workers/project_updated_worker_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ProjectUpdatedWorker do
+  context "with a sample webhook" do
+    let(:url) { "https://example.com/hook" }
+    let(:repository) { create(:repository) }
+    let!(:web_hook) { create(:web_hook, url: url, repository: repository, all_project_updates: true) }
+    let(:project) { create(:project, repository: repository) }
+    let(:version) { create(:version, project: project) }
+
+    it "should be queued and send the webhook on project update" do
+      WebMock.stub_request(:post, url)
+        .to_return(status: 200)
+
+      expect(web_hook.last_sent_at).to be_nil
+      expect(WebHook.receives_all_project_updates.to_a).to eq([web_hook])
+
+      project # create the project here
+      first_updated_at = project.updated_at
+
+      described_class.drain
+
+      expect(web_hook.reload.last_sent_at).not_to be_nil
+      assert_requested :post, url,
+                       body: be_json_string_matching({
+                                                       event: "project_updated",
+                                                       project: {
+                                                         name: project.name,
+                                                         platform: project.platform,
+                                                         updated_at: ActiveModel::Type::DateTime.new(precision: 0).serialize(first_updated_at)
+                                                       }.stringify_keys
+                                                     }.stringify_keys)
+
+      project.touch(time: first_updated_at + 10.seconds)
+      second_updated_at = project.updated_at
+      expect(second_updated_at).not_to eq(first_updated_at)
+
+      described_class.drain
+
+      assert_requested :post, url,
+                       body: be_json_string_matching({
+                                                       event: "project_updated",
+                                                       project: {
+                                                         name: project.name,
+                                                         platform: project.platform,
+                                                         updated_at: ActiveModel::Type::DateTime.new(precision: 0).serialize(second_updated_at)
+                                                       }.stringify_keys
+                                                     }.stringify_keys)
+    end
+  end
+end


### PR DESCRIPTION
Note that we bump updated_at when any Version of the project
is added, as well.

There's no UX for this, the hook in question has to be manually added by admins.