### PR TITLE
Retrieve PyPI RSS feed for missing pubdates; refactor code

### DIFF
--- a/app/models/package_manager/can_request.rb
+++ b/app/models/package_manager/can_request.rb
@@ -1,0 +1,38 @@
+module PackageManager
+  module CanRequest
+    def request(url, options = {})
+      connection = Faraday.new url.strip, options do |builder|
+        builder.use FaradayMiddleware::Gzip
+        builder.use FaradayMiddleware::FollowRedirects, limit: 3
+        builder.request :retry, { max: 2, interval: 0.05, interval_randomness: 0.5, backoff_factor: 2 }
+
+        builder.use :instrumentation
+        builder.adapter :typhoeus
+      end
+      connection.get
+    end
+
+    def get(url, options = {})
+      Oj.load(get_raw(url, options))
+    end
+
+    def get_raw(url, options = {})
+      rsp = request(url, options)
+      return "" unless rsp.status == 200
+
+      rsp.body
+    end
+
+    def get_html(url, options = {})
+      Nokogiri::HTML(get_raw(url, options))
+    end
+
+    def get_xml(url, options = {})
+      Ox.parse(get_raw(url, options))
+    end
+
+    def get_json(url)
+      get(url, headers: { "Accept" => "application/json" })
+    end
+  end
+end

--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -109,21 +109,11 @@ module PackageManager
     def self.versions(raw_project, name)
       return [] if raw_project.nil?
 
-      known = known_versions(name)
-
-      raw_project["releases"].reject { |_k, v| v == [] }.map do |k, v|
-        if known.key?(k)
-          known[k]
-        else
-          release = get("https://pypi.org/pypi/#{name}/#{k}/json")
-
-          {
-            number: k,
-            published_at: v[0]["upload_time"],
-            original_license: release.dig("info", "license"),
-          }
-        end
-      end
+      self::Version.process_raw_data(
+        raw_releases: raw_project["releases"],
+        name: name,
+        known_versions: known_versions(name)
+      )
     end
 
     def self.one_version(raw_project, version_string)

--- a/app/models/package_manager/pypi/raw_release.rb
+++ b/app/models/package_manager/pypi/raw_release.rb
@@ -1,0 +1,42 @@
+module PackageManager
+  class Pypi
+    # A raw release coming from prior PackageManger data transformations,
+    # converted to an object for clearer usage.
+    #
+    # For our current purposes, which is processing data about the list of
+    # possible versions, the only data we need is the published_at date,
+    # which may or may not exist.
+    #
+    # Right now the data for this is being fetched in another part of the
+    # Pypi, specifically from the project endpoint. This gets us closer to
+    # being able to break apart the Pypi code into something more moduler.
+    class RawRelease
+      attr_reader :number
+
+      def initialize(number:, release:)
+        @number = number
+        @release = release
+      end
+
+      # PyPI can return an empty dataset for a single release. In that case,
+      # we'll need to retrieve data about this release from other sources.
+      def details?
+        !@release.empty?
+      end
+
+      def published_at
+        return nil unless details?
+
+        upload_time = @release.dig(0, "upload_time")
+        raise ArgumentError, "does not contain upload_time" unless upload_time
+
+        upload_time ? Time.parse(upload_time) : nil
+      end
+
+      # Create an editable Version object
+      def to_version
+        PackageManager::Pypi::Version.new(number: number, published_at: published_at)
+      end
+    end
+  end
+end

--- a/app/models/package_manager/pypi/version.rb
+++ b/app/models/package_manager/pypi/version.rb
@@ -1,0 +1,107 @@
+module PackageManager
+  class Pypi
+    # An editable container of information about a particular
+    # PyPI release. This is transformed into a hash for
+    # later consumption by package manager class methods.
+    #
+    # All of the version-specific requests are done in this class
+    # with the data never traveling more than one method away.
+    class Version
+      extend CanRequest
+
+      attr_reader :number, :published_at, :original_license
+
+      InvalidReleasesFeedStructure = Class.new(ArgumentError)
+
+      # One source of PyPI data is an RSS feed for each package. Most
+      # importantly, this provides the publish date for some releases that,
+      # for some reason, don't exist in the JSON API.
+      def self.retrieve_project_releases_rss_feed(name:)
+        data = get_xml("https://pypi.org/rss/project/#{name}/releases.xml")
+
+        # If this stops looking like an RSS feed, it's an error
+        raise InvalidReleasesFeedStructure unless data.locate("rss/channel").first
+
+        # No items is not an error
+        data.locate("rss/channel/item").map do |item|
+          {
+            # Don't wrap any errors that might occur here in another error
+            # to make it clearer which part of parsing is failing
+            number: item.locate("title").first.text,
+            published_at: Time.parse(item.locate("pubDate").first.text),
+          }
+        end
+      end
+
+      # Encapsulate remote data gathering for feeds that cover all
+      # possible releases. To be used immediately by process_raw_data.
+      def self.gather_raw_data_details(
+        raw_releases:,
+        name:
+      )
+        raw_release_objs = raw_releases.map { |number, release| RawRelease.new(number: number, release: release) }
+
+        # Don't gather RSS feed details unless we need them
+        feed_releases = if !raw_release_objs.all?(&:details?)
+                          retrieve_project_releases_rss_feed(name: name)
+                        else
+                          []
+                        end
+
+        { raw_release_objs: raw_release_objs, feed_releases: feed_releases }
+      end
+
+      def self.process_raw_data(
+        raw_releases:,
+        name:,
+        known_versions:
+      )
+        details = gather_raw_data_details(
+          raw_releases: raw_releases,
+          name: name
+        )
+
+        details[:raw_release_objs].map do |raw_release|
+          # If we know about this release already, skip the rest of the processing
+          next known_versions[raw_release.number] if known_versions.key?(raw_release.number)
+
+          version = raw_release.to_version
+          version.retrieve_license_details!(name: name)
+          version.maybe_set_feed_published_at!(feed_releases: details[:feed_releases])
+
+          version.to_result
+        end
+      end
+
+      def initialize(number: nil, published_at: nil)
+        @number = number
+        @published_at = published_at
+      end
+
+      def retrieve_license_details!(name:)
+        # The license is stored on the version endpoint
+        response = self.class.get("https://pypi.org/pypi/#{name}/#{number}/json")
+
+        # If there's no original license, this is not an error
+        @original_license = response.dig("info", "license")
+      end
+
+      # Only set the published at date from the feed if it's not
+      # already set on the object.
+      def maybe_set_feed_published_at!(feed_releases:)
+        return if @published_at
+
+        feed_release = feed_releases.find { |fr| fr[:number] == number }
+        @published_at = feed_release[:published_at] if feed_release
+      end
+
+      def to_result
+        {
+          number: number,
+          published_at: @published_at&.iso8601,
+          original_license: original_license,
+        }
+      end
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/pypi/versions/ply.yml
+++ b/spec/fixtures/vcr_cassettes/pypi/versions/ply.yml
@@ -1,0 +1,1856 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://pypi.org/pypi/ply/json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip,deflate,br
+      X-Datadog-Trace-Id:
+      - '230273650400538107'
+      X-Datadog-Parent-Id:
+      - '3086815905530169268'
+      X-Datadog-Sampling-Priority:
+      - '1'
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-PyPI-Last-Serial
+      Access-Control-Max-Age:
+      - '86400'
+      Cache-Control:
+      - max-age=900, public
+      Content-Security-Policy:
+      - base-uri 'self'; block-all-mixed-content; connect-src 'self' https://api.github.com/repos/
+        https://api.github.com/search/issues https://*.google-analytics.com https://*.analytics.google.com
+        https://*.googletagmanager.com fastly-insights.com *.fastly-insights.com *.ethicalads.io
+        https://api.pwnedpasswords.com https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/sre/mathmaps/
+        https://2p66nmmycsj3.statuspage.io; default-src 'none'; font-src 'self' fonts.gstatic.com;
+        form-action 'self' https://checkout.stripe.com; frame-ancestors 'none'; frame-src
+        'none'; img-src 'self' https://warehouse-camo.ingress.cmh1.psfhosted.org/
+        https://*.google-analytics.com https://*.googletagmanager.com *.fastly-insights.com
+        *.ethicalads.io; script-src 'self' https://*.googletagmanager.com https://www.google-analytics.com
+        https://ssl.google-analytics.com *.fastly-insights.com *.ethicalads.io 'sha256-U3hKDidudIaxBDEzwGJApJgPEf2mWk6cfMWghrAa6i0='
+        https://cdn.jsdelivr.net/npm/mathjax@3.2.2/ 'sha256-1CldwzdEg2k1wTmf7s5RWVd7NMXI/7nxxjJM2C4DqII='
+        'sha256-0POaN8stWYQxhzjKS+/eOfbbJ/u4YHO5ZagJvLpMypo='; style-src 'self' fonts.googleapis.com
+        *.ethicalads.io 'sha256-2YHqZokjiizkHi1Zt+6ar0XJ0OeEy/egBnlm+MDMtrM=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
+        'sha256-JLEjeN9e5dGsz5475WyRaoA4eQOdNPxDIeUhclnJDCE=' 'sha256-mQyxHEuwZJqpxCw3SLmc4YOySNKXunyu2Oiz1r3/wAE='
+        'sha256-OCf+kv5Asiwp++8PIevKBYSgnNLNUZvxAp4a7wMLuKA=' 'sha256-h5LOiLhk6wiJrGsG5ItM0KimwzWQH/yAcmoJDJL//bY=';
+        worker-src *.fastly-insights.com
+      Content-Type:
+      - application/json
+      Etag:
+      - '"hUsuo1X5oRJmD5VgeUd0rw"'
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - nginx/1.13.9
+      X-Pypi-Last-Serial:
+      - '3585324'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Thu, 13 Jul 2023 18:46:38 GMT
+      X-Served-By:
+      - cache-iad-kjyo7100132-IAD
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1689273998.062535,VS0,VE1
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Content-Length:
+      - '7670'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"info":{"author":"David Beazley","author_email":"dave@dabeaz.com","bugtrack_url":null,"classifiers":["Programming
+        Language :: Python :: 2","Programming Language :: Python :: 3"],"description":"\nPLY
+        is yet another implementation of lex and yacc for Python. Some notable\nfeatures
+        include the fact that its implemented entirely in Python and it\nuses LALR(1)
+        parsing which is efficient and well suited for larger grammars.\n\nPLY provides
+        most of the standard lex/yacc features including support for empty \nproductions,
+        precedence rules, error recovery, and support for ambiguous grammars. \n\nPLY
+        is extremely easy to use and provides very extensive error checking. \nIt
+        is compatible with both Python 2 and Python 3.\n","description_content_type":null,"docs_url":null,"download_url":"","downloads":{"last_day":-1,"last_month":-1,"last_week":-1},"home_page":"http://www.dabeaz.com/ply/","keywords":"","license":"BSD","maintainer":"","maintainer_email":"","name":"ply","package_url":"https://pypi.org/project/ply/","platform":"","project_url":"https://pypi.org/project/ply/","project_urls":{"Homepage":"http://www.dabeaz.com/ply/"},"release_url":"https://pypi.org/project/ply/3.11/","requires_dist":null,"requires_python":"","summary":"Python
+        Lex & Yacc","version":"3.11","yanked":false,"yanked_reason":null},"last_serial":3585324,"releases":{"1.6":[],"1.8":[],"2.0":[],"2.1":[],"2.2":[],"2.4":[],"2.5":[],"3.1":[],"3.10":[{"comment_text":"","digests":{"blake2b_256":"ce3d1f9ca69192025046f02a02ffc61bfbac2731aab06325a218370fd93e18df","md5":"1d63c166ab250bab87d8dcc42dcca70e","sha256":"96e94af7dd7031d8d6dd6e2a8e0de593b511c211a86e28a9c9621c275ac8bacb"},"downloads":-1,"filename":"ply-3.10.tar.gz","has_sig":false,"md5_digest":"1d63c166ab250bab87d8dcc42dcca70e","packagetype":"sdist","python_version":"source","requires_python":null,"size":150926,"upload_time":"2017-01-31T18:38:34","upload_time_iso_8601":"2017-01-31T18:38:34.244161Z","url":"https://files.pythonhosted.org/packages/ce/3d/1f9ca69192025046f02a02ffc61bfbac2731aab06325a218370fd93e18df/ply-3.10.tar.gz","yanked":false,"yanked_reason":null}],"3.11":[{"comment_text":"","digests":{"blake2b_256":"a35835da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc","md5":"62b6ad5affddc9926ab5571f390cc840","sha256":"096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"},"downloads":-1,"filename":"ply-3.11-py2.py3-none-any.whl","has_sig":false,"md5_digest":"62b6ad5affddc9926ab5571f390cc840","packagetype":"bdist_wheel","python_version":"3.6","requires_python":null,"size":49567,"upload_time":"2018-02-15T19:01:27","upload_time_iso_8601":"2018-02-15T19:01:27.172483Z","url":"https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl","yanked":false,"yanked_reason":null},{"comment_text":"","digests":{"blake2b_256":"e569882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da","md5":"6465f602e656455affcd7c5734c638f8","sha256":"00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},"downloads":-1,"filename":"ply-3.11.tar.gz","has_sig":false,"md5_digest":"6465f602e656455affcd7c5734c638f8","packagetype":"sdist","python_version":"source","requires_python":null,"size":159130,"upload_time":"2018-02-15T19:01:31","upload_time_iso_8601":"2018-02-15T19:01:31.097641Z","url":"https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz","yanked":false,"yanked_reason":null}],"3.3":[],"3.4":[{"comment_text":"","digests":{"blake2b_256":"407d95a7a67fb4c2205d0cbf89e8fabb7b49b4ed812ffdab45510d124bc2bd7e","md5":"ffdc95858819347bf92d7c2acc074894","sha256":"af435f11b7bdd69da5ffbc3fecb8d70a7073ec952e101764c88720cdefb2546b"},"downloads":-1,"filename":"ply-3.4.tar.gz","has_sig":false,"md5_digest":"ffdc95858819347bf92d7c2acc074894","packagetype":"sdist","python_version":"source","requires_python":null,"size":138342,"upload_time":"2012-04-18T14:24:41","upload_time_iso_8601":"2012-04-18T14:24:41.501674Z","url":"https://files.pythonhosted.org/packages/40/7d/95a7a67fb4c2205d0cbf89e8fabb7b49b4ed812ffdab45510d124bc2bd7e/ply-3.4.tar.gz","yanked":false,"yanked_reason":null}],"3.6":[{"comment_text":"","digests":{"blake2b_256":"7fea6aff5b67ddb00d38fa6498df2010b50529700621353d38ac29d25ddb0845","md5":"7aa0e8749d2377a863f477a7d67524d2","sha256":"61367b9eb2f4b819f69ea116750305270f1df8859992c9e356d6a851f25a4b47"},"downloads":-1,"filename":"ply-3.6.tar.gz","has_sig":false,"md5_digest":"7aa0e8749d2377a863f477a7d67524d2","packagetype":"sdist","python_version":"source","requires_python":null,"size":281690,"upload_time":"2015-04-26T21:52:41","upload_time_iso_8601":"2015-04-26T21:52:41.113750Z","url":"https://files.pythonhosted.org/packages/7f/ea/6aff5b67ddb00d38fa6498df2010b50529700621353d38ac29d25ddb0845/ply-3.6.tar.gz","yanked":false,"yanked_reason":null}],"3.8":[{"comment_text":"","digests":{"blake2b_256":"96e0430fcdb6b3ef1ae534d231397bee7e9304be14a47a267e82ebcb3323d0b5","md5":"94726411496c52c87c2b9429b12d5c50","sha256":"e7d1bdff026beb159c9942f7a17e102c375638d9478a7ecd4cc0c76afd8de0b8"},"downloads":-1,"filename":"ply-3.8.tar.gz","has_sig":false,"md5_digest":"94726411496c52c87c2b9429b12d5c50","packagetype":"sdist","python_version":"source","requires_python":null,"size":157286,"upload_time":"2015-10-02T18:15:50","upload_time_iso_8601":"2015-10-02T18:15:50.150715Z","url":"https://files.pythonhosted.org/packages/96/e0/430fcdb6b3ef1ae534d231397bee7e9304be14a47a267e82ebcb3323d0b5/ply-3.8.tar.gz","yanked":false,"yanked_reason":null}],"3.9":[{"comment_text":"","digests":{"blake2b_256":"a84d487e12d0478ee0cbb15d6fe9b8916e98fe4e2fce4cc65e4de309209c0b24","md5":"c5c5767376eff902617fd9874f0c76b7","sha256":"0d7e2940b9c57151392fceaa62b0865c45e06ce1e36687fd8d03f011a907f43e"},"downloads":-1,"filename":"ply-3.9.tar.gz","has_sig":false,"md5_digest":"c5c5767376eff902617fd9874f0c76b7","packagetype":"sdist","python_version":"source","requires_python":null,"size":150750,"upload_time":"2016-08-31T14:13:16","upload_time_iso_8601":"2016-08-31T14:13:16.696602Z","url":"https://files.pythonhosted.org/packages/a8/4d/487e12d0478ee0cbb15d6fe9b8916e98fe4e2fce4cc65e4de309209c0b24/ply-3.9.tar.gz","yanked":false,"yanked_reason":null}]},"urls":[{"comment_text":"","digests":{"blake2b_256":"a35835da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc","md5":"62b6ad5affddc9926ab5571f390cc840","sha256":"096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"},"downloads":-1,"filename":"ply-3.11-py2.py3-none-any.whl","has_sig":false,"md5_digest":"62b6ad5affddc9926ab5571f390cc840","packagetype":"bdist_wheel","python_version":"3.6","requires_python":null,"size":49567,"upload_time":"2018-02-15T19:01:27","upload_time_iso_8601":"2018-02-15T19:01:27.172483Z","url":"https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl","yanked":false,"yanked_reason":null},{"comment_text":"","digests":{"blake2b_256":"e569882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da","md5":"6465f602e656455affcd7c5734c638f8","sha256":"00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},"downloads":-1,"filename":"ply-3.11.tar.gz","has_sig":false,"md5_digest":"6465f602e656455affcd7c5734c638f8","packagetype":"sdist","python_version":"source","requires_python":null,"size":159130,"upload_time":"2018-02-15T19:01:31","upload_time_iso_8601":"2018-02-15T19:01:31.097641Z","url":"https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz","yanked":false,"yanked_reason":null}],"vulnerabilities":[]}
+
+        '
+    http_version:
+  recorded_at: Thu, 13 Jul 2023 18:46:38 GMT
+- request:
+    method: get
+    uri: https://pypi.org/rss/project/ply/releases.xml
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip,deflate,br
+      X-Datadog-Trace-Id:
+      - '3898702895515230605'
+      X-Datadog-Parent-Id:
+      - '573292198746483348'
+      X-Datadog-Sampling-Priority:
+      - '1'
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Security-Policy:
+      - base-uri 'self'; block-all-mixed-content; connect-src 'self' https://api.github.com/repos/
+        https://api.github.com/search/issues https://*.google-analytics.com https://*.analytics.google.com
+        https://*.googletagmanager.com fastly-insights.com *.fastly-insights.com *.ethicalads.io
+        https://api.pwnedpasswords.com https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/sre/mathmaps/
+        https://2p66nmmycsj3.statuspage.io; default-src 'none'; font-src 'self' fonts.gstatic.com;
+        form-action 'self' https://checkout.stripe.com; frame-ancestors 'none'; frame-src
+        'none'; img-src 'self' https://warehouse-camo.ingress.cmh1.psfhosted.org/
+        https://*.google-analytics.com https://*.googletagmanager.com *.fastly-insights.com
+        *.ethicalads.io; script-src 'self' https://*.googletagmanager.com https://www.google-analytics.com
+        https://ssl.google-analytics.com *.fastly-insights.com *.ethicalads.io 'sha256-U3hKDidudIaxBDEzwGJApJgPEf2mWk6cfMWghrAa6i0='
+        https://cdn.jsdelivr.net/npm/mathjax@3.2.2/ 'sha256-1CldwzdEg2k1wTmf7s5RWVd7NMXI/7nxxjJM2C4DqII='
+        'sha256-0POaN8stWYQxhzjKS+/eOfbbJ/u4YHO5ZagJvLpMypo='; style-src 'self' fonts.googleapis.com
+        *.ethicalads.io 'sha256-2YHqZokjiizkHi1Zt+6ar0XJ0OeEy/egBnlm+MDMtrM=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
+        'sha256-JLEjeN9e5dGsz5475WyRaoA4eQOdNPxDIeUhclnJDCE=' 'sha256-mQyxHEuwZJqpxCw3SLmc4YOySNKXunyu2Oiz1r3/wAE='
+        'sha256-OCf+kv5Asiwp++8PIevKBYSgnNLNUZvxAp4a7wMLuKA=' 'sha256-h5LOiLhk6wiJrGsG5ItM0KimwzWQH/yAcmoJDJL//bY='
+        'unsafe-inline'; worker-src *.fastly-insights.com
+      Content-Type:
+      - text/xml; charset=UTF-8
+      Etag:
+      - '"96kfGz/zFOzK+t+Ee9LK/A"'
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - nginx/1.13.9
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Thu, 13 Jul 2023 18:46:38 GMT
+      X-Served-By:
+      - cache-iad-kjyo7100132-IAD
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1689273998.094241,VS0,VE1
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Content-Length:
+      - '4163'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+          <channel>
+            <title>PyPI recent updates for ply</title>
+            <link>https://pypi.org/project/ply/</link>
+            <description>Recent updates to the Python Package Index for ply</description>
+            <language>en</language>
+            <item>
+              <title>3.11</title>
+              <link>https://pypi.org/project/ply/3.11/</link>
+              <description>Python Lex &amp; Yacc</description>
+              <author>dave@dabeaz.com</author>
+              <pubDate>Thu, 15 Feb 2018 19:01:27 GMT</pubDate>
+            </item>
+            <item>
+              <title>3.10</title>
+              <link>https://pypi.org/project/ply/3.10/</link>
+              <description>Python Lex &amp; Yacc</description>
+              <author>dave@dabeaz.com</author>
+              <pubDate>Tue, 31 Jan 2017 18:38:34 GMT</pubDate>
+            </item>
+            <item>
+              <title>3.9</title>
+              <link>https://pypi.org/project/ply/3.9/</link>
+              <description>Python Lex &amp; Yacc</description>
+              <author>dave@dabeaz.com</author>
+              <pubDate>Wed, 31 Aug 2016 14:12:50 GMT</pubDate>
+            </item>
+            <item>
+              <title>3.8</title>
+              <link>https://pypi.org/project/ply/3.8/</link>
+              <description>Python Lex &amp; Yacc</description>
+              <author>dave@dabeaz.com</author>
+              <pubDate>Fri, 02 Oct 2015 18:15:10 GMT</pubDate>
+            </item>
+            <item>
+              <title>3.6</title>
+              <link>https://pypi.org/project/ply/3.6/</link>
+              <description>Python Lex &amp; Yacc</description>
+              <author>dave@dabeaz.com</author>
+              <pubDate>Sun, 26 Apr 2015 21:50:53 GMT</pubDate>
+            </item>
+            <item>
+              <title>3.4</title>
+              <link>https://pypi.org/project/ply/3.4/</link>
+              <description>Python Lex &amp; Yacc</description>
+              <author>dave@dabeaz.com</author>
+              <pubDate>Fri, 18 Feb 2011 04:14:18 GMT</pubDate>
+            </item>
+            <item>
+              <title>3.3</title>
+              <link>https://pypi.org/project/ply/3.3/</link>
+              <description>Python Lex &amp; Yacc</description>
+              <author>dave@dabeaz.com</author>
+              <pubDate>Sun, 11 Oct 2009 18:54:08 GMT</pubDate>
+            </item>
+            <item>
+              <title>3.1</title>
+              <link>https://pypi.org/project/ply/3.1/</link>
+              <description>Python Lex &amp; Yacc</description>
+              <author>dave@dabeaz.com</author>
+              <pubDate>Sat, 28 Feb 2009 17:05:33 GMT</pubDate>
+            </item>
+            <item>
+              <title>2.5</title>
+              <link>https://pypi.org/project/ply/2.5/</link>
+              <description>Python Lex &amp; Yacc</description>
+              <author>dave@dabeaz.com</author>
+              <pubDate>Wed, 28 May 2008 21:47:49 GMT</pubDate>
+            </item>
+            <item>
+              <title>2.4</title>
+              <link>https://pypi.org/project/ply/2.4/</link>
+              <description>Python Lex &amp; Yacc</description>
+              <author>dave@dabeaz.com</author>
+              <pubDate>Tue, 27 May 2008 22:56:47 GMT</pubDate>
+            </item>
+            <item>
+              <title>2.2</title>
+              <link>https://pypi.org/project/ply/2.2/</link>
+              <description>A pure-Python implementation of lex and yacc</description>
+              <author>dave@dabeaz.com</author>
+              <pubDate>Thu, 02 Nov 2006 00:27:35 GMT</pubDate>
+            </item>
+            <item>
+              <title>2.1</title>
+              <link>https://pypi.org/project/ply/2.1/</link>
+              <description>A pure-Python implementation of lex and yacc</description>
+              <author>dave@dabeaz.com</author>
+              <pubDate>Wed, 04 Oct 2006 16:01:11 GMT</pubDate>
+            </item>
+            <item>
+              <title>2.0</title>
+              <link>https://pypi.org/project/ply/2.0/</link>
+              <description>A pure-Python implementation of lex and yacc</description>
+              <author>dave@dabeaz.com</author>
+              <pubDate>Fri, 08 Sep 2006 20:29:24 GMT</pubDate>
+            </item>
+            <item>
+              <title>1.8</title>
+              <link>https://pypi.org/project/ply/1.8/</link>
+              <description>A pure-Python implementation of lex and yacc</description>
+              <author>dave@dabeaz.com</author>
+              <pubDate>Thu, 03 Aug 2006 03:53:19 GMT</pubDate>
+            </item>
+            <item>
+              <title>1.6</title>
+              <link>https://pypi.org/project/ply/1.6/</link>
+              <description>A pure-Python implementation of lex and yacc</description>
+              <author>dave@dabeaz.com</author>
+              <pubDate>Sun, 26 Feb 2006 16:36:49 GMT</pubDate>
+            </item>
+          </channel>
+        </rss>
+    http_version:
+  recorded_at: Thu, 13 Jul 2023 18:46:38 GMT
+- request:
+    method: get
+    uri: https://pypi.org/pypi/ply/1.6/json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip,deflate,br
+      X-Datadog-Trace-Id:
+      - '2136064182527925583'
+      X-Datadog-Parent-Id:
+      - '814309512277651370'
+      X-Datadog-Sampling-Priority:
+      - '1'
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-PyPI-Last-Serial
+      Access-Control-Max-Age:
+      - '86400'
+      Cache-Control:
+      - max-age=900, public
+      Content-Security-Policy:
+      - base-uri 'self'; block-all-mixed-content; connect-src 'self' https://api.github.com/repos/
+        https://api.github.com/search/issues https://*.google-analytics.com https://*.analytics.google.com
+        https://*.googletagmanager.com fastly-insights.com *.fastly-insights.com *.ethicalads.io
+        https://api.pwnedpasswords.com https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/sre/mathmaps/
+        https://2p66nmmycsj3.statuspage.io; default-src 'none'; font-src 'self' fonts.gstatic.com;
+        form-action 'self' https://checkout.stripe.com; frame-ancestors 'none'; frame-src
+        'none'; img-src 'self' https://warehouse-camo.ingress.cmh1.psfhosted.org/
+        https://*.google-analytics.com https://*.googletagmanager.com *.fastly-insights.com
+        *.ethicalads.io; script-src 'self' https://*.googletagmanager.com https://www.google-analytics.com
+        https://ssl.google-analytics.com *.fastly-insights.com *.ethicalads.io 'sha256-U3hKDidudIaxBDEzwGJApJgPEf2mWk6cfMWghrAa6i0='
+        https://cdn.jsdelivr.net/npm/mathjax@3.2.2/ 'sha256-1CldwzdEg2k1wTmf7s5RWVd7NMXI/7nxxjJM2C4DqII='
+        'sha256-0POaN8stWYQxhzjKS+/eOfbbJ/u4YHO5ZagJvLpMypo='; style-src 'self' fonts.googleapis.com
+        *.ethicalads.io 'sha256-2YHqZokjiizkHi1Zt+6ar0XJ0OeEy/egBnlm+MDMtrM=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
+        'sha256-JLEjeN9e5dGsz5475WyRaoA4eQOdNPxDIeUhclnJDCE=' 'sha256-mQyxHEuwZJqpxCw3SLmc4YOySNKXunyu2Oiz1r3/wAE='
+        'sha256-OCf+kv5Asiwp++8PIevKBYSgnNLNUZvxAp4a7wMLuKA=' 'sha256-h5LOiLhk6wiJrGsG5ItM0KimwzWQH/yAcmoJDJL//bY=';
+        worker-src *.fastly-insights.com
+      Content-Type:
+      - application/json
+      Etag:
+      - '"yDvj8Re3adHOpGik4LhHOg"'
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - nginx/1.13.9
+      X-Pypi-Last-Serial:
+      - '3585324'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Thu, 13 Jul 2023 18:46:38 GMT
+      X-Served-By:
+      - cache-iad-kjyo7100132-IAD
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1689273998.130221,VS0,VE2
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Content-Length:
+      - '1064'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"info":{"author":"David Beazley","author_email":"dave@dabeaz.com","bugtrack_url":null,"classifiers":["Development
+        Status :: 5 - Production/Stable"],"description":"PLY is a Python implementation
+        of the lex and yacc parsing tools.   PLY supports SLR and LALR(1) \r\nparsing.  It
+        also provides extensive error checking and diagnostics.","description_content_type":null,"docs_url":null,"download_url":"","downloads":{"last_day":-1,"last_month":-1,"last_week":-1},"home_page":"http://www.dabeaz.com/ply/","keywords":"Parsing,
+        compilers, lex, yacc","license":"LGPL","maintainer":"David Beazley","maintainer_email":"dave@dabeaz.com","name":"ply","package_url":"https://pypi.org/project/ply/","platform":"All","project_url":"https://pypi.org/project/ply/","project_urls":{"Homepage":"http://www.dabeaz.com/ply/"},"release_url":"https://pypi.org/project/ply/1.6/","requires_dist":null,"requires_python":null,"summary":"A
+        pure-Python implementation of lex and yacc","version":"1.6","yanked":false,"yanked_reason":null},"last_serial":3585324,"urls":[],"vulnerabilities":[]}
+
+        '
+    http_version:
+  recorded_at: Thu, 13 Jul 2023 18:46:38 GMT
+- request:
+    method: get
+    uri: https://pypi.org/pypi/ply/1.8/json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip,deflate,br
+      X-Datadog-Trace-Id:
+      - '666956529384188167'
+      X-Datadog-Parent-Id:
+      - '3081711730185770960'
+      X-Datadog-Sampling-Priority:
+      - '1'
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-PyPI-Last-Serial
+      Access-Control-Max-Age:
+      - '86400'
+      Cache-Control:
+      - max-age=900, public
+      Content-Security-Policy:
+      - base-uri 'self'; block-all-mixed-content; connect-src 'self' https://api.github.com/repos/
+        https://api.github.com/search/issues https://*.google-analytics.com https://*.analytics.google.com
+        https://*.googletagmanager.com fastly-insights.com *.fastly-insights.com *.ethicalads.io
+        https://api.pwnedpasswords.com https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/sre/mathmaps/
+        https://2p66nmmycsj3.statuspage.io; default-src 'none'; font-src 'self' fonts.gstatic.com;
+        form-action 'self' https://checkout.stripe.com; frame-ancestors 'none'; frame-src
+        'none'; img-src 'self' https://warehouse-camo.ingress.cmh1.psfhosted.org/
+        https://*.google-analytics.com https://*.googletagmanager.com *.fastly-insights.com
+        *.ethicalads.io; script-src 'self' https://*.googletagmanager.com https://www.google-analytics.com
+        https://ssl.google-analytics.com *.fastly-insights.com *.ethicalads.io 'sha256-U3hKDidudIaxBDEzwGJApJgPEf2mWk6cfMWghrAa6i0='
+        https://cdn.jsdelivr.net/npm/mathjax@3.2.2/ 'sha256-1CldwzdEg2k1wTmf7s5RWVd7NMXI/7nxxjJM2C4DqII='
+        'sha256-0POaN8stWYQxhzjKS+/eOfbbJ/u4YHO5ZagJvLpMypo='; style-src 'self' fonts.googleapis.com
+        *.ethicalads.io 'sha256-2YHqZokjiizkHi1Zt+6ar0XJ0OeEy/egBnlm+MDMtrM=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
+        'sha256-JLEjeN9e5dGsz5475WyRaoA4eQOdNPxDIeUhclnJDCE=' 'sha256-mQyxHEuwZJqpxCw3SLmc4YOySNKXunyu2Oiz1r3/wAE='
+        'sha256-OCf+kv5Asiwp++8PIevKBYSgnNLNUZvxAp4a7wMLuKA=' 'sha256-h5LOiLhk6wiJrGsG5ItM0KimwzWQH/yAcmoJDJL//bY=';
+        worker-src *.fastly-insights.com
+      Content-Type:
+      - application/json
+      Etag:
+      - '"SlXM6gxJmxh0NafNCTrmJg"'
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - nginx/1.13.9
+      X-Pypi-Last-Serial:
+      - '3585324'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Thu, 13 Jul 2023 18:46:38 GMT
+      X-Served-By:
+      - cache-iad-kjyo7100132-IAD
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1689273998.158494,VS0,VE1
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Content-Length:
+      - '1064'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"info":{"author":"David Beazley","author_email":"dave@dabeaz.com","bugtrack_url":null,"classifiers":["Development
+        Status :: 5 - Production/Stable"],"description":"PLY is a Python implementation
+        of the lex and yacc parsing tools.   PLY supports SLR and LALR(1) \r\nparsing.  It
+        also provides extensive error checking and diagnostics.","description_content_type":null,"docs_url":null,"download_url":"","downloads":{"last_day":-1,"last_month":-1,"last_week":-1},"home_page":"http://www.dabeaz.com/ply/","keywords":"Parsing,
+        compilers, lex, yacc","license":"LGPL","maintainer":"David Beazley","maintainer_email":"dave@dabeaz.com","name":"ply","package_url":"https://pypi.org/project/ply/","platform":"All","project_url":"https://pypi.org/project/ply/","project_urls":{"Homepage":"http://www.dabeaz.com/ply/"},"release_url":"https://pypi.org/project/ply/1.8/","requires_dist":null,"requires_python":null,"summary":"A
+        pure-Python implementation of lex and yacc","version":"1.8","yanked":false,"yanked_reason":null},"last_serial":3585324,"urls":[],"vulnerabilities":[]}
+
+        '
+    http_version:
+  recorded_at: Thu, 13 Jul 2023 18:46:38 GMT
+- request:
+    method: get
+    uri: https://pypi.org/pypi/ply/2.0/json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip,deflate,br
+      X-Datadog-Trace-Id:
+      - '1513219969209400977'
+      X-Datadog-Parent-Id:
+      - '4597656873856845508'
+      X-Datadog-Sampling-Priority:
+      - '1'
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-PyPI-Last-Serial
+      Access-Control-Max-Age:
+      - '86400'
+      Cache-Control:
+      - max-age=900, public
+      Content-Security-Policy:
+      - base-uri 'self'; block-all-mixed-content; connect-src 'self' https://api.github.com/repos/
+        https://api.github.com/search/issues https://*.google-analytics.com https://*.analytics.google.com
+        https://*.googletagmanager.com fastly-insights.com *.fastly-insights.com *.ethicalads.io
+        https://api.pwnedpasswords.com https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/sre/mathmaps/
+        https://2p66nmmycsj3.statuspage.io; default-src 'none'; font-src 'self' fonts.gstatic.com;
+        form-action 'self' https://checkout.stripe.com; frame-ancestors 'none'; frame-src
+        'none'; img-src 'self' https://warehouse-camo.ingress.cmh1.psfhosted.org/
+        https://*.google-analytics.com https://*.googletagmanager.com *.fastly-insights.com
+        *.ethicalads.io; script-src 'self' https://*.googletagmanager.com https://www.google-analytics.com
+        https://ssl.google-analytics.com *.fastly-insights.com *.ethicalads.io 'sha256-U3hKDidudIaxBDEzwGJApJgPEf2mWk6cfMWghrAa6i0='
+        https://cdn.jsdelivr.net/npm/mathjax@3.2.2/ 'sha256-1CldwzdEg2k1wTmf7s5RWVd7NMXI/7nxxjJM2C4DqII='
+        'sha256-0POaN8stWYQxhzjKS+/eOfbbJ/u4YHO5ZagJvLpMypo='; style-src 'self' fonts.googleapis.com
+        *.ethicalads.io 'sha256-2YHqZokjiizkHi1Zt+6ar0XJ0OeEy/egBnlm+MDMtrM=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
+        'sha256-JLEjeN9e5dGsz5475WyRaoA4eQOdNPxDIeUhclnJDCE=' 'sha256-mQyxHEuwZJqpxCw3SLmc4YOySNKXunyu2Oiz1r3/wAE='
+        'sha256-OCf+kv5Asiwp++8PIevKBYSgnNLNUZvxAp4a7wMLuKA=' 'sha256-h5LOiLhk6wiJrGsG5ItM0KimwzWQH/yAcmoJDJL//bY=';
+        worker-src *.fastly-insights.com
+      Content-Type:
+      - application/json
+      Etag:
+      - '"oBzOH7KbjEn46fb/8341yg"'
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - nginx/1.13.9
+      X-Pypi-Last-Serial:
+      - '3585324'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Thu, 13 Jul 2023 18:46:38 GMT
+      X-Served-By:
+      - cache-iad-kjyo7100132-IAD
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1689273998.182229,VS0,VE1
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Content-Length:
+      - '1158'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"info":{"author":"David Beazley","author_email":"dave@dabeaz.com","bugtrack_url":null,"classifiers":["Development
+        Status :: 5 - Production/Stable"],"description":"PLY is a Python implementation
+        of the lex and yacc parsing tools.   PLY supports SLR and LALR(1) \r\nparsing.  It
+        also provides extensive error checking and diagnostics.","description_content_type":null,"docs_url":null,"download_url":"http://www.dabeaz.com/ply/ply-2.0.tar.gz","downloads":{"last_day":-1,"last_month":-1,"last_week":-1},"home_page":"http://www.dabeaz.com/ply/","keywords":"Parsing,
+        compilers, lex, yacc","license":"LGPL","maintainer":"David Beazley","maintainer_email":"dave@dabeaz.com","name":"ply","package_url":"https://pypi.org/project/ply/","platform":"All","project_url":"https://pypi.org/project/ply/","project_urls":{"Download":"http://www.dabeaz.com/ply/ply-2.0.tar.gz","Homepage":"http://www.dabeaz.com/ply/"},"release_url":"https://pypi.org/project/ply/2.0/","requires_dist":null,"requires_python":null,"summary":"A
+        pure-Python implementation of lex and yacc","version":"2.0","yanked":false,"yanked_reason":null},"last_serial":3585324,"urls":[],"vulnerabilities":[]}
+
+        '
+    http_version:
+  recorded_at: Thu, 13 Jul 2023 18:46:38 GMT
+- request:
+    method: get
+    uri: https://pypi.org/pypi/ply/2.1/json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip,deflate,br
+      X-Datadog-Trace-Id:
+      - '495289607426642186'
+      X-Datadog-Parent-Id:
+      - '35292421075373743'
+      X-Datadog-Sampling-Priority:
+      - '1'
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-PyPI-Last-Serial
+      Access-Control-Max-Age:
+      - '86400'
+      Cache-Control:
+      - max-age=900, public
+      Content-Security-Policy:
+      - base-uri 'self'; block-all-mixed-content; connect-src 'self' https://api.github.com/repos/
+        https://api.github.com/search/issues https://*.google-analytics.com https://*.analytics.google.com
+        https://*.googletagmanager.com fastly-insights.com *.fastly-insights.com *.ethicalads.io
+        https://api.pwnedpasswords.com https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/sre/mathmaps/
+        https://2p66nmmycsj3.statuspage.io; default-src 'none'; font-src 'self' fonts.gstatic.com;
+        form-action 'self' https://checkout.stripe.com; frame-ancestors 'none'; frame-src
+        'none'; img-src 'self' https://warehouse-camo.ingress.cmh1.psfhosted.org/
+        https://*.google-analytics.com https://*.googletagmanager.com *.fastly-insights.com
+        *.ethicalads.io; script-src 'self' https://*.googletagmanager.com https://www.google-analytics.com
+        https://ssl.google-analytics.com *.fastly-insights.com *.ethicalads.io 'sha256-U3hKDidudIaxBDEzwGJApJgPEf2mWk6cfMWghrAa6i0='
+        https://cdn.jsdelivr.net/npm/mathjax@3.2.2/ 'sha256-1CldwzdEg2k1wTmf7s5RWVd7NMXI/7nxxjJM2C4DqII='
+        'sha256-0POaN8stWYQxhzjKS+/eOfbbJ/u4YHO5ZagJvLpMypo='; style-src 'self' fonts.googleapis.com
+        *.ethicalads.io 'sha256-2YHqZokjiizkHi1Zt+6ar0XJ0OeEy/egBnlm+MDMtrM=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
+        'sha256-JLEjeN9e5dGsz5475WyRaoA4eQOdNPxDIeUhclnJDCE=' 'sha256-mQyxHEuwZJqpxCw3SLmc4YOySNKXunyu2Oiz1r3/wAE='
+        'sha256-OCf+kv5Asiwp++8PIevKBYSgnNLNUZvxAp4a7wMLuKA=' 'sha256-h5LOiLhk6wiJrGsG5ItM0KimwzWQH/yAcmoJDJL//bY=';
+        worker-src *.fastly-insights.com
+      Content-Type:
+      - application/json
+      Etag:
+      - '"0yoitF0II6mt5zTLgXmBiA"'
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - nginx/1.13.9
+      X-Pypi-Last-Serial:
+      - '3585324'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Thu, 13 Jul 2023 18:46:38 GMT
+      X-Served-By:
+      - cache-iad-kjyo7100132-IAD
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1689273998.207108,VS0,VE1
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Content-Length:
+      - '1158'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"info":{"author":"David Beazley","author_email":"dave@dabeaz.com","bugtrack_url":null,"classifiers":["Development
+        Status :: 5 - Production/Stable"],"description":"PLY is a Python implementation
+        of the lex and yacc parsing tools.   PLY supports SLR and LALR(1) \r\nparsing.  It
+        also provides extensive error checking and diagnostics.","description_content_type":null,"docs_url":null,"download_url":"http://www.dabeaz.com/ply/ply-2.1.tar.gz","downloads":{"last_day":-1,"last_month":-1,"last_week":-1},"home_page":"http://www.dabeaz.com/ply/","keywords":"Parsing,
+        compilers, lex, yacc","license":"LGPL","maintainer":"David Beazley","maintainer_email":"dave@dabeaz.com","name":"ply","package_url":"https://pypi.org/project/ply/","platform":"All","project_url":"https://pypi.org/project/ply/","project_urls":{"Download":"http://www.dabeaz.com/ply/ply-2.1.tar.gz","Homepage":"http://www.dabeaz.com/ply/"},"release_url":"https://pypi.org/project/ply/2.1/","requires_dist":null,"requires_python":null,"summary":"A
+        pure-Python implementation of lex and yacc","version":"2.1","yanked":false,"yanked_reason":null},"last_serial":3585324,"urls":[],"vulnerabilities":[]}
+
+        '
+    http_version:
+  recorded_at: Thu, 13 Jul 2023 18:46:38 GMT
+- request:
+    method: get
+    uri: https://pypi.org/pypi/ply/2.2/json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip,deflate,br
+      X-Datadog-Trace-Id:
+      - '1096665521477112580'
+      X-Datadog-Parent-Id:
+      - '3127554862781154016'
+      X-Datadog-Sampling-Priority:
+      - '1'
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-PyPI-Last-Serial
+      Access-Control-Max-Age:
+      - '86400'
+      Cache-Control:
+      - max-age=900, public
+      Content-Security-Policy:
+      - base-uri 'self'; block-all-mixed-content; connect-src 'self' https://api.github.com/repos/
+        https://api.github.com/search/issues https://*.google-analytics.com https://*.analytics.google.com
+        https://*.googletagmanager.com fastly-insights.com *.fastly-insights.com *.ethicalads.io
+        https://api.pwnedpasswords.com https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/sre/mathmaps/
+        https://2p66nmmycsj3.statuspage.io; default-src 'none'; font-src 'self' fonts.gstatic.com;
+        form-action 'self' https://checkout.stripe.com; frame-ancestors 'none'; frame-src
+        'none'; img-src 'self' https://warehouse-camo.ingress.cmh1.psfhosted.org/
+        https://*.google-analytics.com https://*.googletagmanager.com *.fastly-insights.com
+        *.ethicalads.io; script-src 'self' https://*.googletagmanager.com https://www.google-analytics.com
+        https://ssl.google-analytics.com *.fastly-insights.com *.ethicalads.io 'sha256-U3hKDidudIaxBDEzwGJApJgPEf2mWk6cfMWghrAa6i0='
+        https://cdn.jsdelivr.net/npm/mathjax@3.2.2/ 'sha256-1CldwzdEg2k1wTmf7s5RWVd7NMXI/7nxxjJM2C4DqII='
+        'sha256-0POaN8stWYQxhzjKS+/eOfbbJ/u4YHO5ZagJvLpMypo='; style-src 'self' fonts.googleapis.com
+        *.ethicalads.io 'sha256-2YHqZokjiizkHi1Zt+6ar0XJ0OeEy/egBnlm+MDMtrM=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
+        'sha256-JLEjeN9e5dGsz5475WyRaoA4eQOdNPxDIeUhclnJDCE=' 'sha256-mQyxHEuwZJqpxCw3SLmc4YOySNKXunyu2Oiz1r3/wAE='
+        'sha256-OCf+kv5Asiwp++8PIevKBYSgnNLNUZvxAp4a7wMLuKA=' 'sha256-h5LOiLhk6wiJrGsG5ItM0KimwzWQH/yAcmoJDJL//bY=';
+        worker-src *.fastly-insights.com
+      Content-Type:
+      - application/json
+      Etag:
+      - '"UVdBIxyvs+fEktBynAOoGg"'
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - nginx/1.13.9
+      X-Pypi-Last-Serial:
+      - '3585324'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Thu, 13 Jul 2023 18:46:38 GMT
+      X-Served-By:
+      - cache-iad-kjyo7100132-IAD
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1689273998.238116,VS0,VE26
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Content-Length:
+      - '1161'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"info":{"author":"David Beazley","author_email":"dave@dabeaz.com","bugtrack_url":null,"classifiers":["Development
+        Status :: 5 - Production/Stable"],"description":"PLY is a Python implementation
+        of the lex and yacc parsing tools.   PLY supports\r\nSLR and LALR(1) \r\nparsing.  It
+        also provides extensive error checking and diagnostics.","description_content_type":null,"docs_url":null,"download_url":"http://www.dabeaz.com/ply/ply-2.2.tar.gz","downloads":{"last_day":-1,"last_month":-1,"last_week":-1},"home_page":"http://www.dabeaz.com/ply/","keywords":"Parsing,
+        compilers, lex, yacc","license":"LGPL","maintainer":"David Beazley","maintainer_email":"dave@dabeaz.com","name":"ply","package_url":"https://pypi.org/project/ply/","platform":"All","project_url":"https://pypi.org/project/ply/","project_urls":{"Download":"http://www.dabeaz.com/ply/ply-2.2.tar.gz","Homepage":"http://www.dabeaz.com/ply/"},"release_url":"https://pypi.org/project/ply/2.2/","requires_dist":null,"requires_python":null,"summary":"A
+        pure-Python implementation of lex and yacc","version":"2.2","yanked":false,"yanked_reason":null},"last_serial":3585324,"urls":[],"vulnerabilities":[]}
+
+        '
+    http_version:
+  recorded_at: Thu, 13 Jul 2023 18:46:38 GMT
+- request:
+    method: get
+    uri: https://pypi.org/pypi/ply/2.4/json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip,deflate,br
+      X-Datadog-Trace-Id:
+      - '739571111556772911'
+      X-Datadog-Parent-Id:
+      - '2214508804674660630'
+      X-Datadog-Sampling-Priority:
+      - '1'
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-PyPI-Last-Serial
+      Access-Control-Max-Age:
+      - '86400'
+      Cache-Control:
+      - max-age=900, public
+      Content-Security-Policy:
+      - base-uri 'self'; block-all-mixed-content; connect-src 'self' https://api.github.com/repos/
+        https://api.github.com/search/issues https://*.google-analytics.com https://*.analytics.google.com
+        https://*.googletagmanager.com fastly-insights.com *.fastly-insights.com *.ethicalads.io
+        https://api.pwnedpasswords.com https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/sre/mathmaps/
+        https://2p66nmmycsj3.statuspage.io; default-src 'none'; font-src 'self' fonts.gstatic.com;
+        form-action 'self' https://checkout.stripe.com; frame-ancestors 'none'; frame-src
+        'none'; img-src 'self' https://warehouse-camo.ingress.cmh1.psfhosted.org/
+        https://*.google-analytics.com https://*.googletagmanager.com *.fastly-insights.com
+        *.ethicalads.io; script-src 'self' https://*.googletagmanager.com https://www.google-analytics.com
+        https://ssl.google-analytics.com *.fastly-insights.com *.ethicalads.io 'sha256-U3hKDidudIaxBDEzwGJApJgPEf2mWk6cfMWghrAa6i0='
+        https://cdn.jsdelivr.net/npm/mathjax@3.2.2/ 'sha256-1CldwzdEg2k1wTmf7s5RWVd7NMXI/7nxxjJM2C4DqII='
+        'sha256-0POaN8stWYQxhzjKS+/eOfbbJ/u4YHO5ZagJvLpMypo='; style-src 'self' fonts.googleapis.com
+        *.ethicalads.io 'sha256-2YHqZokjiizkHi1Zt+6ar0XJ0OeEy/egBnlm+MDMtrM=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
+        'sha256-JLEjeN9e5dGsz5475WyRaoA4eQOdNPxDIeUhclnJDCE=' 'sha256-mQyxHEuwZJqpxCw3SLmc4YOySNKXunyu2Oiz1r3/wAE='
+        'sha256-OCf+kv5Asiwp++8PIevKBYSgnNLNUZvxAp4a7wMLuKA=' 'sha256-h5LOiLhk6wiJrGsG5ItM0KimwzWQH/yAcmoJDJL//bY=';
+        worker-src *.fastly-insights.com
+      Content-Type:
+      - application/json
+      Etag:
+      - '"DBiptevwjVilfYKhHplX0A"'
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - nginx/1.13.9
+      X-Pypi-Last-Serial:
+      - '3585324'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Thu, 13 Jul 2023 18:46:38 GMT
+      X-Served-By:
+      - cache-iad-kjyo7100132-IAD
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1689273998.300451,VS0,VE1
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Content-Length:
+      - '1101'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"info":{"author":"David Beazley","author_email":"dave@dabeaz.com","bugtrack_url":null,"classifiers":["Topic
+        :: Software Development :: Compilers"],"description":"PLY is an  implementation
+        of lex and yacc for Python.    It supports LALR(1) and SLR parsing and supports
+        \r\nmost lex/yacc features.","description_content_type":null,"docs_url":null,"download_url":"http://www.dabeaz.com/ply/ply-2.4.tar.gz","downloads":{"last_day":-1,"last_month":-1,"last_week":-1},"home_page":"http://www.dabeaz.com/ply/","keywords":"","license":"Lesser
+        GPL (LGPL)","maintainer":"David Beazley","maintainer_email":"dave@dabeaz.com","name":"ply","package_url":"https://pypi.org/project/ply/","platform":"Python,
+        Jython, IronPython","project_url":"https://pypi.org/project/ply/","project_urls":{"Download":"http://www.dabeaz.com/ply/ply-2.4.tar.gz","Homepage":"http://www.dabeaz.com/ply/"},"release_url":"https://pypi.org/project/ply/2.4/","requires_dist":null,"requires_python":null,"summary":"Python
+        Lex & Yacc","version":"2.4","yanked":false,"yanked_reason":null},"last_serial":3585324,"urls":[],"vulnerabilities":[]}
+
+        '
+    http_version:
+  recorded_at: Thu, 13 Jul 2023 18:46:38 GMT
+- request:
+    method: get
+    uri: https://pypi.org/pypi/ply/2.5/json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip,deflate,br
+      X-Datadog-Trace-Id:
+      - '3464104099808784986'
+      X-Datadog-Parent-Id:
+      - '2606090586353510756'
+      X-Datadog-Sampling-Priority:
+      - '1'
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-PyPI-Last-Serial
+      Access-Control-Max-Age:
+      - '86400'
+      Cache-Control:
+      - max-age=900, public
+      Content-Security-Policy:
+      - base-uri 'self'; block-all-mixed-content; connect-src 'self' https://api.github.com/repos/
+        https://api.github.com/search/issues https://*.google-analytics.com https://*.analytics.google.com
+        https://*.googletagmanager.com fastly-insights.com *.fastly-insights.com *.ethicalads.io
+        https://api.pwnedpasswords.com https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/sre/mathmaps/
+        https://2p66nmmycsj3.statuspage.io; default-src 'none'; font-src 'self' fonts.gstatic.com;
+        form-action 'self' https://checkout.stripe.com; frame-ancestors 'none'; frame-src
+        'none'; img-src 'self' https://warehouse-camo.ingress.cmh1.psfhosted.org/
+        https://*.google-analytics.com https://*.googletagmanager.com *.fastly-insights.com
+        *.ethicalads.io; script-src 'self' https://*.googletagmanager.com https://www.google-analytics.com
+        https://ssl.google-analytics.com *.fastly-insights.com *.ethicalads.io 'sha256-U3hKDidudIaxBDEzwGJApJgPEf2mWk6cfMWghrAa6i0='
+        https://cdn.jsdelivr.net/npm/mathjax@3.2.2/ 'sha256-1CldwzdEg2k1wTmf7s5RWVd7NMXI/7nxxjJM2C4DqII='
+        'sha256-0POaN8stWYQxhzjKS+/eOfbbJ/u4YHO5ZagJvLpMypo='; style-src 'self' fonts.googleapis.com
+        *.ethicalads.io 'sha256-2YHqZokjiizkHi1Zt+6ar0XJ0OeEy/egBnlm+MDMtrM=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
+        'sha256-JLEjeN9e5dGsz5475WyRaoA4eQOdNPxDIeUhclnJDCE=' 'sha256-mQyxHEuwZJqpxCw3SLmc4YOySNKXunyu2Oiz1r3/wAE='
+        'sha256-OCf+kv5Asiwp++8PIevKBYSgnNLNUZvxAp4a7wMLuKA=' 'sha256-h5LOiLhk6wiJrGsG5ItM0KimwzWQH/yAcmoJDJL//bY=';
+        worker-src *.fastly-insights.com
+      Content-Type:
+      - application/json
+      Etag:
+      - '"4QNKu0PM3vpUkj5o0wJEnQ"'
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - nginx/1.13.9
+      X-Pypi-Last-Serial:
+      - '3585324'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Thu, 13 Jul 2023 18:46:38 GMT
+      X-Served-By:
+      - cache-iad-kjyo7100132-IAD
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1689273998.343224,VS0,VE2
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Content-Length:
+      - '1507'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"info":{"author":"David Beazley","author_email":"dave@dabeaz.com","bugtrack_url":null,"classifiers":["Topic
+        :: Software Development :: Compilers"],"description":"PLY is yet another implementation
+        of lex and yacc for Python. Although several other\r\nparsing tools are available
+        for Python, there are several reasons why you might\r\nwant to take a look
+        at PLY: \r\n\r\nIt''s implemented entirely in Python. \r\n\r\nIt uses LR-parsing
+        which is reasonably efficient and well suited for larger grammars. \r\n\r\nPLY
+        provides most of the standard lex/yacc features including support for empty
+        \r\nproductions, precedence rules, error recovery, and support for ambiguous
+        grammars. \r\n\r\nPLY is extremely easy to use and provides very extensive
+        error checking.","description_content_type":null,"docs_url":null,"download_url":"http://www.dabeaz.com/ply/ply-2.5.tar.gz","downloads":{"last_day":-1,"last_month":-1,"last_week":-1},"home_page":"http://www.dabeaz.com/ply/","keywords":"","license":"Lesser
+        GPL (LGPL)","maintainer":"","maintainer_email":"","name":"ply","package_url":"https://pypi.org/project/ply/","platform":"","project_url":"https://pypi.org/project/ply/","project_urls":{"Download":"http://www.dabeaz.com/ply/ply-2.5.tar.gz","Homepage":"http://www.dabeaz.com/ply/"},"release_url":"https://pypi.org/project/ply/2.5/","requires_dist":null,"requires_python":null,"summary":"Python
+        Lex & Yacc","version":"2.5","yanked":false,"yanked_reason":null},"last_serial":3585324,"urls":[],"vulnerabilities":[]}
+
+        '
+    http_version:
+  recorded_at: Thu, 13 Jul 2023 18:46:38 GMT
+- request:
+    method: get
+    uri: https://pypi.org/pypi/ply/3.1/json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip,deflate,br
+      X-Datadog-Trace-Id:
+      - '4341625274760723842'
+      X-Datadog-Parent-Id:
+      - '1090041514924297499'
+      X-Datadog-Sampling-Priority:
+      - '1'
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-PyPI-Last-Serial
+      Access-Control-Max-Age:
+      - '86400'
+      Cache-Control:
+      - max-age=900, public
+      Content-Security-Policy:
+      - base-uri 'self'; block-all-mixed-content; connect-src 'self' https://api.github.com/repos/
+        https://api.github.com/search/issues https://*.google-analytics.com https://*.analytics.google.com
+        https://*.googletagmanager.com fastly-insights.com *.fastly-insights.com *.ethicalads.io
+        https://api.pwnedpasswords.com https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/sre/mathmaps/
+        https://2p66nmmycsj3.statuspage.io; default-src 'none'; font-src 'self' fonts.gstatic.com;
+        form-action 'self' https://checkout.stripe.com; frame-ancestors 'none'; frame-src
+        'none'; img-src 'self' https://warehouse-camo.ingress.cmh1.psfhosted.org/
+        https://*.google-analytics.com https://*.googletagmanager.com *.fastly-insights.com
+        *.ethicalads.io; script-src 'self' https://*.googletagmanager.com https://www.google-analytics.com
+        https://ssl.google-analytics.com *.fastly-insights.com *.ethicalads.io 'sha256-U3hKDidudIaxBDEzwGJApJgPEf2mWk6cfMWghrAa6i0='
+        https://cdn.jsdelivr.net/npm/mathjax@3.2.2/ 'sha256-1CldwzdEg2k1wTmf7s5RWVd7NMXI/7nxxjJM2C4DqII='
+        'sha256-0POaN8stWYQxhzjKS+/eOfbbJ/u4YHO5ZagJvLpMypo='; style-src 'self' fonts.googleapis.com
+        *.ethicalads.io 'sha256-2YHqZokjiizkHi1Zt+6ar0XJ0OeEy/egBnlm+MDMtrM=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
+        'sha256-JLEjeN9e5dGsz5475WyRaoA4eQOdNPxDIeUhclnJDCE=' 'sha256-mQyxHEuwZJqpxCw3SLmc4YOySNKXunyu2Oiz1r3/wAE='
+        'sha256-OCf+kv5Asiwp++8PIevKBYSgnNLNUZvxAp4a7wMLuKA=' 'sha256-h5LOiLhk6wiJrGsG5ItM0KimwzWQH/yAcmoJDJL//bY=';
+        worker-src *.fastly-insights.com
+      Content-Type:
+      - application/json
+      Etag:
+      - '"qy9gobX30x0YhyTLVM8qrA"'
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - nginx/1.13.9
+      X-Pypi-Last-Serial:
+      - '3585324'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Thu, 13 Jul 2023 18:46:38 GMT
+      X-Served-By:
+      - cache-iad-kjyo7100132-IAD
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '58'
+      X-Timer:
+      - S1689273998.375542,VS0,VE0
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Content-Length:
+      - '1371'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"info":{"author":"David Beazley","author_email":"dave@dabeaz.com","bugtrack_url":null,"classifiers":["Programming
+        Language :: Python :: 2","Programming Language :: Python :: 3"],"description":"PLY
+        is yet another implementation of lex and yacc for Python. Some notable\r\nfeatures
+        include the fact that its implemented entirely in Python and it\r\nuses LALR(1)
+        parsing which is efficient and well suited for larger grammars.\r\n\r\nPLY
+        provides most of the standard lex/yacc features including support for empty
+        \r\nproductions, precedence rules, error recovery, and support for ambiguous
+        grammars. \r\n\r\nPLY is extremely easy to use and provides very extensive
+        error checking.","description_content_type":null,"docs_url":null,"download_url":"UNKNOWN","downloads":{"last_day":-1,"last_month":-1,"last_week":-1},"home_page":"http://www.dabeaz.com/ply/","keywords":"","license":"Lesser
+        GPL (LGPL)","maintainer":"","maintainer_email":"","name":"ply","package_url":"https://pypi.org/project/ply/","platform":"UNKNOWN","project_url":"https://pypi.org/project/ply/","project_urls":{"Download":"UNKNOWN","Homepage":"http://www.dabeaz.com/ply/"},"release_url":"https://pypi.org/project/ply/3.1/","requires_dist":null,"requires_python":null,"summary":"Python
+        Lex & Yacc","version":"3.1","yanked":false,"yanked_reason":null},"last_serial":3585324,"urls":[],"vulnerabilities":[]}
+
+        '
+    http_version:
+  recorded_at: Thu, 13 Jul 2023 18:46:38 GMT
+- request:
+    method: get
+    uri: https://pypi.org/pypi/ply/3.10/json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip,deflate,br
+      X-Datadog-Trace-Id:
+      - '3002457463684382484'
+      X-Datadog-Parent-Id:
+      - '1516487235195267416'
+      X-Datadog-Sampling-Priority:
+      - '1'
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-PyPI-Last-Serial
+      Access-Control-Max-Age:
+      - '86400'
+      Cache-Control:
+      - max-age=900, public
+      Content-Security-Policy:
+      - base-uri 'self'; block-all-mixed-content; connect-src 'self' https://api.github.com/repos/
+        https://api.github.com/search/issues https://*.google-analytics.com https://*.analytics.google.com
+        https://*.googletagmanager.com fastly-insights.com *.fastly-insights.com *.ethicalads.io
+        https://api.pwnedpasswords.com https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/sre/mathmaps/
+        https://2p66nmmycsj3.statuspage.io; default-src 'none'; font-src 'self' fonts.gstatic.com;
+        form-action 'self' https://checkout.stripe.com; frame-ancestors 'none'; frame-src
+        'none'; img-src 'self' https://warehouse-camo.ingress.cmh1.psfhosted.org/
+        https://*.google-analytics.com https://*.googletagmanager.com *.fastly-insights.com
+        *.ethicalads.io; script-src 'self' https://*.googletagmanager.com https://www.google-analytics.com
+        https://ssl.google-analytics.com *.fastly-insights.com *.ethicalads.io 'sha256-U3hKDidudIaxBDEzwGJApJgPEf2mWk6cfMWghrAa6i0='
+        https://cdn.jsdelivr.net/npm/mathjax@3.2.2/ 'sha256-1CldwzdEg2k1wTmf7s5RWVd7NMXI/7nxxjJM2C4DqII='
+        'sha256-0POaN8stWYQxhzjKS+/eOfbbJ/u4YHO5ZagJvLpMypo='; style-src 'self' fonts.googleapis.com
+        *.ethicalads.io 'sha256-2YHqZokjiizkHi1Zt+6ar0XJ0OeEy/egBnlm+MDMtrM=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
+        'sha256-JLEjeN9e5dGsz5475WyRaoA4eQOdNPxDIeUhclnJDCE=' 'sha256-mQyxHEuwZJqpxCw3SLmc4YOySNKXunyu2Oiz1r3/wAE='
+        'sha256-OCf+kv5Asiwp++8PIevKBYSgnNLNUZvxAp4a7wMLuKA=' 'sha256-h5LOiLhk6wiJrGsG5ItM0KimwzWQH/yAcmoJDJL//bY=';
+        worker-src *.fastly-insights.com
+      Content-Type:
+      - application/json
+      Etag:
+      - '"6LDY7QwvI1oz9a6FmsEv0w"'
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - nginx/1.13.9
+      X-Pypi-Last-Serial:
+      - '3585324'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Thu, 13 Jul 2023 18:46:38 GMT
+      X-Served-By:
+      - cache-iad-kjyo7100132-IAD
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1689273998.410303,VS0,VE2
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Content-Length:
+      - '2042'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"info":{"author":"David Beazley","author_email":"dave@dabeaz.com","bugtrack_url":null,"classifiers":["Programming
+        Language :: Python :: 2","Programming Language :: Python :: 3"],"description":"\nPLY
+        is yet another implementation of lex and yacc for Python. Some notable\nfeatures
+        include the fact that its implemented entirely in Python and it\nuses LALR(1)
+        parsing which is efficient and well suited for larger grammars.\n\nPLY provides
+        most of the standard lex/yacc features including support for empty \nproductions,
+        precedence rules, error recovery, and support for ambiguous grammars. \n\nPLY
+        is extremely easy to use and provides very extensive error checking. \nIt
+        is compatible with both Python 2 and Python 3.\n","description_content_type":null,"docs_url":null,"download_url":"","downloads":{"last_day":-1,"last_month":-1,"last_week":-1},"home_page":"http://www.dabeaz.com/ply/","keywords":"","license":"BSD","maintainer":"","maintainer_email":"","name":"ply","package_url":"https://pypi.org/project/ply/","platform":"","project_url":"https://pypi.org/project/ply/","project_urls":{"Homepage":"http://www.dabeaz.com/ply/"},"release_url":"https://pypi.org/project/ply/3.10/","requires_dist":null,"requires_python":"","summary":"Python
+        Lex & Yacc","version":"3.10","yanked":false,"yanked_reason":null},"last_serial":3585324,"urls":[{"comment_text":"","digests":{"blake2b_256":"ce3d1f9ca69192025046f02a02ffc61bfbac2731aab06325a218370fd93e18df","md5":"1d63c166ab250bab87d8dcc42dcca70e","sha256":"96e94af7dd7031d8d6dd6e2a8e0de593b511c211a86e28a9c9621c275ac8bacb"},"downloads":-1,"filename":"ply-3.10.tar.gz","has_sig":false,"md5_digest":"1d63c166ab250bab87d8dcc42dcca70e","packagetype":"sdist","python_version":"source","requires_python":null,"size":150926,"upload_time":"2017-01-31T18:38:34","upload_time_iso_8601":"2017-01-31T18:38:34.244161Z","url":"https://files.pythonhosted.org/packages/ce/3d/1f9ca69192025046f02a02ffc61bfbac2731aab06325a218370fd93e18df/ply-3.10.tar.gz","yanked":false,"yanked_reason":null}],"vulnerabilities":[]}
+
+        '
+    http_version:
+  recorded_at: Thu, 13 Jul 2023 18:46:38 GMT
+- request:
+    method: get
+    uri: https://pypi.org/pypi/ply/3.11/json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip,deflate,br
+      X-Datadog-Trace-Id:
+      - '640783424692519917'
+      X-Datadog-Parent-Id:
+      - '1959168001042995796'
+      X-Datadog-Sampling-Priority:
+      - '1'
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-PyPI-Last-Serial
+      Access-Control-Max-Age:
+      - '86400'
+      Cache-Control:
+      - max-age=900, public
+      Content-Security-Policy:
+      - base-uri 'self'; block-all-mixed-content; connect-src 'self' https://api.github.com/repos/
+        https://api.github.com/search/issues https://*.google-analytics.com https://*.analytics.google.com
+        https://*.googletagmanager.com fastly-insights.com *.fastly-insights.com *.ethicalads.io
+        https://api.pwnedpasswords.com https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/sre/mathmaps/
+        https://2p66nmmycsj3.statuspage.io; default-src 'none'; font-src 'self' fonts.gstatic.com;
+        form-action 'self' https://checkout.stripe.com; frame-ancestors 'none'; frame-src
+        'none'; img-src 'self' https://warehouse-camo.ingress.cmh1.psfhosted.org/
+        https://*.google-analytics.com https://*.googletagmanager.com *.fastly-insights.com
+        *.ethicalads.io; script-src 'self' https://*.googletagmanager.com https://www.google-analytics.com
+        https://ssl.google-analytics.com *.fastly-insights.com *.ethicalads.io 'sha256-U3hKDidudIaxBDEzwGJApJgPEf2mWk6cfMWghrAa6i0='
+        https://cdn.jsdelivr.net/npm/mathjax@3.2.2/ 'sha256-1CldwzdEg2k1wTmf7s5RWVd7NMXI/7nxxjJM2C4DqII='
+        'sha256-0POaN8stWYQxhzjKS+/eOfbbJ/u4YHO5ZagJvLpMypo='; style-src 'self' fonts.googleapis.com
+        *.ethicalads.io 'sha256-2YHqZokjiizkHi1Zt+6ar0XJ0OeEy/egBnlm+MDMtrM=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
+        'sha256-JLEjeN9e5dGsz5475WyRaoA4eQOdNPxDIeUhclnJDCE=' 'sha256-mQyxHEuwZJqpxCw3SLmc4YOySNKXunyu2Oiz1r3/wAE='
+        'sha256-OCf+kv5Asiwp++8PIevKBYSgnNLNUZvxAp4a7wMLuKA=' 'sha256-h5LOiLhk6wiJrGsG5ItM0KimwzWQH/yAcmoJDJL//bY=';
+        worker-src *.fastly-insights.com
+      Content-Type:
+      - application/json
+      Etag:
+      - '"QdQmGi206AZCybe3iChFIg"'
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - nginx/1.13.9
+      X-Pypi-Last-Serial:
+      - '3585324'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Thu, 13 Jul 2023 18:46:38 GMT
+      X-Served-By:
+      - cache-iad-kjyo7100132-IAD
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1689273998.454373,VS0,VE2
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Content-Length:
+      - '2751'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"info":{"author":"David Beazley","author_email":"dave@dabeaz.com","bugtrack_url":null,"classifiers":["Programming
+        Language :: Python :: 2","Programming Language :: Python :: 3"],"description":"\nPLY
+        is yet another implementation of lex and yacc for Python. Some notable\nfeatures
+        include the fact that its implemented entirely in Python and it\nuses LALR(1)
+        parsing which is efficient and well suited for larger grammars.\n\nPLY provides
+        most of the standard lex/yacc features including support for empty \nproductions,
+        precedence rules, error recovery, and support for ambiguous grammars. \n\nPLY
+        is extremely easy to use and provides very extensive error checking. \nIt
+        is compatible with both Python 2 and Python 3.\n","description_content_type":null,"docs_url":null,"download_url":"","downloads":{"last_day":-1,"last_month":-1,"last_week":-1},"home_page":"http://www.dabeaz.com/ply/","keywords":"","license":"BSD","maintainer":"","maintainer_email":"","name":"ply","package_url":"https://pypi.org/project/ply/","platform":"","project_url":"https://pypi.org/project/ply/","project_urls":{"Homepage":"http://www.dabeaz.com/ply/"},"release_url":"https://pypi.org/project/ply/3.11/","requires_dist":null,"requires_python":"","summary":"Python
+        Lex & Yacc","version":"3.11","yanked":false,"yanked_reason":null},"last_serial":3585324,"urls":[{"comment_text":"","digests":{"blake2b_256":"a35835da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc","md5":"62b6ad5affddc9926ab5571f390cc840","sha256":"096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"},"downloads":-1,"filename":"ply-3.11-py2.py3-none-any.whl","has_sig":false,"md5_digest":"62b6ad5affddc9926ab5571f390cc840","packagetype":"bdist_wheel","python_version":"3.6","requires_python":null,"size":49567,"upload_time":"2018-02-15T19:01:27","upload_time_iso_8601":"2018-02-15T19:01:27.172483Z","url":"https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl","yanked":false,"yanked_reason":null},{"comment_text":"","digests":{"blake2b_256":"e569882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da","md5":"6465f602e656455affcd7c5734c638f8","sha256":"00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},"downloads":-1,"filename":"ply-3.11.tar.gz","has_sig":false,"md5_digest":"6465f602e656455affcd7c5734c638f8","packagetype":"sdist","python_version":"source","requires_python":null,"size":159130,"upload_time":"2018-02-15T19:01:31","upload_time_iso_8601":"2018-02-15T19:01:31.097641Z","url":"https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz","yanked":false,"yanked_reason":null}],"vulnerabilities":[]}
+
+        '
+    http_version:
+  recorded_at: Thu, 13 Jul 2023 18:46:38 GMT
+- request:
+    method: get
+    uri: https://pypi.org/pypi/ply/3.3/json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip,deflate,br
+      X-Datadog-Trace-Id:
+      - '3698289035836551381'
+      X-Datadog-Parent-Id:
+      - '2586041319363570358'
+      X-Datadog-Sampling-Priority:
+      - '1'
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-PyPI-Last-Serial
+      Access-Control-Max-Age:
+      - '86400'
+      Cache-Control:
+      - max-age=900, public
+      Content-Security-Policy:
+      - base-uri 'self'; block-all-mixed-content; connect-src 'self' https://api.github.com/repos/
+        https://api.github.com/search/issues https://*.google-analytics.com https://*.analytics.google.com
+        https://*.googletagmanager.com fastly-insights.com *.fastly-insights.com *.ethicalads.io
+        https://api.pwnedpasswords.com https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/sre/mathmaps/
+        https://2p66nmmycsj3.statuspage.io; default-src 'none'; font-src 'self' fonts.gstatic.com;
+        form-action 'self' https://checkout.stripe.com; frame-ancestors 'none'; frame-src
+        'none'; img-src 'self' https://warehouse-camo.ingress.cmh1.psfhosted.org/
+        https://*.google-analytics.com https://*.googletagmanager.com *.fastly-insights.com
+        *.ethicalads.io; script-src 'self' https://*.googletagmanager.com https://www.google-analytics.com
+        https://ssl.google-analytics.com *.fastly-insights.com *.ethicalads.io 'sha256-U3hKDidudIaxBDEzwGJApJgPEf2mWk6cfMWghrAa6i0='
+        https://cdn.jsdelivr.net/npm/mathjax@3.2.2/ 'sha256-1CldwzdEg2k1wTmf7s5RWVd7NMXI/7nxxjJM2C4DqII='
+        'sha256-0POaN8stWYQxhzjKS+/eOfbbJ/u4YHO5ZagJvLpMypo='; style-src 'self' fonts.googleapis.com
+        *.ethicalads.io 'sha256-2YHqZokjiizkHi1Zt+6ar0XJ0OeEy/egBnlm+MDMtrM=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
+        'sha256-JLEjeN9e5dGsz5475WyRaoA4eQOdNPxDIeUhclnJDCE=' 'sha256-mQyxHEuwZJqpxCw3SLmc4YOySNKXunyu2Oiz1r3/wAE='
+        'sha256-OCf+kv5Asiwp++8PIevKBYSgnNLNUZvxAp4a7wMLuKA=' 'sha256-h5LOiLhk6wiJrGsG5ItM0KimwzWQH/yAcmoJDJL//bY=';
+        worker-src *.fastly-insights.com
+      Content-Type:
+      - application/json
+      Etag:
+      - '"YM2SlT1jwkOKrW96mXwAqg"'
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - nginx/1.13.9
+      X-Pypi-Last-Serial:
+      - '3585324'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Thu, 13 Jul 2023 18:46:38 GMT
+      X-Served-By:
+      - cache-iad-kjyo7100132-IAD
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1689273998.486366,VS0,VE2
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Content-Length:
+      - '1274'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"info":{"author":"David Beazley","author_email":"dave@dabeaz.com","bugtrack_url":null,"classifiers":[],"description":"PLY
+        is yet another implementation of lex and yacc for Python. Some notable\nfeatures
+        include the fact that its implemented entirely in Python and it\nuses LALR(1)
+        parsing which is efficient and well suited for larger grammars.\n\nPLY provides
+        most of the standard lex/yacc features including support for empty \nproductions,
+        precedence rules, error recovery, and support for ambiguous grammars. \n\nPLY
+        is extremely easy to use and provides very extensive error checking.","description_content_type":null,"docs_url":null,"download_url":"UNKNOWN","downloads":{"last_day":-1,"last_month":-1,"last_week":-1},"home_page":"http://www.dabeaz.com/ply/","keywords":null,"license":"BSD","maintainer":null,"maintainer_email":null,"name":"ply","package_url":"https://pypi.org/project/ply/","platform":"UNKNOWN","project_url":"https://pypi.org/project/ply/","project_urls":{"Download":"UNKNOWN","Homepage":"http://www.dabeaz.com/ply/"},"release_url":"https://pypi.org/project/ply/3.3/","requires_dist":null,"requires_python":null,"summary":"Python
+        Lex & Yacc","version":"3.3","yanked":false,"yanked_reason":null},"last_serial":3585324,"urls":[],"vulnerabilities":[]}
+
+        '
+    http_version:
+  recorded_at: Thu, 13 Jul 2023 18:46:38 GMT
+- request:
+    method: get
+    uri: https://pypi.org/pypi/ply/3.4/json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip,deflate,br
+      X-Datadog-Trace-Id:
+      - '1176327655452936149'
+      X-Datadog-Parent-Id:
+      - '3910682083299347978'
+      X-Datadog-Sampling-Priority:
+      - '1'
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-PyPI-Last-Serial
+      Access-Control-Max-Age:
+      - '86400'
+      Cache-Control:
+      - max-age=900, public
+      Content-Security-Policy:
+      - base-uri 'self'; block-all-mixed-content; connect-src 'self' https://api.github.com/repos/
+        https://api.github.com/search/issues https://*.google-analytics.com https://*.analytics.google.com
+        https://*.googletagmanager.com fastly-insights.com *.fastly-insights.com *.ethicalads.io
+        https://api.pwnedpasswords.com https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/sre/mathmaps/
+        https://2p66nmmycsj3.statuspage.io; default-src 'none'; font-src 'self' fonts.gstatic.com;
+        form-action 'self' https://checkout.stripe.com; frame-ancestors 'none'; frame-src
+        'none'; img-src 'self' https://warehouse-camo.ingress.cmh1.psfhosted.org/
+        https://*.google-analytics.com https://*.googletagmanager.com *.fastly-insights.com
+        *.ethicalads.io; script-src 'self' https://*.googletagmanager.com https://www.google-analytics.com
+        https://ssl.google-analytics.com *.fastly-insights.com *.ethicalads.io 'sha256-U3hKDidudIaxBDEzwGJApJgPEf2mWk6cfMWghrAa6i0='
+        https://cdn.jsdelivr.net/npm/mathjax@3.2.2/ 'sha256-1CldwzdEg2k1wTmf7s5RWVd7NMXI/7nxxjJM2C4DqII='
+        'sha256-0POaN8stWYQxhzjKS+/eOfbbJ/u4YHO5ZagJvLpMypo='; style-src 'self' fonts.googleapis.com
+        *.ethicalads.io 'sha256-2YHqZokjiizkHi1Zt+6ar0XJ0OeEy/egBnlm+MDMtrM=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
+        'sha256-JLEjeN9e5dGsz5475WyRaoA4eQOdNPxDIeUhclnJDCE=' 'sha256-mQyxHEuwZJqpxCw3SLmc4YOySNKXunyu2Oiz1r3/wAE='
+        'sha256-OCf+kv5Asiwp++8PIevKBYSgnNLNUZvxAp4a7wMLuKA=' 'sha256-h5LOiLhk6wiJrGsG5ItM0KimwzWQH/yAcmoJDJL//bY=';
+        worker-src *.fastly-insights.com
+      Content-Type:
+      - application/json
+      Etag:
+      - '"hYTeo3C0wq4ePj+jFIi3Ag"'
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - nginx/1.13.9
+      X-Pypi-Last-Serial:
+      - '3585324'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Thu, 13 Jul 2023 18:46:38 GMT
+      X-Served-By:
+      - cache-iad-kjyo7100132-IAD
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1689273999.519309,VS0,VE2
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Content-Length:
+      - '2115'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"info":{"author":"David Beazley","author_email":"dave@dabeaz.com","bugtrack_url":null,"classifiers":["Programming
+        Language :: Python :: 2","Programming Language :: Python :: 3"],"description":"PLY
+        is yet another implementation of lex and yacc for Python. Some notable\n        features
+        include the fact that its implemented entirely in Python and it\n        uses
+        LALR(1) parsing which is efficient and well suited for larger grammars.\n        \n        PLY
+        provides most of the standard lex/yacc features including support for empty
+        \n        productions, precedence rules, error recovery, and support for ambiguous
+        grammars. \n        \n        PLY is extremely easy to use and provides very
+        extensive error checking. \n        It is compatible with both Python 2 and
+        Python 3.","description_content_type":null,"docs_url":null,"download_url":null,"downloads":{"last_day":-1,"last_month":-1,"last_week":-1},"home_page":"http://www.dabeaz.com/ply/","keywords":null,"license":"BSD","maintainer":null,"maintainer_email":null,"name":"ply","package_url":"https://pypi.org/project/ply/","platform":"UNKNOWN","project_url":"https://pypi.org/project/ply/","project_urls":{"Homepage":"http://www.dabeaz.com/ply/"},"release_url":"https://pypi.org/project/ply/3.4/","requires_dist":null,"requires_python":null,"summary":"Python
+        Lex & Yacc","version":"3.4","yanked":false,"yanked_reason":null},"last_serial":3585324,"urls":[{"comment_text":"","digests":{"blake2b_256":"407d95a7a67fb4c2205d0cbf89e8fabb7b49b4ed812ffdab45510d124bc2bd7e","md5":"ffdc95858819347bf92d7c2acc074894","sha256":"af435f11b7bdd69da5ffbc3fecb8d70a7073ec952e101764c88720cdefb2546b"},"downloads":-1,"filename":"ply-3.4.tar.gz","has_sig":false,"md5_digest":"ffdc95858819347bf92d7c2acc074894","packagetype":"sdist","python_version":"source","requires_python":null,"size":138342,"upload_time":"2012-04-18T14:24:41","upload_time_iso_8601":"2012-04-18T14:24:41.501674Z","url":"https://files.pythonhosted.org/packages/40/7d/95a7a67fb4c2205d0cbf89e8fabb7b49b4ed812ffdab45510d124bc2bd7e/ply-3.4.tar.gz","yanked":false,"yanked_reason":null}],"vulnerabilities":[]}
+
+        '
+    http_version:
+  recorded_at: Thu, 13 Jul 2023 18:46:38 GMT
+- request:
+    method: get
+    uri: https://pypi.org/pypi/ply/3.6/json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip,deflate,br
+      X-Datadog-Trace-Id:
+      - '22537098173020847'
+      X-Datadog-Parent-Id:
+      - '551426103134935311'
+      X-Datadog-Sampling-Priority:
+      - '1'
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-PyPI-Last-Serial
+      Access-Control-Max-Age:
+      - '86400'
+      Cache-Control:
+      - max-age=900, public
+      Content-Security-Policy:
+      - base-uri 'self'; block-all-mixed-content; connect-src 'self' https://api.github.com/repos/
+        https://api.github.com/search/issues https://*.google-analytics.com https://*.analytics.google.com
+        https://*.googletagmanager.com fastly-insights.com *.fastly-insights.com *.ethicalads.io
+        https://api.pwnedpasswords.com https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/sre/mathmaps/
+        https://2p66nmmycsj3.statuspage.io; default-src 'none'; font-src 'self' fonts.gstatic.com;
+        form-action 'self' https://checkout.stripe.com; frame-ancestors 'none'; frame-src
+        'none'; img-src 'self' https://warehouse-camo.ingress.cmh1.psfhosted.org/
+        https://*.google-analytics.com https://*.googletagmanager.com *.fastly-insights.com
+        *.ethicalads.io; script-src 'self' https://*.googletagmanager.com https://www.google-analytics.com
+        https://ssl.google-analytics.com *.fastly-insights.com *.ethicalads.io 'sha256-U3hKDidudIaxBDEzwGJApJgPEf2mWk6cfMWghrAa6i0='
+        https://cdn.jsdelivr.net/npm/mathjax@3.2.2/ 'sha256-1CldwzdEg2k1wTmf7s5RWVd7NMXI/7nxxjJM2C4DqII='
+        'sha256-0POaN8stWYQxhzjKS+/eOfbbJ/u4YHO5ZagJvLpMypo='; style-src 'self' fonts.googleapis.com
+        *.ethicalads.io 'sha256-2YHqZokjiizkHi1Zt+6ar0XJ0OeEy/egBnlm+MDMtrM=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
+        'sha256-JLEjeN9e5dGsz5475WyRaoA4eQOdNPxDIeUhclnJDCE=' 'sha256-mQyxHEuwZJqpxCw3SLmc4YOySNKXunyu2Oiz1r3/wAE='
+        'sha256-OCf+kv5Asiwp++8PIevKBYSgnNLNUZvxAp4a7wMLuKA=' 'sha256-h5LOiLhk6wiJrGsG5ItM0KimwzWQH/yAcmoJDJL//bY=';
+        worker-src *.fastly-insights.com
+      Content-Type:
+      - application/json
+      Etag:
+      - '"tYpKzRo3gpDD90yUgBV3Zw"'
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - nginx/1.13.9
+      X-Pypi-Last-Serial:
+      - '3585324'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Thu, 13 Jul 2023 18:46:38 GMT
+      X-Served-By:
+      - cache-iad-kjyo7100132-IAD
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1689273999.550551,VS0,VE2
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Content-Length:
+      - '2077'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"info":{"author":"David Beazley","author_email":"dave@dabeaz.com","bugtrack_url":null,"classifiers":["Programming
+        Language :: Python :: 2","Programming Language :: Python :: 3"],"description":"PLY
+        is yet another implementation of lex and yacc for Python. Some notable\nfeatures
+        include the fact that its implemented entirely in Python and it\nuses LALR(1)
+        parsing which is efficient and well suited for larger grammars.\n\nPLY provides
+        most of the standard lex/yacc features including support for empty \nproductions,
+        precedence rules, error recovery, and support for ambiguous grammars. \n\nPLY
+        is extremely easy to use and provides very extensive error checking. \nIt
+        is compatible with both Python 2 and Python 3.","description_content_type":null,"docs_url":null,"download_url":"UNKNOWN","downloads":{"last_day":-1,"last_month":-1,"last_week":-1},"home_page":"http://www.dabeaz.com/ply/","keywords":null,"license":"BSD","maintainer":null,"maintainer_email":null,"name":"ply","package_url":"https://pypi.org/project/ply/","platform":"UNKNOWN","project_url":"https://pypi.org/project/ply/","project_urls":{"Download":"UNKNOWN","Homepage":"http://www.dabeaz.com/ply/"},"release_url":"https://pypi.org/project/ply/3.6/","requires_dist":null,"requires_python":null,"summary":"Python
+        Lex & Yacc","version":"3.6","yanked":false,"yanked_reason":null},"last_serial":3585324,"urls":[{"comment_text":"","digests":{"blake2b_256":"7fea6aff5b67ddb00d38fa6498df2010b50529700621353d38ac29d25ddb0845","md5":"7aa0e8749d2377a863f477a7d67524d2","sha256":"61367b9eb2f4b819f69ea116750305270f1df8859992c9e356d6a851f25a4b47"},"downloads":-1,"filename":"ply-3.6.tar.gz","has_sig":false,"md5_digest":"7aa0e8749d2377a863f477a7d67524d2","packagetype":"sdist","python_version":"source","requires_python":null,"size":281690,"upload_time":"2015-04-26T21:52:41","upload_time_iso_8601":"2015-04-26T21:52:41.113750Z","url":"https://files.pythonhosted.org/packages/7f/ea/6aff5b67ddb00d38fa6498df2010b50529700621353d38ac29d25ddb0845/ply-3.6.tar.gz","yanked":false,"yanked_reason":null}],"vulnerabilities":[]}
+
+        '
+    http_version:
+  recorded_at: Thu, 13 Jul 2023 18:46:38 GMT
+- request:
+    method: get
+    uri: https://pypi.org/pypi/ply/3.8/json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip,deflate,br
+      X-Datadog-Trace-Id:
+      - '3782684497665964214'
+      X-Datadog-Parent-Id:
+      - '3907672070343333850'
+      X-Datadog-Sampling-Priority:
+      - '1'
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-PyPI-Last-Serial
+      Access-Control-Max-Age:
+      - '86400'
+      Cache-Control:
+      - max-age=900, public
+      Content-Security-Policy:
+      - base-uri 'self'; block-all-mixed-content; connect-src 'self' https://api.github.com/repos/
+        https://api.github.com/search/issues https://*.google-analytics.com https://*.analytics.google.com
+        https://*.googletagmanager.com fastly-insights.com *.fastly-insights.com *.ethicalads.io
+        https://api.pwnedpasswords.com https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/sre/mathmaps/
+        https://2p66nmmycsj3.statuspage.io; default-src 'none'; font-src 'self' fonts.gstatic.com;
+        form-action 'self' https://checkout.stripe.com; frame-ancestors 'none'; frame-src
+        'none'; img-src 'self' https://warehouse-camo.ingress.cmh1.psfhosted.org/
+        https://*.google-analytics.com https://*.googletagmanager.com *.fastly-insights.com
+        *.ethicalads.io; script-src 'self' https://*.googletagmanager.com https://www.google-analytics.com
+        https://ssl.google-analytics.com *.fastly-insights.com *.ethicalads.io 'sha256-U3hKDidudIaxBDEzwGJApJgPEf2mWk6cfMWghrAa6i0='
+        https://cdn.jsdelivr.net/npm/mathjax@3.2.2/ 'sha256-1CldwzdEg2k1wTmf7s5RWVd7NMXI/7nxxjJM2C4DqII='
+        'sha256-0POaN8stWYQxhzjKS+/eOfbbJ/u4YHO5ZagJvLpMypo='; style-src 'self' fonts.googleapis.com
+        *.ethicalads.io 'sha256-2YHqZokjiizkHi1Zt+6ar0XJ0OeEy/egBnlm+MDMtrM=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
+        'sha256-JLEjeN9e5dGsz5475WyRaoA4eQOdNPxDIeUhclnJDCE=' 'sha256-mQyxHEuwZJqpxCw3SLmc4YOySNKXunyu2Oiz1r3/wAE='
+        'sha256-OCf+kv5Asiwp++8PIevKBYSgnNLNUZvxAp4a7wMLuKA=' 'sha256-h5LOiLhk6wiJrGsG5ItM0KimwzWQH/yAcmoJDJL//bY=';
+        worker-src *.fastly-insights.com
+      Content-Type:
+      - application/json
+      Etag:
+      - '"WP8aVSQOBSb2I3bpx8pcjw"'
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - nginx/1.13.9
+      X-Pypi-Last-Serial:
+      - '3585324'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Thu, 13 Jul 2023 18:46:38 GMT
+      X-Served-By:
+      - cache-iad-kjyo7100132-IAD
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1689273999.582336,VS0,VE3
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Content-Length:
+      - '2077'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"info":{"author":"David Beazley","author_email":"dave@dabeaz.com","bugtrack_url":null,"classifiers":["Programming
+        Language :: Python :: 2","Programming Language :: Python :: 3"],"description":"PLY
+        is yet another implementation of lex and yacc for Python. Some notable\nfeatures
+        include the fact that its implemented entirely in Python and it\nuses LALR(1)
+        parsing which is efficient and well suited for larger grammars.\n\nPLY provides
+        most of the standard lex/yacc features including support for empty \nproductions,
+        precedence rules, error recovery, and support for ambiguous grammars. \n\nPLY
+        is extremely easy to use and provides very extensive error checking. \nIt
+        is compatible with both Python 2 and Python 3.","description_content_type":null,"docs_url":null,"download_url":"UNKNOWN","downloads":{"last_day":-1,"last_month":-1,"last_week":-1},"home_page":"http://www.dabeaz.com/ply/","keywords":null,"license":"BSD","maintainer":null,"maintainer_email":null,"name":"ply","package_url":"https://pypi.org/project/ply/","platform":"UNKNOWN","project_url":"https://pypi.org/project/ply/","project_urls":{"Download":"UNKNOWN","Homepage":"http://www.dabeaz.com/ply/"},"release_url":"https://pypi.org/project/ply/3.8/","requires_dist":null,"requires_python":null,"summary":"Python
+        Lex & Yacc","version":"3.8","yanked":false,"yanked_reason":null},"last_serial":3585324,"urls":[{"comment_text":"","digests":{"blake2b_256":"96e0430fcdb6b3ef1ae534d231397bee7e9304be14a47a267e82ebcb3323d0b5","md5":"94726411496c52c87c2b9429b12d5c50","sha256":"e7d1bdff026beb159c9942f7a17e102c375638d9478a7ecd4cc0c76afd8de0b8"},"downloads":-1,"filename":"ply-3.8.tar.gz","has_sig":false,"md5_digest":"94726411496c52c87c2b9429b12d5c50","packagetype":"sdist","python_version":"source","requires_python":null,"size":157286,"upload_time":"2015-10-02T18:15:50","upload_time_iso_8601":"2015-10-02T18:15:50.150715Z","url":"https://files.pythonhosted.org/packages/96/e0/430fcdb6b3ef1ae534d231397bee7e9304be14a47a267e82ebcb3323d0b5/ply-3.8.tar.gz","yanked":false,"yanked_reason":null}],"vulnerabilities":[]}
+
+        '
+    http_version:
+  recorded_at: Thu, 13 Jul 2023 18:46:38 GMT
+- request:
+    method: get
+    uri: https://pypi.org/pypi/ply/3.9/json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip,deflate,br
+      X-Datadog-Trace-Id:
+      - '397081942270112223'
+      X-Datadog-Parent-Id:
+      - '2011307813383523443'
+      X-Datadog-Sampling-Priority:
+      - '1'
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - X-PyPI-Last-Serial
+      Access-Control-Max-Age:
+      - '86400'
+      Cache-Control:
+      - max-age=900, public
+      Content-Security-Policy:
+      - base-uri 'self'; block-all-mixed-content; connect-src 'self' https://api.github.com/repos/
+        https://api.github.com/search/issues https://*.google-analytics.com https://*.analytics.google.com
+        https://*.googletagmanager.com fastly-insights.com *.fastly-insights.com *.ethicalads.io
+        https://api.pwnedpasswords.com https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/sre/mathmaps/
+        https://2p66nmmycsj3.statuspage.io; default-src 'none'; font-src 'self' fonts.gstatic.com;
+        form-action 'self' https://checkout.stripe.com; frame-ancestors 'none'; frame-src
+        'none'; img-src 'self' https://warehouse-camo.ingress.cmh1.psfhosted.org/
+        https://*.google-analytics.com https://*.googletagmanager.com *.fastly-insights.com
+        *.ethicalads.io; script-src 'self' https://*.googletagmanager.com https://www.google-analytics.com
+        https://ssl.google-analytics.com *.fastly-insights.com *.ethicalads.io 'sha256-U3hKDidudIaxBDEzwGJApJgPEf2mWk6cfMWghrAa6i0='
+        https://cdn.jsdelivr.net/npm/mathjax@3.2.2/ 'sha256-1CldwzdEg2k1wTmf7s5RWVd7NMXI/7nxxjJM2C4DqII='
+        'sha256-0POaN8stWYQxhzjKS+/eOfbbJ/u4YHO5ZagJvLpMypo='; style-src 'self' fonts.googleapis.com
+        *.ethicalads.io 'sha256-2YHqZokjiizkHi1Zt+6ar0XJ0OeEy/egBnlm+MDMtrM=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='
+        'sha256-JLEjeN9e5dGsz5475WyRaoA4eQOdNPxDIeUhclnJDCE=' 'sha256-mQyxHEuwZJqpxCw3SLmc4YOySNKXunyu2Oiz1r3/wAE='
+        'sha256-OCf+kv5Asiwp++8PIevKBYSgnNLNUZvxAp4a7wMLuKA=' 'sha256-h5LOiLhk6wiJrGsG5ItM0KimwzWQH/yAcmoJDJL//bY=';
+        worker-src *.fastly-insights.com
+      Content-Type:
+      - application/json
+      Etag:
+      - '"eyWlt5hXWPqh0yuas/xN0g"'
+      Referrer-Policy:
+      - origin-when-cross-origin
+      Server:
+      - nginx/1.13.9
+      X-Pypi-Last-Serial:
+      - '3585324'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Thu, 13 Jul 2023 18:46:38 GMT
+      X-Served-By:
+      - cache-iad-kjyo7100132-IAD
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1689273999.618258,VS0,VE1
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Content-Length:
+      - '2077'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"info":{"author":"David Beazley","author_email":"dave@dabeaz.com","bugtrack_url":null,"classifiers":["Programming
+        Language :: Python :: 2","Programming Language :: Python :: 3"],"description":"PLY
+        is yet another implementation of lex and yacc for Python. Some notable\nfeatures
+        include the fact that its implemented entirely in Python and it\nuses LALR(1)
+        parsing which is efficient and well suited for larger grammars.\n\nPLY provides
+        most of the standard lex/yacc features including support for empty \nproductions,
+        precedence rules, error recovery, and support for ambiguous grammars. \n\nPLY
+        is extremely easy to use and provides very extensive error checking. \nIt
+        is compatible with both Python 2 and Python 3.","description_content_type":null,"docs_url":null,"download_url":"UNKNOWN","downloads":{"last_day":-1,"last_month":-1,"last_week":-1},"home_page":"http://www.dabeaz.com/ply/","keywords":null,"license":"BSD","maintainer":null,"maintainer_email":null,"name":"ply","package_url":"https://pypi.org/project/ply/","platform":"UNKNOWN","project_url":"https://pypi.org/project/ply/","project_urls":{"Download":"UNKNOWN","Homepage":"http://www.dabeaz.com/ply/"},"release_url":"https://pypi.org/project/ply/3.9/","requires_dist":null,"requires_python":null,"summary":"Python
+        Lex & Yacc","version":"3.9","yanked":false,"yanked_reason":null},"last_serial":3585324,"urls":[{"comment_text":"","digests":{"blake2b_256":"a84d487e12d0478ee0cbb15d6fe9b8916e98fe4e2fce4cc65e4de309209c0b24","md5":"c5c5767376eff902617fd9874f0c76b7","sha256":"0d7e2940b9c57151392fceaa62b0865c45e06ce1e36687fd8d03f011a907f43e"},"downloads":-1,"filename":"ply-3.9.tar.gz","has_sig":false,"md5_digest":"c5c5767376eff902617fd9874f0c76b7","packagetype":"sdist","python_version":"source","requires_python":null,"size":150750,"upload_time":"2016-08-31T14:13:16","upload_time_iso_8601":"2016-08-31T14:13:16.696602Z","url":"https://files.pythonhosted.org/packages/a8/4d/487e12d0478ee0cbb15d6fe9b8916e98fe4e2fce4cc65e4de309209c0b24/ply-3.9.tar.gz","yanked":false,"yanked_reason":null}],"vulnerabilities":[]}
+
+        '
+    http_version:
+  recorded_at: Thu, 13 Jul 2023 18:46:38 GMT
+recorded_with: VCR 4.0.0

--- a/spec/models/package_manager/pypi/raw_release_spec.rb
+++ b/spec/models/package_manager/pypi/raw_release_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+describe PackageManager::Pypi::RawRelease do
+  describe "#details?" do
+    let(:raw_release) { described_class.new(number: "1.0.0", release: release) }
+
+    context "with details" do
+      let(:release) { [{}] }
+
+      it "returns true" do
+        expect(raw_release.details?).to eq(true)
+      end
+    end
+
+    context "without details" do
+      let(:release) { [] }
+
+      it "returns false" do
+        expect(raw_release.details?).to eq(false)
+      end
+    end
+  end
+
+  describe "#published_at" do
+    let(:raw_release) { described_class.new(number: "1.0.0", release: release) }
+
+    context "without details" do
+      let(:release) { [] }
+
+      it "returns nil" do
+        expect(raw_release.published_at).to eq(nil)
+      end
+    end
+
+    context "with no upload time" do
+      let(:release) { [{}] }
+
+      it "raises an error" do
+        expect { raw_release.published_at }.to raise_error(ArgumentError, /does not contain upload_time/)
+      end
+    end
+
+    context "with a bad upload time" do
+      let(:release) do
+        [{
+          "upload_time" => "{]",
+        }]
+      end
+
+      it "raises an error" do
+        expect { raw_release.published_at }.to raise_error(ArgumentError, /no time information/)
+      end
+    end
+
+    context "with a good upload time" do
+      let(:release) do
+        [{
+          "upload_time" => "2020-01-01 10:00:00",
+        }]
+      end
+
+      it "returns a time object" do
+        expect(raw_release.published_at.year).to eq(2020)
+      end
+    end
+  end
+end

--- a/spec/models/package_manager/pypi/version_spec.rb
+++ b/spec/models/package_manager/pypi/version_spec.rb
@@ -1,0 +1,143 @@
+require "rails_helper"
+
+describe PackageManager::Pypi::Version do
+  describe ".retrieve_project_releases_rss_feed" do
+    let(:name) { "name" }
+
+    before do
+      allow(described_class).to receive(:get_xml).with("https://pypi.org/rss/project/#{name}/releases.xml").and_return(result)
+    end
+
+    context "with invalid rss feed" do
+      let(:result) { Ox.parse("<bad></bad>") }
+
+      it "raises an exception" do
+        expect { described_class.retrieve_project_releases_rss_feed(name: name) }.to raise_error(described_class::InvalidReleasesFeedStructure)
+      end
+    end
+
+    context "with invalid rss entry" do
+      let(:result) do
+        Ox.parse(
+          <<-XML
+          <?xml version="1.0" ?>
+          <rss><channel><item></item></channel></rss>
+          XML
+        )
+      end
+
+      it "raises whatever exception would be raised by internal code" do
+        expect { described_class.retrieve_project_releases_rss_feed(name: name) }.to raise_error(NoMethodError)
+      end
+    end
+
+    context "with correct rss entry" do
+      let(:time_string) { "Sun, Feb 26 2006 16:36:49 GMT" }
+
+      let(:result) do
+        Ox.parse(
+          <<-XML
+          <?xml version="1.0" ?>
+          <rss><channel><item><title>1.0.0</title><pubDate>#{time_string}</pubDate></item></channel></rss>
+          XML
+        )
+      end
+
+      it "returns processed data" do
+        expect(described_class.retrieve_project_releases_rss_feed(name: name)).to eq([
+          { number: "1.0.0", published_at: Time.parse(time_string) },
+  ])
+      end
+    end
+  end
+
+  describe ".gather_raw_data_details" do
+    let(:name) { "name" }
+    let(:feed_releases) { [{ number: "0.1.1", published_at: "whenever" }] }
+
+    before do
+      allow(described_class).to receive(:retrieve_project_releases_rss_feed).with(name: name).and_return(feed_releases)
+    end
+
+    context "no releases missing details" do
+      let(:raw_releases) { { "1.0.0" => [{}] } }
+
+      it "returns no feed releases" do
+        result = described_class.gather_raw_data_details(name: name, raw_releases: raw_releases)
+        expect(result[:raw_release_objs].first.number).to eq("1.0.0")
+
+        expect(result[:feed_releases]).to eq([])
+        expect(described_class).not_to have_received(:retrieve_project_releases_rss_feed)
+      end
+    end
+
+    context "one release missing details" do
+      let(:raw_releases) { { "1.0.0" => [] } }
+
+      it "returns feed releases" do
+        result = described_class.gather_raw_data_details(name: name, raw_releases: raw_releases)
+        expect(result[:raw_release_objs].first.number).to eq("1.0.0")
+
+        expect(result[:feed_releases]).to eq(feed_releases)
+        expect(described_class).to have_received(:retrieve_project_releases_rss_feed)
+      end
+    end
+  end
+
+  describe "#retrieve_license_details!" do
+    # we are not trapping retrieval errors here, instead passing them up the chain
+    let(:name) { "name" }
+    let(:number) { "1.0.0" }
+    let(:response) do
+      { "info" => { "license" => license } }
+    end
+    let(:license) { "MIT" }
+    let(:version) { described_class.new(number: number) }
+
+    before do
+      allow(described_class).to receive(:get).with("https://pypi.org/pypi/#{name}/#{number}/json").and_return(response)
+    end
+
+    it "can process a response" do
+      # only test that we can get the value out and set it. dig has plenty of tests around its functionality
+      version.retrieve_license_details!(name: name)
+
+      expect(version.original_license).to eq(license)
+    end
+  end
+
+  describe "#maybe_set_feed_published_at!" do
+    let(:number) { "1.0.0" }
+    let(:published_at) { Time.zone.now }
+    let(:original_published_at) { nil }
+
+    let(:version) { described_class.new(number: number, published_at: original_published_at) }
+
+    context "with matching feed entry" do
+      let(:feed_releases) { [{ number: number, published_at: published_at }] }
+
+      context "with already set published at" do
+        let(:original_published_at) { 1.hour.ago }
+
+        it "does not update the current setting" do
+          version.maybe_set_feed_published_at!(feed_releases: feed_releases)
+          expect(version.published_at).to eq(original_published_at)
+        end
+      end
+
+      it "updates the current setting" do
+        version.maybe_set_feed_published_at!(feed_releases: feed_releases)
+        expect(version.published_at).to eq(published_at)
+      end
+    end
+
+    context "without matching feed entry" do
+      let(:feed_releases) { [] }
+
+      it "does not update the current setting" do
+        version.maybe_set_feed_published_at!(feed_releases: feed_releases)
+        expect(version.published_at).to eq(original_published_at)
+      end
+    end
+  end
+end

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -355,4 +355,22 @@ describe PackageManager::Pypi do
       end
     end
   end
+
+  describe ".versions" do
+    it "retrieves data for a package that uses both the JSON and RSS APIs" do
+      VCR.use_cassette("pypi/versions/ply") do
+        raw_project = described_class.project("ply")
+
+        # This will be empty, which is why we need to use the RSS feed to get the
+        # publish date.
+        expect(raw_project["releases"]["1.6"]).to eq([])
+
+        versions = described_class.versions(raw_project, "ply")
+
+        # We will get the published date from the RSS feed
+        version16 = versions.find { |v| v[:number] == "1.6" }
+        expect(version16[:published_at]).not_to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Feature-wise, this adds the ability to retrieve a PyPI package's RSS feed to gather publishing dates when the JSON ASPI has no information on them. It also adds an integration test to ensure version retrieval works as intended.

Structure-wise, this breaks apart the PyPI version processing code into a few classes which makes testing the individual pieces a lot easier. It also breaks out the shared data retrieval code into a module for use outside of PackageManager::Base and its subclasses.
