### PR TITLE
Remove the with_project_name scope from Daily Dependency Rake Task

### DIFF
--- a/app/models/concerns/repo_manifests.rb
+++ b/app/models/concerns/repo_manifests.rb
@@ -63,10 +63,10 @@ module RepoManifests
         platform = manifest.platform
         next unless dep.is_a?(Hash)
 
-        project = Project.platform(platform).find_by_name(dep[:name])
+        project_id = Project.find_best(platform, dep[:name])&.id
 
         manifest.repository_dependencies.create({
-                                                  project_id: project.try(:id),
+                                                  project_id: project_id,
                                                   project_name: dep[:name].try(:strip),
                                                   platform: platform,
                                                   requirements: dep[:requirement],

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -489,6 +489,7 @@ class Project < ApplicationRecord
 
     names = platform_class
       .project_find_names(name)
+      .compact
       .map(&:downcase)
 
     visible

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -17,8 +17,8 @@ namespace :projects do
   desc "Link dependencies to projects"
   task link_dependencies: :environment do
     exit if ENV["READ_ONLY"].present?
-    Dependency.where("created_at::date > date(?)", 1.day.ago).without_project_id.with_project_name.find_each(&:update_project_id)
-    RepositoryDependency.where("created_at::date > date(?)", 1.day.ago).without_project_id.with_project_name.find_each(&:update_project_id)
+    Dependency.where("created_at::date > date(?)", 1.day.ago).without_project_id.find_each(&:update_project_id)
+    RepositoryDependency.where("created_at::date > date(?)", 1.day.ago).without_project_id.find_each(&:update_project_id)
   end
 
   # rake projects:check_status[100,5]


### PR DESCRIPTION
`Dependency` has a validation that a `project_name` should exist so the scope should be a no-op for that table. `RepositoryDependency` doesn't have that validation, but the lookup for project ID should return a `nil` if a project can't be found. This also updates how project IDs are mapped for repository dependencies so that they also use `Project.find_best` when looking for the correct `project_id`.

This PR should hopefully help `projects::link_dependencies` to finish more consistently and bring `RepositoryDependency` Project ID resolution in line with the `Dependency` table.