### PR TITLE
Query for all Dependency IDs Instead of Using Batching SQL Queries

### DIFF
--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -17,12 +17,12 @@ namespace :projects do
   desc "Link dependencies to projects"
   task link_dependencies: :environment do
     exit if ENV["READ_ONLY"].present?
-    ids = Dependency.where("created_at::date > date(?)", 1.day.ago).without_project_id.pluck(:id)
+    ids = Dependency.where("created_at::date >= date(?)", 1.day.ago).without_project_id.pluck(:id)
     ids.in_groups_of(1000) do |group|
       Dependency.where(id: group).each(&:update_project_id)
     end
 
-    ids = RepositoryDependency.where("created_at::date > date(?)", 1.day.ago).without_project_id.pluck(:id)
+    ids = RepositoryDependency.where("created_at::date >= date(?)", 1.day.ago).without_project_id.pluck(:id)
     ids.in_groups_of(1000) do |group|
       RepositoryDependency.where(id: group).each(&:update_project_id)
     end

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -18,12 +18,12 @@ namespace :projects do
   task link_dependencies: :environment do
     exit if ENV["READ_ONLY"].present?
     ids = Dependency.where("created_at::date >= date(?)", 1.day.ago).without_project_id.pluck(:id)
-    ids.in_groups_of(1000) do |group|
+    ids.in_groups_of(1000, false) do |group|
       Dependency.where(id: group).each(&:update_project_id)
     end
 
     ids = RepositoryDependency.where("created_at::date >= date(?)", 1.day.ago).without_project_id.pluck(:id)
-    ids.in_groups_of(1000) do |group|
+    ids.in_groups_of(1000, false) do |group|
       RepositoryDependency.where(id: group).each(&:update_project_id)
     end
   end

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -18,12 +18,20 @@ namespace :projects do
   task link_dependencies: :environment do
     exit if ENV["READ_ONLY"].present?
     ids = Dependency.where("created_at::date >= date(?)", 1.day.ago).without_project_id.pluck(:id)
-    ids.in_groups_of(1000, false) do |group|
+    Rails.logger.info("Found #{ids.count} Dependency IDs")
+
+    total_slices = (ids.count / 1000.to_f).ceil
+    ids.each_slice(1000).with_index do |group, index|
+      Rails.logger.info("Updating slice #{index + 1} of #{total_slices}")
       Dependency.where(id: group).each(&:update_project_id)
     end
 
     ids = RepositoryDependency.where("created_at::date >= date(?)", 1.day.ago).without_project_id.pluck(:id)
-    ids.in_groups_of(1000, false) do |group|
+    Rails.logger.info("Found #{ids.count} RepositoryDependency IDs")
+
+    total_slices = (ids.count / 1000.to_f).ceil
+    ids.each_slice(1000).with_index do |group, index|
+      Rails.logger.info("Updating slice #{index + 1} of #{total_slices}")
       RepositoryDependency.where(id: group).each(&:update_project_id)
     end
   end


### PR DESCRIPTION
The query without using the batching SQL query parameters, namely `order by id asc where id > ? limit 1000`, seems to run pretty quickly and should avoid timing out. This change may result in the container hitting some memory issues, but that seems more manageable than trying to speed up the queries on these tables some more. 