### PR TITLE
Remove deprecation class code/test mocks, move calculation to PORO

### DIFF
--- a/app/models/package_manager/pypi/json_api_project.rb
+++ b/app/models/package_manager/pypi/json_api_project.rb
@@ -1,6 +1,8 @@
 module PackageManager
   class Pypi
     class JsonApiProject
+      CLASSIFIER_INACTIVE = "Development Status :: 7 - Inactive"
+
       def self.request(project_name:)
         data = begin
           ApiService.request_json_with_headers("https://pypi.org/pypi/#{project_name}/json")
@@ -28,7 +30,7 @@ module PackageManager
       end
 
       def license_classifiers
-        license_classifiers = @data.dig("info", "classifiers").select { |c| c.start_with?("License :: ") }
+        license_classifiers = classifiers.select { |c| c.start_with?("License :: ") }
         license_classifiers.map { |l| l.split(":: ").last }.join(",")
       end
 
@@ -73,9 +75,13 @@ module PackageManager
       def releases
         JsonApiProjectReleases.new(
           @data["releases"].map do |version_number, details|
+            first_details = details.first || {}
+
             JsonApiProjectRelease.new(
               version_number: version_number,
-              published_at: release_data_published_at(details)
+              published_at: release_data_published_at(details),
+              is_yanked: first_details["yanked"] == true,
+              yanked_reason: first_details["yanked_reason"]
             )
           end
         )
@@ -94,7 +100,41 @@ module PackageManager
         }
       end
 
+      def deprecated?
+        deprecation_status[:is_deprecated]
+      end
+
+      def deprecation_message
+        deprecation_status[:message]
+      end
+
       private
+
+      def classifiers
+        @data.dig("info", "classifiers")
+      end
+
+      def deprecation_status
+        return @deprecation_status if @deprecation_status
+
+        is_deprecated = false
+        message = nil
+
+        latest_stable = releases.reject(&:prerelease?).last
+
+        if latest_stable&.yanked?
+          is_deprecated = true
+          message = latest_stable.yanked_reason
+        elsif classifiers.include?(CLASSIFIER_INACTIVE)
+          is_deprecated = true
+          message = CLASSIFIER_INACTIVE
+        end
+
+        @deprecation_status = {
+          is_deprecated: is_deprecated,
+          message: message,
+        }
+      end
 
       def release_data_published_at(details)
         return nil if details == []

--- a/app/models/package_manager/pypi/json_api_project_release.rb
+++ b/app/models/package_manager/pypi/json_api_project_release.rb
@@ -1,15 +1,32 @@
 module PackageManager
   class Pypi
     class JsonApiProjectRelease
-      attr_reader :version_number, :published_at
+      attr_reader :version_number, :published_at, :yanked_reason
 
-      def initialize(version_number:, published_at:)
+      PYPI_PRERELEASE = /(a|b|rc|dev)[-_.]?[0-9]*$/.freeze
+
+      def initialize(
+        version_number:,
+        published_at:,
+        is_yanked:,
+        yanked_reason:
+      )
         @version_number = version_number
         @published_at = published_at
+        @is_yanked = is_yanked
+        @yanked_reason = yanked_reason
       end
 
       def published_at?
         !@published_at.nil?
+      end
+
+      def prerelease?
+        @version_number =~ PYPI_PRERELEASE
+      end
+
+      def yanked?
+        @is_yanked
       end
     end
   end

--- a/spec/models/package_manager/pypi/json_api_project_release_spec.rb
+++ b/spec/models/package_manager/pypi/json_api_project_release_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe PackageManager::Pypi::JsonApiProjectRelease do
   describe "#published_at?" do
-    let(:release) { described_class.new(version_number: "1.0.0", published_at: published_at) }
+    let(:release) { described_class.new(version_number: "1.0.0", published_at: published_at, is_yanked: false, yanked_reason: nil) }
     let(:published_at) { nil }
 
     context "with nil published_at" do

--- a/spec/models/package_manager/pypi/json_api_project_releases_spec.rb
+++ b/spec/models/package_manager/pypi/json_api_project_releases_spec.rb
@@ -6,8 +6,8 @@ describe PackageManager::Pypi::JsonApiProjectReleases do
       described_class.new([release1, release2])
     end
 
-    let(:release1) { PackageManager::Pypi::JsonApiProjectRelease.new(version_number: "1.0.0", published_at: Time.now) }
-    let(:release2) { PackageManager::Pypi::JsonApiProjectRelease.new(version_number: "2.0.0", published_at: release2_published_at) }
+    let(:release1) { PackageManager::Pypi::JsonApiProjectRelease.new(version_number: "1.0.0", published_at: Time.now, is_yanked: false, yanked_reason: nil) }
+    let(:release2) { PackageManager::Pypi::JsonApiProjectRelease.new(version_number: "2.0.0", published_at: release2_published_at, is_yanked: false, yanked_reason: nil) }
 
     let(:release2_published_at) { Time.now }
 

--- a/spec/models/package_manager/pypi/version_processor_spec.rb
+++ b/spec/models/package_manager/pypi/version_processor_spec.rb
@@ -11,10 +11,10 @@ describe PackageManager::Pypi::VersionProcessor do
 
     let(:project_releases) do
       PackageManager::Pypi::JsonApiProjectReleases.new([
-        PackageManager::Pypi::JsonApiProjectRelease.new(version_number: "1.0.0", published_at: version1_time),
-        PackageManager::Pypi::JsonApiProjectRelease.new(version_number: "2.0.0", published_at: version2_time),
-        PackageManager::Pypi::JsonApiProjectRelease.new(version_number: "3.0.0", published_at: version3_time),
-        PackageManager::Pypi::JsonApiProjectRelease.new(version_number: "4.0.0", published_at: nil),
+        PackageManager::Pypi::JsonApiProjectRelease.new(version_number: "1.0.0", published_at: version1_time, is_yanked: false, yanked_reason: nil),
+        PackageManager::Pypi::JsonApiProjectRelease.new(version_number: "2.0.0", published_at: version2_time, is_yanked: false, yanked_reason: nil),
+        PackageManager::Pypi::JsonApiProjectRelease.new(version_number: "3.0.0", published_at: version3_time, is_yanked: false, yanked_reason: nil),
+        PackageManager::Pypi::JsonApiProjectRelease.new(version_number: "4.0.0", published_at: nil, is_yanked: false, yanked_reason: nil),
       ])
     end
 

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -42,74 +42,20 @@ describe PackageManager::Pypi do
   end
 
   describe "#deprecation_info" do
-    it "returns not-deprecated if last version isn't deprecated" do
-      expect(PackageManager::Pypi).to receive(:project).with("foo").and_return(
-        {
-          "releases" => {
-            "0.0.1" => [{}],
-            "0.0.2" => [{ "yanked" => true, "yanked_reason" => "This package is deprecated" }],
-            "0.0.3" => [{}],
-          },
-        }
+    let(:json_api_project) do
+      instance_double(
+        PackageManager::Pypi::JsonApiProject,
+        deprecated?: true,
+        deprecation_message: "wow"
       )
-
-      expect(described_class.deprecation_info(project)).to eq({ is_deprecated: false, message: nil })
     end
 
-    it "returns deprecated if last version is deprecated" do
-      expect(PackageManager::Pypi).to receive(:project).with("foo").and_return(
-        {
-          "releases" => {
-            "0.0.1" => [{}],
-            "0.0.2" => [{ "yanked" => true, "yanked_reason" => "This package is deprecated" }],
-            "0.0.3" => [{ "yanked" => true, "yanked_reason" => "This package is deprecated" }],
-          },
-        }
-      )
-
-      expect(described_class.deprecation_info(project)).to eq({ is_deprecated: true, message: "This package is deprecated" })
+    before do
+      allow(described_class).to receive(:project).with(project.name).and_return(json_api_project)
     end
 
-    it "returns not-deprecated if last version is a pre-release and deprecated" do
-      expect(PackageManager::Pypi).to receive(:project).with("foo").and_return(
-        {
-          "releases" => {
-            "0.0.1" => [{}],
-            "0.0.2" => [{}],
-            "0.0.3" => [{}],
-            "0.0.3a" => [{ "yanked" => true, "yanked_reason" => "This package is deprecated" }],
-            "0.0.3a1" => [{ "yanked" => true, "yanked_reason" => "This package is deprecated" }],
-          },
-        }
-      )
-
-      expect(described_class.deprecation_info(project)).to eq({ is_deprecated: false, message: nil })
-    end
-
-    it "return not-deprecated if 'development status' is not 'inactive'" do
-      expect(PackageManager::Pypi).to receive(:project).with("foo").and_return(
-        {
-          "releases" => {},
-          "info" => {
-            "classifiers" => ["Development Status :: 5 - Production/Stable"],
-          },
-        }
-      )
-
-      expect(described_class.deprecation_info(project)).to eq({ is_deprecated: false, message: nil })
-    end
-
-    it "return deprecated if 'development status' is 'inactive'" do
-      expect(PackageManager::Pypi).to receive(:project).with("foo").and_return(
-        {
-          "releases" => {},
-          "info" => {
-            "classifiers" => ["Development Status :: 7 - Inactive"],
-          },
-        }
-      )
-
-      expect(described_class.deprecation_info(project)).to eq({ is_deprecated: true, message: "Development Status :: 7 - Inactive" })
+    it "calls through to the json api project" do
+      expect(described_class.deprecation_info(project)).to eq({ is_deprecated: true, message: "wow" })
     end
   end
 


### PR DESCRIPTION
A mocked implementation of the output of project in the deprecation_info
tests made it so I missed that project was being used there. This moves
deprecation calculation into the JSON API classes and replaces the mocks
with a verifying instance double.