### PR TITLE
Enable pypi package versions to be individually marked as removed

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -176,12 +176,14 @@ module PackageManager
           .where.not(number: version_hashes.pluck(:number))
           .update_all(status: removed_status)
       when "pypi"
-        removed_versions = version_hashes.filter { |x| x[:yanked] }
+        removed_versions = version_hashes.filter { |x| x[:yanked] == true }
 
-        db_project
-          .versions
-          .where(number: removed_versions.pluck(:number))
-          .update_all(status: removed_status, updated_at: Time.zone.now)
+        if removed_versions.any?
+          db_project
+            .versions
+            .where(number: removed_versions.pluck(:number).compact)
+            .update_all(status: removed_status, updated_at: Time.zone.now)
+        end
       end
     end
 

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -166,13 +166,22 @@ module PackageManager
     end
 
     def self.deprecate_versions(db_project, version_hashes)
+      removed_status = "Removed"
+
       case db_project.platform.downcase
       # retracted go, unpublished npm, and yanked rubygems versions will be omitted from project JSON versions
       when "go", "npm", "rubygems"
         db_project
           .versions
           .where.not(number: version_hashes.pluck(:number))
-          .update_all(status: "Removed")
+          .update_all(status: removed_status)
+      when "pypi"
+        removed_versions = version_hashes.filter { |x| x[:yanked] }
+
+        db_project
+          .versions
+          .where(number: removed_versions.pluck(:number))
+          .update_all(status: removed_status, updated_at: Time.zone.now)
       end
     end
 

--- a/app/models/package_manager/pypi/json_api_project.rb
+++ b/app/models/package_manager/pypi/json_api_project.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PackageManager
   class Pypi
     class JsonApiProject
@@ -79,6 +81,7 @@ module PackageManager
       def releases
         JsonApiProjectReleases.new(
           @data["releases"].map do |version_number, details|
+            # this assumes that each file type distribution of the package/version has the same yanked status & reason
             first_details = details.first || {}
 
             JsonApiProjectRelease.new(

--- a/app/models/package_manager/pypi/json_api_project_release.rb
+++ b/app/models/package_manager/pypi/json_api_project_release.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PackageManager
   class Pypi
     class JsonApiProjectRelease

--- a/app/models/package_manager/pypi/version_processor.rb
+++ b/app/models/package_manager/pypi/version_processor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PackageManager
   class Pypi
     class VersionProcessor
@@ -15,11 +17,13 @@ module PackageManager
           original_license = json_api_single_release_for_version(version_number).license
           rss_api_release = rss_api_releases_hash[version_number]
           published_at = project_release.published_at || rss_api_release&.published_at
+          yanked = project_release&.yanked? || false
 
           {
             number: version_number,
             published_at: published_at,
             original_license: original_license,
+            yanked: yanked,
           }
         end
       end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -44,6 +44,11 @@ FactoryBot.define do
       platform { "Maven" }
       language { "Java" }
     end
+
+    trait :pypi do
+      platform { "Pypi" }
+      language { "Python" }
+    end
   end
 
   factory :platform do

--- a/spec/models/package_manager/pypi/version_processor_spec.rb
+++ b/spec/models/package_manager/pypi/version_processor_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe PackageManager::Pypi::VersionProcessor do
@@ -13,7 +15,7 @@ describe PackageManager::Pypi::VersionProcessor do
       PackageManager::Pypi::JsonApiProjectReleases.new([
         PackageManager::Pypi::JsonApiProjectRelease.new(version_number: "1.0.0", published_at: version1_time, is_yanked: false, yanked_reason: nil),
         PackageManager::Pypi::JsonApiProjectRelease.new(version_number: "2.0.0", published_at: version2_time, is_yanked: false, yanked_reason: nil),
-        PackageManager::Pypi::JsonApiProjectRelease.new(version_number: "3.0.0", published_at: version3_time, is_yanked: false, yanked_reason: nil),
+        PackageManager::Pypi::JsonApiProjectRelease.new(version_number: "3.0.0", published_at: version3_time, is_yanked: true, yanked_reason: "accidentally published"),
         PackageManager::Pypi::JsonApiProjectRelease.new(version_number: "4.0.0", published_at: nil, is_yanked: false, yanked_reason: nil),
       ])
     end
@@ -60,10 +62,10 @@ describe PackageManager::Pypi::VersionProcessor do
       results = version_processor.execute
 
       expect(results).to eq([
-      { number: "1.0.0", published_at: version1_time, original_license: "one" },
-      { number: "2.0.0", published_at: version2_time, original_license: "two" },
-      { number: "3.0.0", published_at: version3_time, original_license: "three" },
-      { number: "4.0.0", published_at: version4_time, original_license: "four" },
+      { number: "1.0.0", published_at: version1_time, original_license: "one", yanked: false },
+      { number: "2.0.0", published_at: version2_time, original_license: "two", yanked: false },
+      { number: "3.0.0", published_at: version3_time, original_license: "three", yanked: true },
+      { number: "4.0.0", published_at: version4_time, original_license: "four", yanked: false },
       ])
     end
   end


### PR DESCRIPTION
The Pypi api returns a yanked status at the package release level. This PR extracts that data and stores it in the database for each Pypi package version.

One assumption this PR makes is that if there are multiple distributions of a package release (e.g. `package-1.0.0.tar.gz`, `package-1.0.0.whl`), if one of the package releases is yanked then all of the package releases are yanked. 

There are also a couple of rubocop autocorrect fixes in the PR. 