### PR TITLE
Centralize env-based external key config in application.rb

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,3 +8,13 @@ require File.expand_path("config/application", __dir__)
 Rails.application.load_tasks
 
 require "elasticsearch/rails/tasks/import"
+
+desc "Run the linter"
+task :lint do
+  sh "bundle exec rubocop -P"
+end
+
+desc "Run the linter with autofix"
+task :fix do
+  sh "bundle exec rubocop -A"
+end

--- a/app/models/concerns/github_identity.rb
+++ b/app/models/concerns/github_identity.rb
@@ -23,11 +23,11 @@ module GithubIdentity
 
   def github_settings_url
     if private_repo_token.present?
-      key = ENV["GITHUB_PRIVATE_KEY"]
+      Rails.configuration.github_private_key
     elsif public_repo_token.present?
-      key = ENV["GITHUB_PUBLIC_KEY"]
+      Rails.configuration.github_public_key
     elsif github_token.present?
-      key = ENV["GITHUB_KEY"]
+      Rails.configuration.github_key
     else
       return nil
     end

--- a/app/models/repository_host/bitbucket.rb
+++ b/app/models/repository_host/bitbucket.rb
@@ -193,7 +193,7 @@ module RepositoryHost
     end
 
     def self.api_client(token = nil)
-      BitBucket.new oauth_token: token || ENV["BITBUCKET_KEY"]
+      BitBucket.new oauth_token: token || Rails.configuration.bitbucket_key
     end
 
     private

--- a/app/models/repository_host/gitlab.rb
+++ b/app/models/repository_host/gitlab.rb
@@ -188,7 +188,7 @@ module RepositoryHost
     end
 
     def self.api_client(token = nil)
-      ::Gitlab.client(endpoint: "https://gitlab.com/api/v4", private_token: token || ENV["GITLAB_KEY"])
+      ::Gitlab.client(endpoint: "https://gitlab.com/api/v4", private_token: token || Rails.configuration.gitlab_key)
     end
 
     private

--- a/app/models/repository_owner/bitbucket.rb
+++ b/app/models/repository_owner/bitbucket.rb
@@ -27,7 +27,7 @@ module RepositoryOwner
     end
 
     def self.api_client(token = nil)
-      BitBucket.new oauth_token: token || ENV["BITBUCKET_KEY"]
+      BitBucket.new oauth_token: token || Rails.configuration.bitbucket_key
     end
 
     def api_client(token = nil)

--- a/app/models/repository_owner/gitlab.rb
+++ b/app/models/repository_owner/gitlab.rb
@@ -27,7 +27,7 @@ module RepositoryOwner
     end
 
     def self.api_client(token = nil)
-      ::Gitlab.client(endpoint: "https://gitlab.com/api/v4", private_token: token || ENV["GITLAB_KEY"])
+      ::Gitlab.client(endpoint: "https://gitlab.com/api/v4", private_token: token || Rails.configuration.gitlab_key)
     end
 
     def api_client(token = nil)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,26 +31,26 @@
   <link rel="canonical" href="https://libraries.io<%= yield(:canonical_url) %>" />
   <% end %>
   <link href="/opensearch.xml" title="Libraries.io" rel="search" type="application/opensearchdescription+xml">
-  <% if ENV["GA_ANALYTICS_ID"].present? %>
+  <% if Rails.configuration.ga_analytics_id.present? %>
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
       <% if logged_in? %>
-        ga('create', '<%= ENV["GA_ANALYTICS_ID"] %>', 'auto', { 'userId': <%= current_user.id %> });
+        ga('create', '<%= Rails.configuration.ga_analytics_id %>', 'auto', { 'userId': <%= current_user.id %> });
       <% else %>
-        ga('create', '<%= ENV["GA_ANALYTICS_ID"] %>', 'auto');
+        ga('create', '<%= Rails.configuration.ga_analytics_id %>', 'auto');
       <% end %>
     </script>
     <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=IntersectionObserver"></script>
   <% end %>
-  <% if ENV["GTM_ID"].present? %>
+  <% if Rails.configuration.gtm_id.present? %>
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','<%= ENV["GTM_ID"] %>');</script>
+    })(window,document,'script','dataLayer','<%= Rails.configuration.gtm_id %>');</script>
   <% end %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <script type="application/ld+json">

--- a/config/application.rb
+++ b/config/application.rb
@@ -65,5 +65,22 @@ module Libraries
                  max_age: 86400)
       end
     end
+
+    # Env-based config
+    config.github_public_key = ENV["GITHUB_PUBLIC_KEY"]
+    config.github_public_secret = ENV["GITHUB_PUBLIC_SECRET"]
+    config.github_private_key = ENV["GITHUB_PRIVATE_KEY"]
+    config.github_private_secret = ENV["GITHUB_PRIVATE_SECRET"]
+    config.github_key = ENV["GITHUB_KEY"]
+    config.github_secret = ENV["GITHUB_SECRET"]
+    config.bitbucket_key = ENV["BITBUCKET_KEY"]
+    config.gitlab_key = ENV["GITLAB_KEY"]
+    config.gitlab_application_id = ENV["GITLAB_APPLICATION_ID"]
+    config.gitlab_secret = ENV["GITLAB_SECRET"]
+    config.bugsnag_api_key = ENV["BUGSNAG_API_KEY"]
+    config.bitbucket_application_id = ENV["BITBUCKET_APPLICATION_ID"]
+    config.bitbucket_secret = ENV["BITBUCKET_SECRET"]
+    config.ga_analytics_id = ENV["GA_ANALYTICS_ID"]
+    config.gtm_id = ENV["GTM_ID"]
   end
 end

--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -2,7 +2,7 @@
 
 if Rails.env.production?
   Bugsnag.configure do |config|
-    config.api_key = ENV["BUGSNAG_API_KEY"]
+    config.api_key = Rails.configuration.bugsnag_api_key
     config.ignore_classes << ActiveRecord::RecordNotFound
     # Temprarily uncomment this is we get a huge spike of these errors and need to investigate:
     config.ignore_classes << PackageManagerDownloadWorker::VersionUpdateFailure

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -15,11 +15,11 @@ module OmniAuth
 end
 
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :github, ENV["GITHUB_KEY"], ENV["GITHUB_SECRET"], scope: "user:email"
-  provider :github_public, ENV["GITHUB_PUBLIC_KEY"], ENV["GITHUB_PUBLIC_SECRET"], scope: "user:email,write:repo_hook,read:org", request_path: "/auth/github_public", callback_path: "/auth/github_public/callback"
-  provider :github_private, ENV["GITHUB_PRIVATE_KEY"], ENV["GITHUB_PRIVATE_SECRET"], scope: "user:email,repo,read:org", request_path: "/auth/github_private", callback_path: "/auth/github_private/callback"
-  provider :gitlab, ENV["GITLAB_APPLICATION_ID"], ENV["GITLAB_SECRET"], scope: "read_user"
-  provider :bitbucket, ENV["BITBUCKET_APPLICATION_ID"], ENV["BITBUCKET_SECRET"]
+  provider :github, Rails.configuration.github_key, Rails.configuration.github_secret, scope: "user:email"
+  provider :github_public, Rails.configuration.github_public_key, Rails.configuration.github_public_secret, scope: "user:email,write:repo_hook,read:org", request_path: "/auth/github_public", callback_path: "/auth/github_public/callback"
+  provider :github_private, Rails.configuration.github_private_key, Rails.configuration.github_private_secret, scope: "user:email,repo,read:org", request_path: "/auth/github_private", callback_path: "/auth/github_private/callback"
+  provider :gitlab, Rails.configuration.gitlab_application_id, Rails.configuration.gitlab_secret, scope: "read_user"
+  provider :bitbucket, Rails.configuration.bitbucket_application_id, Rails.configuration.bitbucket_secret
 end
 
 Rails.application.config.default_provider = :github


### PR DESCRIPTION
Having these in one place (application.rb) makes them easier to see at-once, and would make it easier to transition to [Rails' stored credentials](https://guides.rubyonrails.org/security.html#custom-credentials) if we ever do that (e.g. we'd just replace `Rails.configuration.foo` with `Rails.application.credentials.foo`)