### PR TITLE
Update Libraries Pypi parser to handle different "homepage" variations

### DIFF
--- a/app/models/package_manager/pypi/json_api_project.rb
+++ b/app/models/package_manager/pypi/json_api_project.rb
@@ -68,7 +68,10 @@ module PackageManager
 
       def homepage_url
         @data.dig("info", "home_page").presence ||
-          @data.dig("info", "project_urls", "Homepage")
+          @data.dig("info", "project_urls", "Homepage") ||
+          @data.dig("info", "project_urls", "Home") ||
+          @data.dig("info", "project_urls", "homepage") ||
+          @data.dig("info", "project_urls", "HomePage")
       end
 
       def preferred_repository_url

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -489,4 +489,23 @@ describe PackageManager::Pypi do
       end
     end
   end
+
+  describe "#homepage_url" do
+    context "when the homepage URL is returned in a different format" do
+      let(:project_home_url) { "https://www.libraries.io/package_name/home" }
+      let(:project) do
+        PackageManager::Pypi::JsonApiProject.new(
+          {
+            "info" => {
+              "project_urls" => { "Home" => project_home_url },
+            },
+          }
+        )
+      end
+
+      it "returns the homepage URL" do
+        expect(project.homepage_url).to be_present
+      end
+    end
+  end
 end

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -489,7 +489,9 @@ describe PackageManager::Pypi do
       end
     end
   end
+end
 
+describe PackageManager::Pypi::JsonApiProject do
   describe "#homepage_url" do
     context "when the homepage URL is returned in a different format" do
       let(:project_home_url) { "https://www.libraries.io/package_name/home" }


### PR DESCRIPTION
Libraries will display a "Homepage" link for each package where we have such data available.
Libraries example: https://libraries.io/pypi/PyICU
Pypi source: https://pypi.org/project/PyICU/ (note the "Homepage" link under "Project links")

In the JSON API response we look for `home_page` or  `project_urls` => `Homepage` to populate this field in Libraries.

However, Pypi is not consistent with this field, and different projects will refer to this field in different ways. I've also observed:
- `project_urls` => `Home`
- `project_urls` => `homepage`
- `project_urls` => `HomePage`

Examples from Pypi where we are missing homepage data on Libraries:
- https://pypi.org/project/jupyter-server-fileid/
- https://pypi.org/project/nlbq/
- https://pypi.org/project/objverify/
- https://pypi.org/project/attacus/
- https://pypi.org/project/coolapi/
- https://pypi.org/project/songwhip/
- https://pypi.org/project/smartdoor/
- https://pypi.org/project/bit8/

This changes ensures we parse out the few additional fields that are also used on PyPI, so checking these ones in addition should allow us to fill in more homepage data.