### PR TITLE
Allow pypi project versions to change statuses

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -177,16 +177,8 @@ module PackageManager
           .where.not(number: version_hashes.pluck(:number))
           .where("status != ? or status is null", removed_status)
           .update_all(status: removed_status, updated_at: current_time)
-      when "pypi"
-        removed_versions = version_hashes.filter { |x| x[:yanked] == true }
-
-        if removed_versions.any?
-          db_project
-            .versions
-            .where(number: removed_versions.pluck(:number).compact)
-            .where("status != ? or status is null", removed_status)
-            .update_all(status: removed_status, updated_at: current_time)
-        end
+        # yanked pypi versions are marked as such in the api, and the majority of them are handled upstream of here
+        # TODO: if libraries knows about the version but pypi does not, also mark the version differences as deprecated
       end
     end
 

--- a/app/models/package_manager/base/api_version_to_upsert.rb
+++ b/app/models/package_manager/base/api_version_to_upsert.rb
@@ -22,14 +22,17 @@ module PackageManager
       end
 
       def to_version_model_attributes
-        {
+        non_nillable_attributes = {
           number: @version_number,
           published_at: @published_at,
           runtime_dependencies_count: @runtime_dependencies_count,
           original_license: @original_license,
           repository_sources: @repository_sources,
-          status: @status,
         }.compact
+
+        # If the status is currently "Removed" and a change comes in to update that status to nil/"Active",
+        # Update the version's status
+        non_nillable_attributes.merge({ status: @status })
       end
     end
   end

--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -98,7 +98,7 @@ module PackageManager
       Project
         .find_by(platform: "Pypi", name: name)
         &.versions
-        &.map { |v| v.slice(:number, :published_at, :original_license).symbolize_keys }
+        &.map { |v| v.slice(:number, :published_at, :original_license, :status).symbolize_keys }
         &.index_by { |v| v[:number] } || {}
     end
 


### PR DESCRIPTION
This PR allows changes to the status field on existing Pypi project version.

For Pypi projects, the existing code short circuits updating the version if Libraries already knows about the version. I suspect this is due to not wanting to make multiple external API calls per project version on lookup of a project's versions, especially for the individual version's license & published_ats. This makes sense, as it would get extremely expensive for projects that have tens of thousands of releases, and we don't expect versions to change that much after they get published (e.g. once a version is published, we don't expect its published date to change). Doing this set of lookups/updates only when we see a new version that we haven't seen before mitigates that concern.

However, this existing short circuit prevents us from updating project versions if something changes about it after publication -- such as when a specific version gets yanked. This PR changes that behavior slightly to allow updates to the status if we see that the version has been yanked, which we get from the main project API call. If the version is marked with `yanked: true`, we will change the version.status to 'Removed'; if it is not, then we either keep the existing status or set the status to nil (the "unyanking" case). Setting the version.status is done in the Pypi specific version processor, and the update happens in the `add_version` call, which is more of an upsert at this point. This means the `deprecate_version` method is effectively not doing anything for Pypi projects, but I've left a note there that it may need to get updated to support the "libraries knows about the version, but pypi doesn't (probably because it was hard deleted on the package manager side)" scenario. 