### PR TITLE
Update Libraries Pypi parser to handle different "homepage" variations rework

### DIFF
--- a/app/models/package_manager/pypi/json_api_project.rb
+++ b/app/models/package_manager/pypi/json_api_project.rb
@@ -49,7 +49,11 @@ module PackageManager
       end
 
       def homepage
-        @data.dig("info", "home_page")
+        @data.dig("info", "home_page").presence ||
+          @data.dig("info", "project_urls", "Homepage") ||
+          @data.dig("info", "project_urls", "Home") ||
+          @data.dig("info", "project_urls", "homepage") ||
+          @data.dig("info", "project_urls", "HomePage")
       end
 
       def keywords_array
@@ -66,18 +70,10 @@ module PackageManager
         end.first
       end
 
-      def homepage_url
-        @data.dig("info", "home_page").presence ||
-          @data.dig("info", "project_urls", "Homepage") ||
-          @data.dig("info", "project_urls", "Home") ||
-          @data.dig("info", "project_urls", "homepage") ||
-          @data.dig("info", "project_urls", "HomePage")
-      end
-
       def preferred_repository_url
         RepositoryService.repo_fallback(
           repository_url,
-          homepage_url
+          homepage
         )
       end
 

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -506,7 +506,7 @@ describe PackageManager::Pypi::JsonApiProject do
       end
 
       it "returns the homepage URL" do
-        expect(project.homepage_url).to be_present
+        expect(project.homepage).to be_present
       end
     end
   end


### PR DESCRIPTION
This slightly reworks the changes introduced in #3174.

The previous PR does updates the `homepage_url` value used, but that is not ultimately used to set the `Project#homepage` value: https://github.com/librariesio/libraries.io/blob/456440d4ece34fdc96965ddaa36da2b9fcdaa36e/app/models/package_manager/pypi/json_api_project.rb#L106

The `homepage_url` value is only passed into the [`repo_fallback` method](https://github.com/librariesio/libraries.io/blob/main/app/models/package_manager/repository_service.rb#L14-L20), which is used to set the `repository_url`.

I don't see a need to distinguish between the `homepage` and `homepage_url` methods, so this consolidates them.