### PR TITLE
move flash above the navbar, remove '+ more' text

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -238,6 +238,12 @@ a.rss{
   color: #FF6600;
 }
 
+.flash-banner {
+  background-color: #733153;
+  color: white;
+  padding: 12px 0;
+}
+
 .alert {
   margin-top: 10px;
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -87,6 +87,7 @@
   </script>
 </head>
 <body>
+  <%= render 'shared/flash' %>
   <div class="navbar navbar-inverse navbar-static-top">
     <div class="container">
       <div class="navbar-header">
@@ -158,7 +159,6 @@
   </div>
 
   <div class="container">
-    <%= render 'shared/flash' %>
     <%= yield %>
   </div>
   <%= render 'layouts/footer' %>

--- a/app/views/projects/_dev_practices.erb
+++ b/app/views/projects/_dev_practices.erb
@@ -12,7 +12,7 @@
         'Dependencies are managed',
         'Issue-free release available',
         'Succession plan available',
-        'Package manager 2FA enable'
+        'Package manager 2FA enabled'
       ].each do |practice|
     %>
       <dt class='col-xs-9'>
@@ -22,9 +22,6 @@
         <b>TEXT!</b>
       </dd>
     <%end%>
-  </div>
-  <div class='col-xs-8'>
-    <b>+ 12 more</b>
   </div>
   <div class='col-xs-12 has-margin-top'>
     <div class='has-margin-top'>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -47,8 +47,10 @@
 <% end %>
 
 <% if flash.empty? %>
-  <div class="alert alert-info hidden-xs" role="alert" style="background-color: #F6914D; border-color: #F6914D; color: white;">
-    <img src="<%= image_url('tidelift-small.png') %>" width="36px" style="padding-right: 12px;" />
+  <div
+    class="flash-banner text-center hidden-xs"
+    role="alert"
+  >
     <%= render :file => tidelift_flash_partial %>
   </div>
 <% end %>


### PR DESCRIPTION
* move the flash banner above the navbar
* change tidelift banner styling (new bg color, center aligned, no tidelift logo)
* fix typo in dev-practices
* 
<img width="1440" alt="image" src="https://github.com/librariesio/libraries.io/assets/7821335/4b72a4e1-777a-4425-9358-aee15ef1e4a7">
