### PR TITLE
fix: [sc-36694] [libraries] Fix encoding error when scraping README contents

### DIFF
--- a/app/models/readme.rb
+++ b/app/models/readme.rb
@@ -40,7 +40,7 @@ class Readme < ApplicationRecord
     return unless content.present?
     return unless supported_format?(path)
 
-    GitHub::Markup.render(path, content.force_encoding("UTF-8"))
+    GitHub::Markup.render(path, content.force_encoding(Encoding::UTF_8))
   rescue GitHub::Markup::CommandError
     nil
   end
@@ -89,6 +89,6 @@ class Readme < ApplicationRecord
       rescue NoMethodError, URI::InvalidURIError, URI::InvalidComponentError # rubocop: disable Lint/SuppressedException
       end
     end
-    self.html_body = doc.to_s
+    self.html_body = doc.to_html(encoding: Encoding::UTF_8)
   end
 end

--- a/app/models/repository_host/github.rb
+++ b/app/models/repository_host/github.rb
@@ -165,14 +165,14 @@ module RepositoryHost
     end
 
     def download_readme(token = nil)
-      contents = {
-        html_body: api_client(token).readme(repository.full_name, accept: "application/vnd.github.V3.html"),
-      }
+      contents = api_client(token)
+        .readme(repository.full_name, accept: "application/vnd.github.V3.html")
+        .force_encoding(Encoding::UTF_8)
 
       if repository.readme.nil?
-        repository.create_readme(contents)
+        repository.create_readme(html_body: contents)
       else
-        repository.readme.update(contents)
+        repository.readme.update(html_body: contents)
       end
     rescue *IGNORABLE_EXCEPTIONS
       nil


### PR DESCRIPTION
Story details: https://app.shortcut.com/tidelift/story/36694