### PR TITLE
fix: README scraping: duplicate key error

### DIFF
--- a/app/models/repository_host/bitbucket.rb
+++ b/app/models/repository_host/bitbucket.rb
@@ -103,7 +103,7 @@ module RepositoryHost
       content = Readme.format_markup(readme_path, file[:content])
       return unless content.present?
 
-      if repository.readme.nil?
+      if repository.reload_readme.nil?
         repository.create_readme(html_body: content)
       else
         repository.readme.update(html_body: content)

--- a/app/models/repository_host/github.rb
+++ b/app/models/repository_host/github.rb
@@ -169,7 +169,7 @@ module RepositoryHost
         .readme(repository.full_name, accept: "application/vnd.github.V3.html")
         .force_encoding(Encoding::UTF_8)
 
-      if repository.readme.nil?
+      if repository.reload_readme.nil?
         repository.create_readme(html_body: contents)
       else
         repository.readme.update(html_body: contents)

--- a/app/models/repository_host/gitlab.rb
+++ b/app/models/repository_host/gitlab.rb
@@ -110,7 +110,7 @@ module RepositoryHost
       content = Readme.format_markup(readme_path, file[:content])
       return unless content.present?
 
-      if repository.readme.nil?
+      if repository.reload_readme.nil?
         repository.create_readme(html_body: content)
       else
         repository.readme.update(html_body: content)


### PR DESCRIPTION
This may be an old issue or one that cropped up after Rails upgrades. But it looks like we're getting cases where the readme record associated to a repository exists in the database, but hasn't been loaded by ActiveRecord (or was inserted by another thread?), and the existing basic nil check doesn't work. Unless there's a bigger problem this should cut down on these [snags](https://app.bugsnag.com/tidelift/libraries-dot-io/errors/631906c923d8450008a59c5e).