### PR TITLE
chore: Roll out bumping Rails' defaults to current production version

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,8 +23,7 @@ Bundler.require(*Rails.groups)
 
 module Libraries
   class Application < Rails::Application
-    # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.2
+    config.load_defaults 6.1
     config.autoloader = :zeitwerk
 
     # Configuration for the application, engines, and railties goes here.

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -9,14 +9,14 @@
 # Read the Rails 5.0 release notes for more info on each option.
 
 # Enable per-form CSRF tokens. Previous versions had false.
-Rails.application.config.action_controller.per_form_csrf_tokens = false
+# Rails.application.config.action_controller.per_form_csrf_tokens = false
 
 # Enable origin-checking CSRF mitigation. Previous versions had false.
-Rails.application.config.action_controller.forgery_protection_origin_check = false
+# Rails.application.config.action_controller.forgery_protection_origin_check = false
 
 # Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
 # Previous versions had false.
-ActiveSupport.to_time_preserves_timezone = false
+# ActiveSupport.to_time_preserves_timezone = false
 
 # Require `belongs_to` associations by default. Previous versions had false.
 Rails.application.config.active_record.belongs_to_required_by_default = false


### PR DESCRIPTION
Ahead of rolling out Rails 7, I want to get the defaults to a closer version. 

AFAICT, the only default that is still relevant is `active_record.belongs_to_required_by_default = false`. Given it is still supported as an option, we don't need to prioritize unwinding all that. The others pertain to libraries we're not using or should be safe to enable once we're stable on 6.1, which we seem to be.

