### PR TITLE
Update bugsnag config to not need to autoload constants, fix build issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,7 +138,7 @@ GEM
       sassc (>= 2.0.0)
     brakeman (4.5.1)
     brotli (0.2.3)
-    bugsnag (6.24.2)
+    bugsnag (6.26.0)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)

--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -3,9 +3,9 @@
 if Rails.env.production?
   Bugsnag.configure do |config|
     config.api_key = Rails.configuration.bugsnag_api_key
-    config.ignore_classes << ActiveRecord::RecordNotFound
+    config.discard_classes << "ActiveRecord::RecordNotFound"
     # Temprarily uncomment this is we get a huge spike of these errors and need to investigate:
-    config.ignore_classes << PackageManagerDownloadWorker::VersionUpdateFailure
+    config.discard_classes << "PackageManagerDownloadWorker::VersionUpdateFailure"
 
     if File.exist?("#{Rails.root}/REVISION")
       config.app_version = File.read("#{Rails.root}/REVISION").strip


### PR DESCRIPTION
Autoloading this PackageManagerDownloadWorker::VersionUpdateFailure is causing a build issue, but the good news is, we don't have to.

https://github.com/bugsnag/bugsnag-ruby/blob/master/CHANGELOG.md?plain=1#L258/bugsnag/bugsnag-ruby/blob/bdfbf3972f2137b3b9b95194a6bedf9c8edf6555/CHANGELOG.md?plain=1#L258