### PR TITLE
SearchController#index: short-circuit when no search term is provided

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -3,11 +3,18 @@
 class SearchController < ApplicationController
   def index
     @query = params[:q]
-    @search = search_projects(@query)
-    @suggestion = @search.response.suggest.did_you_mean.first if @query.present?
-    @projects = @search.results.map { |result| ProjectSearchResult.new(result) }
-    @facets = @search.response.aggregations
+    @search = []
+    @projects = []
+    @facets = []
     @title = page_title
+
+    if @query.present?
+      @search = search_projects(@query)
+      @suggestion = @search.response.suggest.did_you_mean.first
+      @projects = @search.results.map { |result| ProjectSearchResult.new(result) }
+      @facets = @search.response.aggregations
+    end
+
     respond_to do |format|
       format.html
       format.atom

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,11 +41,10 @@ module ApplicationHelper
                                      else
                                        collection.first.class.name.split("::").last.titleize
                                      end)
-    if collection.total_pages < 2
-      case collection.size
-      when 0 then "No #{entry_name.pluralize} found"
-      else; "#{collection.total_entries} #{entry_name.pluralize}"
-      end
+    if collection.empty?
+      "No #{entry_name.pluralize} found"
+    elsif collection.total_pages < 2
+      "#{collection.total_entries} #{entry_name.pluralize}"
     else
       format(%(%d - %d of #{number_to_human(collection.total_entries)} #{entry_name.pluralize}), collection.offset + 1, collection.offset + collection.length)
     end

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -10,6 +10,9 @@
       <div class="row">
         <div class="col-xs-6">
           <h5><%= search_page_entries_info @search, model: 'package' %></h5>
+          <% unless @query.present? %>
+            <p>Please provide a search term and try again</p>
+          <% end %>
         </div>
         <div class="col-xs-6">
           <div class="btn-group pull-right">

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -4,19 +4,43 @@ require "rails_helper"
 
 describe "SearchController", elasticsearch: true do
   let!(:project) { create(:project) }
+  let(:search_term) { project.name }
 
   describe "GET /search", type: :request do
+    context "without a search term" do
+      let(:search_term) { "" }
+
+      it "renders instructions to try again" do
+        Project.__elasticsearch__.refresh_index!
+        visit search_path(params: { q: search_term })
+
+        expect(page).not_to have_content project.name
+        expect(page).to have_content "Please provide a search term and try again"
+      end
+    end
+
     it "renders successfully when logged out" do
       Project.__elasticsearch__.refresh_index!
-      visit search_path
+      visit search_path(params: { q: search_term })
       expect(page).to have_content project.name
     end
   end
 
   describe "GET /search.atom", type: :request do
+    context "without a search term" do
+      let(:search_term) { "" }
+
+      it "renders no results" do
+        Project.__elasticsearch__.refresh_index!
+        visit search_path(params: { q: search_term })
+
+        expect(page).not_to have_content project.name
+      end
+    end
+
     it "renders successfully when logged out" do
       Project.__elasticsearch__.refresh_index!
-      visit search_path(format: :atom)
+      visit search_path(params: { q: search_term }, format: :atom)
       expect(page).to have_content project.name
     end
   end


### PR DESCRIPTION
This prevents expensive elasticsearch queries that have been the target of scraping efforts.

![Screenshot 2023-09-22 at 11 35 42 AM](https://github.com/librariesio/libraries.io/assets/624279/f6d005b5-cdeb-4127-9f93-15b7fe44f698)
