### PR TITLE
feat: [sc-31318] [libraries] Backfill NuGet packages in libraries

### DIFF
--- a/app/models/concerns/status.rb
+++ b/app/models/concerns/status.rb
@@ -16,4 +16,8 @@ module Status
   def maintained?
     !deprecated? && !removed? && !unmaintained?
   end
+
+  def hidden?
+    status == "Hidden"
+  end
 end

--- a/app/models/package_manager/nu_get.rb
+++ b/app/models/package_manager/nu_get.rb
@@ -237,7 +237,10 @@ module PackageManager
     class ParseCanonicalNameFailedError < StandardError; end
 
     # Returns canonical casing for case-insensitive NuGet package names
-    # @return String, false, nil
+    # @param name [String] A given project name to check
+    # @return [String] If successfully found, the canonical form of the given name
+    # @return [nil] The scrape request was unsuccessful
+    # @return [false] The scrape succeeded, but we didn't detect a name
     def self.fetch_canonical_nuget_name(name)
       base_url = "https://nuget.org/packages/"
       page = get_html("#{base_url}#{name}")

--- a/app/models/package_manager/nu_get.rb
+++ b/app/models/package_manager/nu_get.rb
@@ -237,15 +237,19 @@ module PackageManager
     class ParseCanonicalNameFailedError < StandardError; end
 
     # Returns canonical casing for case-insensitive NuGet package names
+    # @return String, false, nil
     def self.fetch_canonical_nuget_name(name)
       base_url = "https://nuget.org/packages/"
       page = get_html("#{base_url}#{name}")
       og_url_element = page.css("meta[property='og:url']").first
 
-      # This is likely to be a transient error or a sign the package was removed.
-      # A spike could indicate something systemic, however.
-      unless og_url_element
+      if page.text.empty? # Request failed, likely temporarily
         StructuredLog.capture("FETCH_CANONICAL_NAME_FAILED", { platform: "nuget", name: name })
+        return nil
+      elsif og_url_element.nil?
+        # If we got a response, but don't find this element, it most likely means
+        # the project was removed upstream.
+        StructuredLog.capture("CANONICAL_NAME_ELEMENT_MISSING", { platform: "nuget", name: name })
         return false
       end
 
@@ -253,7 +257,7 @@ module PackageManager
       canonical_name = og_url.sub(base_url, "").sub(/\/$/, "")
 
       # If we got as far as to grab values but they don't meet our assumptions, this should be
-      # exceptional. It could mean we need to change our strategy here.
+      # exceptional. It likely means we need to update this method.
       if !og_url.start_with?(base_url) || canonical_name.blank?
         raise ParseCanonicalNameFailedError, "Could not parse a canonical name for `#{name}`. Did upstream change their markup structure?"
       end

--- a/app/workers/nuget_project_verification_worker.rb
+++ b/app/workers/nuget_project_verification_worker.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# This worker is meant to verify if this package name is correct and is and we
+# keep one canonically named record for each project.
+class NugetProjectVerificationWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :small
+
+  def perform(name)
+    project = Project.platform("NuGet").find_by(name: name)
+
+    return if project.nil? || project&.removed? || project&.hidden?
+
+    canonical_name = PackageManager::NuGet.fetch_canonical_nuget_name(project.name)
+    return unless canonical_name
+
+    if project.name != canonical_name
+      # Soft-delete erroneous projects until we're sure it's safe to remove them
+      project.update!(status: "Hidden")
+
+      StructuredLog.capture(
+        "PROJECT_MARKED_NONCANONICAL",
+        {
+          platform: project.platform,
+          name: project.name,
+          project_id: project.id,
+          canonical_name: canonical_name,
+        }
+      )
+    end
+  end
+end

--- a/app/workers/nuget_project_verification_worker.rb
+++ b/app/workers/nuget_project_verification_worker.rb
@@ -4,7 +4,7 @@
 # keep one canonically named record for each project.
 class NugetProjectVerificationWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :small
+  sidekiq_options queue: :small, retry: 3, unique: :until_executed
 
   def perform(id)
     project = Project

--- a/app/workers/nuget_project_verification_worker.rb
+++ b/app/workers/nuget_project_verification_worker.rb
@@ -6,10 +6,13 @@ class NugetProjectVerificationWorker
   include Sidekiq::Worker
   sidekiq_options queue: :small
 
-  def perform(name)
-    project = Project.platform("NuGet").find_by(name: name)
+  def perform(id)
+    project = Project
+      .platform("NuGet")
+      .visible # Skip projects that are already out of circulation
+      .find_by(id: id)
 
-    return if project.nil? || project&.removed? || project&.hidden?
+    return if project.nil?
 
     canonical_name = PackageManager::NuGet.fetch_canonical_nuget_name(project.name)
     return unless canonical_name

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -299,12 +299,14 @@ namespace :projects do
   task :verify_nuget_projects, [:count] => :environment do |_task, args|
     args.with_defaults(count: 100)
 
+    batch_interval = (60.seconds / 100.0) * args.count
+
     Project
       .platform("NuGet")
       .visible
-      .find_in_batches(batch_size: count) do |project_batch|
+      .find_in_batches(batch_size: args.count) do |project_batch|
         project_batch.each do |project|
-          NugetProjectVerificationWorker.perform_async(project.id)
+          NugetProjectVerificationWorker.perform_in(batch_interval, project.id)
         end
       end
   end

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -295,6 +295,20 @@ namespace :projects do
     end
   end
 
+  desc "Verify NuGet Projects"
+  task :verify_nuget_projects, [:count] => :environment do |_task, args|
+    args.with_defaults(count: 100)
+
+    Project
+      .platform("NuGet")
+      .visible
+      .find_in_batches(batch_size: count) do |project_batch|
+        project_batch.each do |project|
+          NugetProjectVerificationWorker.perform_async(project.id)
+        end
+      end
+  end
+
   desc "Manual sync projects from list"
   task :sync_from_list, %i[input_file commit] => :environment do |_t, args|
     commit = args.commit.present? && args.commit == "yes"

--- a/spec/custom_matchers.rb
+++ b/spec/custom_matchers.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module CustomMatchers
+  RSpec::Matchers.define_negated_matcher :not_change, :change
+
   RSpec::Matchers.define :be_json_string_matching do |expected|
     match do |json_string|
       values_match?(expected, JSON.parse(json_string))

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -19,6 +19,10 @@ FactoryBot.define do
     "https://github.com/rails/rails#{n}"
   end
 
+  trait :removed do
+    status { "Removed" }
+  end
+
   factory :project do
     name
     platform        { "Rubygems" }

--- a/spec/models/package_manager/nu_get_spec.rb
+++ b/spec/models/package_manager/nu_get_spec.rb
@@ -276,7 +276,17 @@ describe PackageManager::NuGet do
         end
       end
 
-      context "when possibly removed" do
+      context "when request failed" do
+        let(:stub_page) { Nokogiri::HTML("") }
+
+        it "logs instance and returns nil" do
+          expect(StructuredLog).to receive(:capture).with("FETCH_CANONICAL_NAME_FAILED", { platform: "nuget", name: name })
+
+          expect(result).to eq(nil)
+        end
+      end
+
+      context "when element missing" do
         let(:stub_page) do
           Nokogiri::HTML(
             <<~HTML
@@ -290,10 +300,10 @@ describe PackageManager::NuGet do
           )
         end
 
-        it "logs fetch error and returns false" do
-          expect(StructuredLog).to receive(:capture).with("FETCH_CANONICAL_NAME_FAILED", { platform: "nuget", name: name })
+        it "logs instance and returns false" do
+          expect(StructuredLog).to receive(:capture).with("CANONICAL_NAME_ELEMENT_MISSING", { platform: "nuget", name: name })
 
-          expect(result).to be(false)
+          expect(result).to eq(false)
         end
       end
 

--- a/spec/workers/nuget_project_verification_worker_spec.rb
+++ b/spec/workers/nuget_project_verification_worker_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 describe NugetProjectVerificationWorker do
-  let(:project) { create(:project, :nuget, name: name) }
   let(:canonical_name) { "Newtonsoft.Json" }
+  let(:project) { create(:project, :nuget, name: name) }
 
   before do
     allow(PackageManager::NuGet).to receive(:fetch_canonical_nuget_name)
@@ -18,7 +18,7 @@ describe NugetProjectVerificationWorker do
   context "name matches canonical" do
     let(:name) { canonical_name }
     it "doesn't touch project status" do
-      expect { subject.perform(name) }.to not_change { project.reload.status }.from(nil)
+      expect { subject.perform(project.id) }.to not_change { project.reload.status }.from(nil)
     end
   end
 
@@ -26,7 +26,7 @@ describe NugetProjectVerificationWorker do
     let(:name) { canonical_name.upcase }
 
     it "marks project hidden" do
-      expect { subject.perform(name) }.to change { project.reload.status }.from(nil).to("Hidden")
+      expect { subject.perform(project.id) }.to change { project.reload.status }.from(nil).to("Hidden")
     end
 
     it "logs action performed" do
@@ -35,7 +35,7 @@ describe NugetProjectVerificationWorker do
         { platform: "NuGet", name: name, canonical_name: canonical_name, project_id: project.id }
       )
 
-      subject.perform(name)
+      subject.perform(project.id)
     end
   end
 end

--- a/spec/workers/nuget_project_verification_worker_spec.rb
+++ b/spec/workers/nuget_project_verification_worker_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe NugetProjectVerificationWorker do
+  let(:project) { create(:project, :nuget, name: name) }
+  let(:canonical_name) { "Newtonsoft.Json" }
+
+  before do
+    allow(PackageManager::NuGet).to receive(:fetch_canonical_nuget_name)
+      .and_return(canonical_name)
+  end
+
+  it "should use the low priority queue" do
+    is_expected.to be_processed_in :small
+  end
+
+  context "name matches canonical" do
+    let(:name) { canonical_name }
+    it "doesn't touch project status" do
+      expect { subject.perform(name) }.to not_change { project.reload.status }.from(nil)
+    end
+  end
+
+  context "name differs from canonical" do
+    let(:name) { canonical_name.upcase }
+
+    it "marks project hidden" do
+      expect { subject.perform(name) }.to change { project.reload.status }.from(nil).to("Hidden")
+    end
+
+    it "logs action performed" do
+      expect(StructuredLog).to receive(:capture).with(
+        "PROJECT_MARKED_NONCANONICAL",
+        { platform: "NuGet", name: name, canonical_name: canonical_name, project_id: project.id }
+      )
+
+      subject.perform(name)
+    end
+  end
+end


### PR DESCRIPTION
Story details: https://app.shortcut.com/tidelift/story/31318

This uses marking hidden as a soft-delete, but AFAICT there's nothing in `check_status` or `CheckStatusWorker` from resetting hidden projects. I'm considering that an issue for another day. The idea here is to gather data & do a safe sweep. 

Once we're satisfied, we can follow up with a hard-delete or other 'permanent' state.