### PR TITLE
SearchController#index: short-circuit when no search criteria are provided

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -3,11 +3,21 @@
 class SearchController < ApplicationController
   def index
     @query = params[:q]
-    @search = search_projects(@query)
-    @suggestion = @search.response.suggest.did_you_mean.first if @query.present?
-    @projects = @search.results.map { |result| ProjectSearchResult.new(result) }
-    @facets = @search.response.aggregations
+    @any_criteria = params
+      .values_at(:q, :platforms, :languages, :licenses, :keywords)
+      .any?(&:present?)
+    @search = []
+    @projects = []
+    @facets = []
     @title = page_title
+
+    if @any_criteria
+      @search = search_projects(@query)
+      @suggestion = @search.response.suggest.did_you_mean.first if @query.present?
+      @projects = @search.results.map { |result| ProjectSearchResult.new(result) }
+      @facets = @search.response.aggregations
+    end
+
     respond_to do |format|
       format.html
       format.atom

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,11 +41,10 @@ module ApplicationHelper
                                      else
                                        collection.first.class.name.split("::").last.titleize
                                      end)
-    if collection.total_pages < 2
-      case collection.size
-      when 0 then "No #{entry_name.pluralize} found"
-      else; "#{collection.total_entries} #{entry_name.pluralize}"
-      end
+    if collection.empty?
+      "No #{entry_name.pluralize} found"
+    elsif collection.total_pages < 2
+      "#{collection.total_entries} #{entry_name.pluralize}"
     else
       format(%(%d - %d of #{number_to_human(collection.total_entries)} #{entry_name.pluralize}), collection.offset + 1, collection.offset + collection.length)
     end

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -10,6 +10,9 @@
       <div class="row">
         <div class="col-xs-6">
           <h5><%= search_page_entries_info @search, model: 'package' %></h5>
+          <% unless @any_criteria %>
+            <p>Please provide search criteria and try again</p>
+          <% end %>
         </div>
         <div class="col-xs-6">
           <div class="btn-group pull-right">

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -4,19 +4,43 @@ require "rails_helper"
 
 describe "SearchController", elasticsearch: true do
   let!(:project) { create(:project) }
+  let(:search_criteria) { project.name }
 
   describe "GET /search", type: :request do
+    context "without search criteria" do
+      let(:search_criteria) { "" }
+
+      it "renders instructions to try again" do
+        Project.__elasticsearch__.refresh_index!
+        visit search_path(params: { q: search_criteria })
+
+        expect(page).not_to have_content project.name
+        expect(page).to have_content "Please provide search criteria and try again"
+      end
+    end
+
     it "renders successfully when logged out" do
       Project.__elasticsearch__.refresh_index!
-      visit search_path
+      visit search_path(params: { q: search_criteria })
       expect(page).to have_content project.name
     end
   end
 
   describe "GET /search.atom", type: :request do
+    context "without search criteria" do
+      let(:search_criteria) { "" }
+
+      it "renders no results" do
+        Project.__elasticsearch__.refresh_index!
+        visit search_path(params: { q: search_criteria })
+
+        expect(page).not_to have_content project.name
+      end
+    end
+
     it "renders successfully when logged out" do
       Project.__elasticsearch__.refresh_index!
-      visit search_path(format: :atom)
+      visit search_path(params: { q: search_criteria }, format: :atom)
       expect(page).to have_content project.name
     end
   end


### PR DESCRIPTION
Revisit https://github.com/librariesio/libraries.io/pull/3209

This prevents expensive elasticsearch queries that have been the target of scraping efforts. However, this time we only deny a search if no criteria at all is present. e.g. a search without a query is allowed if it has a license filter on it. But a search with only a sort is not allowed.

<img width="868" alt="Screenshot 2023-09-25 at 12 42 52 PM" src="https://github.com/librariesio/libraries.io/assets/624279/64f28fa7-d0db-45f6-9e04-117924c444c9">
