### PR TITLE
fix: [sc-37352] Packages are incorrectly being marked as deprecated

### DIFF
--- a/app/models/package_manager/pypi/json_api_project.rb
+++ b/app/models/package_manager/pypi/json_api_project.rb
@@ -89,7 +89,7 @@ module PackageManager
               is_yanked: first_details["yanked"] == true,
               yanked_reason: first_details["yanked_reason"]
             )
-          end
+          end.sort
         )
       end
 

--- a/app/models/package_manager/pypi/json_api_project_release.rb
+++ b/app/models/package_manager/pypi/json_api_project_release.rb
@@ -30,6 +30,13 @@ module PackageManager
       def yanked?
         @is_yanked
       end
+
+      def <=>(other)
+        return -1 unless published_at?
+        return 1 unless other.published_at?
+
+        @published_at <=> other.published_at
+      end
     end
   end
 end

--- a/spec/models/package_manager/pypi/json_api_project_release_spec.rb
+++ b/spec/models/package_manager/pypi/json_api_project_release_spec.rb
@@ -21,4 +21,34 @@ describe PackageManager::Pypi::JsonApiProjectRelease do
       end
     end
   end
+
+  describe "#<=>" do
+    let(:left_release) { described_class.new(version_number: "1.0.0", published_at: published_at_left, is_yanked: false, yanked_reason: nil) }
+    let(:right_release) { described_class.new(version_number: "1.0.1", published_at: published_at_right, is_yanked: false, yanked_reason: nil) }
+
+    let(:published_at_left) { 1.month.ago }
+    let(:published_at_right) { 1.day.ago }
+
+    context "with both releases having published at dates" do
+      it "sorts correctly" do
+        expect([left_release, right_release].sort).to eq([left_release, right_release])
+      end
+    end
+
+    context "with left release not having published at date" do
+      let(:published_at_left) { nil }
+
+      it "sorts the empty item first" do
+        expect([left_release, right_release].sort).to eq([left_release, right_release])
+      end
+    end
+
+    context "with right release not having published at date" do
+      let(:published_at_right) { nil }
+
+      it "sorts the empty item first" do
+        expect([left_release, right_release].sort).to eq([right_release, left_release])
+      end
+    end
+  end
 end

--- a/spec/models/package_manager/pypi/json_api_project_spec.rb
+++ b/spec/models/package_manager/pypi/json_api_project_spec.rb
@@ -295,6 +295,35 @@ describe PackageManager::Pypi::JsonApiProject do
         end
       end
     end
+
+    context "with three releases" do
+      context "with point release older than highest stable release" do
+        let(:raw_releases) do
+          {
+            "1.0.0" => [{
+              "upload_time" => 1.day.ago.iso8601,
+              "yanked" => false,
+              "yanked_reason" => "",
+            }],
+            "1.0.1" => [{
+              "upload_time" => 1.minute.ago.iso8601,
+              "yanked" => false,
+              "yanked_reason" => "",
+            }],
+            "2.0.0" => [{
+              "upload_time" => 1.hour.ago.iso8601,
+              "yanked" => true,
+              "yanked_reason" => "use 1.0.1",
+            }],
+          }
+        end
+
+        it "orders releases chronologically" do
+          expect(project.releases.count).to eq(3)
+          expect(project.releases.map(&:version_number)).to eq(["1.0.0", "2.0.0", "1.0.1"])
+        end
+      end
+    end
   end
 
   describe "#present?" do


### PR DESCRIPTION
This should help with PyPI packages being incorrectly marked as deprecated when:

* the latest stable becomes deprecated
* a newer, lower version becomes the most recently published

This ensures that the most recent release chronologically is the one used for deprecation determination.