### PR TITLE
Temporarily Disable Maintenance Stat Worker

### DIFF
--- a/app/workers/repository_maintenance_stat_worker.rb
+++ b/app/workers/repository_maintenance_stat_worker.rb
@@ -5,7 +5,11 @@ class RepositoryMaintenanceStatWorker
   sidekiq_options queue: :repo_maintenance_stat, retry: 3, unique: :until_executed
 
   def perform(repo_id)
-    Repository.find(repo_id).gather_maintenance_stats
+    # Oct 5 2023
+    # temporarily disabling this worker while we figure out what is going on with
+    # auth tokens all being marked as unauthorized
+
+    # Repository.find(repo_id).gather_maintenance_stats
   end
 
   def self.enqueue(repo_id, priority: :medium)

--- a/spec/workers/repository_maintenance_stat_worker_spec.rb
+++ b/spec/workers/repository_maintenance_stat_worker_spec.rb
@@ -2,7 +2,8 @@
 
 require "rails_helper"
 
-describe RepositoryMaintenanceStatWorker do
+# Oct 5 2023 temporarily disabled maintenance stat worker
+xdescribe RepositoryMaintenanceStatWorker do
   let!(:repository) { create(:repository) }
 
   before do


### PR DESCRIPTION
There is something going on with AuthTokens when we try to find one to use for GraphQL calls to GitHub. Right now our workers can't find one to use so they spin for a very long time trying to find one which clogs up all the queues. This PR should no-op the worker and allow the other work to go through while we figure out what is happening.