### PR TITLE
feat: [sc-34666] Move MavenUrl to separate file

### DIFF
--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -258,57 +258,5 @@ module PackageManager
     def self.db_platform
       "Maven"
     end
-
-    class MavenUrl
-      def self.from_name(name, repo_base, delimiter = ":")
-        group_id, artifact_id = *name.split(delimiter, 2)
-
-        # Clojars names, when missing a group id, are implied to have the same group and artifact ids.
-        artifact_id = group_id if artifact_id.nil? && delimiter == PackageManager::Clojars::NAME_DELIMITER
-
-        new(group_id, artifact_id, repo_base)
-      end
-
-      def self.legal_name?(name, delimiter = ":")
-        name.present? && name.split(delimiter).size == 2
-      end
-
-      def initialize(group_id, artifact_id, repo_base)
-        @group_id = group_id
-        @artifact_id = artifact_id
-        @repo_base = repo_base
-      end
-
-      def base
-        "#{@repo_base}/#{group_path}/#{@artifact_id}"
-      end
-
-      def jar(version)
-        "#{base}/#{version}/#{@artifact_id}-#{version}.jar"
-      end
-
-      def pom(version)
-        "#{base}/#{version}/#{@artifact_id}-#{version}.pom"
-      end
-
-      # this is very specific to Maven Central
-      def search(version = nil)
-        if version
-          "http://search.maven.org/#artifactdetails%7C#{@group_id}%7C#{@artifact_id}%7C#{version}%7Cjar"
-        else
-          "http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22#{@group_id}%22%20AND%20a%3A%22#{@artifact_id}%22"
-        end
-      end
-
-      def maven_metadata
-        "#{@repo_base}/#{group_path}/#{@artifact_id}/maven-metadata.xml"
-      end
-
-      private
-
-      def group_path
-        @group_id.gsub(".", "/")
-      end
-    end
   end
 end

--- a/app/models/package_manager/maven/maven_url.rb
+++ b/app/models/package_manager/maven/maven_url.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module PackageManager
+  class Maven < MultipleSourcesBase
+    class MavenUrl
+      DELIMITER = ":"
+      GROUP_ARTIFACT_SPLIT_SIZE = 2
+
+      def self.from_name(name, repo_base, delimiter = DELIMITER)
+        group_id, artifact_id = *name.split(delimiter, GROUP_ARTIFACT_SPLIT_SIZE)
+
+        # Clojars names, when missing a group id, are implied to have the same group and artifact ids.
+        artifact_id = group_id if artifact_id.nil? && delimiter == PackageManager::Clojars::NAME_DELIMITER
+
+        new(group_id, artifact_id, repo_base)
+      end
+
+      def self.legal_name?(name, delimiter = DELIMITER)
+        name.present? && name.split(delimiter).size == GROUP_ARTIFACT_SPLIT_SIZE
+      end
+
+      def initialize(group_id, artifact_id, repo_base)
+        @group_id = group_id
+        @artifact_id = artifact_id
+        @repo_base = repo_base
+      end
+
+      def base
+        "#{@repo_base}/#{group_path}/#{@artifact_id}"
+      end
+
+      def jar(version)
+        "#{path_base(version)}.jar"
+      end
+
+      def pom(version)
+        "#{path_base(version)}.pom"
+      end
+
+      # this is very specific to Maven Central
+      def search(version = nil)
+        if version
+          "http://search.maven.org/#artifactdetails%7C#{@group_id}%7C#{@artifact_id}%7C#{version}%7Cjar"
+        else
+          "http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22#{@group_id}%22%20AND%20a%3A%22#{@artifact_id}%22"
+        end
+      end
+
+      def maven_metadata
+        "#{@repo_base}/#{group_path}/#{@artifact_id}/maven-metadata.xml"
+      end
+
+      private
+
+      def group_path
+        @group_id.gsub(".", "/")
+      end
+
+      def path_base(version)
+        "#{base}/#{version}/#{@artifact_id}-#{version}"
+      end
+    end
+  end
+end

--- a/spec/models/package_manager/maven/maven_url_spec.rb
+++ b/spec/models/package_manager/maven/maven_url_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe PackageManager::Maven::MavenUrl do
+  describe "#legal_name?" do
+    it "allows names with the format {group_id}:{artifact_name}" do
+      ["com.google:guava", "junit:junit", "org.springframework.boot:spring-boot-starter-web", "org.scala-lang:scala-library"].each do |name|
+        expect(described_class.legal_name?(name)).to be true
+      end
+    end
+
+    it "does not allow names without the format {group_id}:{artifact_name}" do
+      ["guava", "junit", "org.springframework.boot", "org.scala-lang"].each do |name|
+        expect(described_class.legal_name?(name)).to be false
+      end
+    end
+  end
+end

--- a/spec/models/package_manager/maven_spec.rb
+++ b/spec/models/package_manager/maven_spec.rb
@@ -359,19 +359,3 @@ describe PackageManager::Maven do
     end
   end
 end
-
-describe PackageManager::Maven::MavenUrl do
-  describe "#legal_name?" do
-    it "allows names with the format {group_id}:{artifact_name}" do
-      ["com.google:guava", "junit:junit", "org.springframework.boot:spring-boot-starter-web", "org.scala-lang:scala-library"].each do |name|
-        expect(described_class.legal_name?(name)).to be true
-      end
-    end
-
-    it "does not allow names without the format {group_id}:{artifact_name}" do
-      ["guava", "junit", "org.springframework.boot", "org.scala-lang"].each do |name|
-        expect(described_class.legal_name?(name)).to be false
-      end
-    end
-  end
-end


### PR DESCRIPTION
Subclasses should be placed into separate files, not inlined into other
files. Some small code cleanups in MavenUrl as well.