### PR TITLE
Allow sidekiq jobs to quietly raise and retry

### DIFF
--- a/app/workers/nuget_project_verification_worker.rb
+++ b/app/workers/nuget_project_verification_worker.rb
@@ -25,7 +25,7 @@ class NugetProjectVerificationWorker
 
     if canonical_name.nil?
       # Retry if the fetch failed
-      raise "FETCH_CANONICAL_NAME_FAILED"
+      raise SidekiqQuietRetryError, "FETCH_CANONICAL_NAME_FAILED"
     elsif canonical_name == false
       if project.removed?
         StructuredLog.capture("CANONICAL_NAME_ELEMENT_MISSING_PROJECT_REMOVED", logging_info)

--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -6,6 +6,7 @@ if Rails.env.production?
     config.discard_classes << "ActiveRecord::RecordNotFound"
     # Temprarily uncomment this is we get a huge spike of these errors and need to investigate:
     config.discard_classes << "PackageManagerDownloadWorker::VersionUpdateFailure"
+    config.discard_classes << "SidekiqQuietRetryError"
 
     if File.exist?("#{Rails.root}/REVISION")
       config.app_version = File.read("#{Rails.root}/REVISION").strip

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,6 +2,9 @@
 
 require "resolv-replace" # pure ruby DNS
 
+# Use this exception to retry Sidekiq jobs without sounding Bugsnag alerts
+class SidekiqQuietRetryError < StandardError; end
+
 # disable id so that sidekiq will work with google cloud memorystore redis
 # https://github.com/mperham/sidekiq/issues/3518#issuecomment-390896088
 Sidekiq.configure_server do |config|

--- a/spec/workers/nuget_project_verification_worker_spec.rb
+++ b/spec/workers/nuget_project_verification_worker_spec.rb
@@ -52,7 +52,7 @@ describe NugetProjectVerificationWorker do
     end
 
     it "raises to retry" do
-      expect { subject.perform(project.id) }.to raise_error(RuntimeError, "FETCH_CANONICAL_NAME_FAILED")
+      expect { subject.perform(project.id) }.to raise_error(SidekiqQuietRetryError, "FETCH_CANONICAL_NAME_FAILED")
     end
   end
 


### PR DESCRIPTION
Adds a custom error class we can raise to use Sidekiq's built-in retry mechanisms without flooding error monitoring.