### PR TITLE
feat: [sc-31318] NuGet project verification worker: fix queueing adjust and rate of work

### DIFF
--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -307,7 +307,7 @@ namespace :projects do
       .select("id")
       .in_batches(of: args.count)
       .each_with_index do |project_batch, batch_index|
-        project_batch.pluck(:id) do |project_id|
+        project_batch.pluck(:id).each do |project_id|
           NugetProjectVerificationWorker.perform_in(batch_index * batch_interval, project_id)
         end
       end


### PR DESCRIPTION
Story details: https://app.shortcut.com/tidelift/story/31318

Fix spacing out the batches, and slow the rate some more to be safe & considerate. 