### PR TITLE
fix: [sc-37574] Add task to scan and clean out expired authtokens

### DIFF
--- a/lib/tasks/auth_tokens.rake
+++ b/lib/tasks/auth_tokens.rake
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+namespace :auth_tokens do
+  desc "Verify each authorized AuthToken that it's still authorized"
+  task :reverify_authorized, %i[count start] => :environment do |_task, args|
+    exit if ENV["READ_ONLY"].present?
+    args.with_defaults(count: 500, start: nil)
+    last_id = "none"
+
+    begin
+      AuthToken
+        .authorized
+        .in_batches(of: args.count, start: args.start)
+        .each do |token_batch|
+          token_batch.each do |token|
+            token.update_attributes(
+              login: token.github_client.user[:login],
+              authorized: token.still_authorized?
+            )
+
+            last_id = token.id
+          end
+
+          # Don't necessarily have to worry about rate limit #still_authorized? /should/ still work
+          # because a rate limit means we auth'ed successfully. But we can still pace ourselves.
+          sleep 1
+        end
+    rescue StandardError, Interrupt => e
+      puts "\n\n### Last AuthToken id processed: #{last_id} \n\n\n"
+      raise e
+    end
+  end
+end

--- a/lib/tasks/auth_tokens.rake
+++ b/lib/tasks/auth_tokens.rake
@@ -14,11 +14,10 @@ namespace :auth_tokens do
     begin
       AuthToken
         .authorized
-        .in_batches(of: args.batch_size, start: args.start)
-        .each do |token_batch|
+        .find_in_batches(of: args.batch_size, start: args.start).each |token_batch|
           token_batch.each do |token|
             result = token.still_authorized?
-            fresh_login = token.github_client.user[:login]
+            fresh_login = token.github_client.user[:login] if result
 
             token.update(
               login: (fresh_login || token.login),

--- a/lib/tasks/auth_tokens.rake
+++ b/lib/tasks/auth_tokens.rake
@@ -26,7 +26,6 @@ namespace :auth_tokens do
                 "AUTH_TOKEN_MARKED_EXPIRED",
                 {
                   token_id: token.id,
-                  github_login: token.login,
                   authorized: result,
                   created_at: token.created_at,
                 }

--- a/lib/tasks/auth_tokens.rake
+++ b/lib/tasks/auth_tokens.rake
@@ -25,7 +25,7 @@ namespace :auth_tokens do
               StructuredLog.capture(
                 "AUTH_TOKEN_MARKED_EXPIRED",
                 {
-                  token_id: token.id,
+                  auth_token_id: token.id,
                   authorized: result,
                   created_at: token.created_at,
                 }

--- a/lib/tasks/auth_tokens.rake
+++ b/lib/tasks/auth_tokens.rake
@@ -21,7 +21,7 @@ namespace :auth_tokens do
               authorized: result
             )
 
-            if result.false?
+            unless result
               StructuredLog.capture(
                 "AUTH_TOKEN_MARKED_EXPIRED",
                 {


### PR DESCRIPTION
Story details: https://app.shortcut.com/tidelift/story/37574

First part of cleaning AuthTokens up. Toss out the expired ones so we can get to the good ones.

I wrote this as a one-off, but it's probably worth scheduling too, monthly maybe.