### PR TITLE
fix: [sc-37574] Resolve Libraries to Github API connection errors

### DIFF
--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -67,13 +67,10 @@ class AuthToken < ApplicationRecord
   def self.new_v4_client(token)
     token ||= AuthToken.token
     http_adapter = GraphQL::Client::HTTP.new("https://api.github.com/graphql") do
-      @token = token
-
+      @@token = token # rubocop: disable Style/ClassVars
       # rubocop: disable Lint/NestedMethodDefinition:
       def headers(_context)
-        {
-          "Authorization" => "Bearer #{@token}",
-        }
+        { "Authorization" => "bearer #{@@token}" }
       end
       # rubocop: enable Lint/NestedMethodDefinition:
     end

--- a/spec/models/auth_token_spec.rb
+++ b/spec/models/auth_token_spec.rb
@@ -4,4 +4,18 @@ require "rails_helper"
 
 describe AuthToken, type: :model do
   it { should validate_presence_of(:token) }
+
+  describe "::new_v4_client" do
+    let(:token_value) { Faker::Alphanumeric.alpha }
+    subject(:v4_client) { described_class.new_v4_client(token_value) }
+
+    def get_headers_from_client(graphql_client)
+      graphql_client.execute.headers(nil)
+    end
+
+    it "applies given token to client headers" do
+      expect(token_value).to be_present
+      expect(get_headers_from_client(v4_client)).to eq({ "Authorization" => "bearer #{token_value}" })
+    end
+  end
 end


### PR DESCRIPTION
Story details: https://app.shortcut.com/tidelift/story/37574

It turns out we are not passing the token anymore, and they'd really like to see one.