### PR TITLE
Fetch graphql rate limits from same request as rest limits

### DIFF
--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -54,8 +54,12 @@ class AuthToken < ApplicationRecord
     remaining > LOW_RATE_LIMIT_REMAINING_THRESHOLD
   rescue Octokit::Unauthorized, Octokit::AccountSuspended
     false
-  rescue StandardError
-    StructuredLog.capture("FAILED_READING_GITHUB_RATE_LIMITS", { api_version: api_version, auth_token_id: id, remaining: remaining })
+  rescue StandardError => e
+    StructuredLog.capture(
+      "FAILED_READING_GITHUB_RATE_LIMITS",
+      { api_version: api_version, auth_token_id: id, remaining: remaining, error_class: e, error_message: e.message }
+    )
+
     false
   end
 

--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -15,6 +15,8 @@ class AuthToken < ApplicationRecord
   validates_presence_of :token
   scope :authorized, -> { where(authorized: [true, nil]) }
 
+  LOW_RATE_LIMIT_REMAINING_THRESHOLD = 500
+
   def self.client(options = {})
     find_token(:v3).github_client(options)
   end
@@ -33,11 +35,27 @@ class AuthToken < ApplicationRecord
     end
   end
 
-  def high_rate_limit?(api_version)
-    return v4_remaining_rate > 500 if api_version == :v4
+  def fetch_resource_limits
+    client = github_client
 
-    github_client.rate_limit.remaining > 500
+    v3_stat = client.rate_limit!.remaining
+    v4_stat = client.last_response.data.resources.graphql.remaining
+
+    {
+      v3: v3_stat,
+      v4: v4_stat,
+    }
+  end
+
+  def safe_to_use?(api_version)
+    resource_limits = fetch_resource_limits
+    remaining = resource_limits.fetch(api_version)
+
+    remaining > LOW_RATE_LIMIT_REMAINING_THRESHOLD
   rescue Octokit::Unauthorized, Octokit::AccountSuspended
+    false
+  rescue StandardError
+    StructuredLog.capture("FAILED_READING_GITHUB_RATE_LIMITS", { api_version: api_version, auth_token_id: id, remaining: remaining })
     false
   end
 
@@ -84,34 +102,11 @@ class AuthToken < ApplicationRecord
 
   def self.find_token(api_version, retries: 0)
     auth_token = authorized.order(Arel.sql("RANDOM()")).first
-    return auth_token if auth_token.high_rate_limit?(api_version)
+    return auth_token if auth_token.safe_to_use?(api_version)
 
     retries += 1
     raise "No Authorized AuthToken Could Be Found!" if retries >= 10
 
     find_token(api_version, retries: retries)
   end
-
-  private
-
-  def v4_remaining_rate
-    query_result = v4_github_client.query(V4RateLimitQuery)
-    if query_result.data.nil?
-      0
-    else
-      # check the return
-      query_result.data.rate_limit.remaining
-    end
-  end
-
-  V4RateLimitQuery = Rails.application.config.graphql.client.parse <<-GRAPHQL
-    query {
-      viewer {
-        login
-      }
-      rateLimit {
-        remaining
-      }
-    }
-  GRAPHQL
 end

--- a/spec/models/auth_token_spec.rb
+++ b/spec/models/auth_token_spec.rb
@@ -18,4 +18,55 @@ describe AuthToken, type: :model do
       expect(get_headers_from_client(v4_client)).to eq({ "Authorization" => "bearer #{token_value}" })
     end
   end
+
+  describe "#safe_to_use?" do
+    subject(:auth_token) { described_class.new(token: token_value) }
+    let(:token_value) { "" }
+
+    context "when token fails to authenticate" do
+      let(:token_value) { "foo" }
+
+      it "returns false" do
+        expect(auth_token.safe_to_use?(:v3)).to eq(false)
+        expect(auth_token.safe_to_use?(:v4)).to eq(false)
+      end
+    end
+
+    context "when resource_limits aren't found" do
+      before do
+        allow(auth_token).to receive(:fetch_resource_limits).and_return({ v3: nil })
+      end
+
+      it "returns false" do
+        expect(auth_token.safe_to_use?(:v3)).to eq(false)
+        expect(auth_token.safe_to_use?(:v4)).to eq(false)
+      end
+    end
+
+    it "checks the appropriate api limits" do
+      allow(auth_token).to receive(:fetch_resource_limits).and_return({ v3: 40, v4: 5000 })
+
+      expect(auth_token.safe_to_use?(:v3)).to eq(false)
+      expect(auth_token.safe_to_use?(:v4)).to eq(true)
+    end
+  end
+
+  describe "#fetch_resource_limits" do
+    subject(:limit_stats) do
+      VCR.use_cassette("github/chalk_api", match_requests_on: %i[method uri body query]) do
+        auth_token.fetch_resource_limits
+      end
+    end
+
+    let(:auth_token) { described_class.new(token: token_value) }
+    let(:token_value) { "foo" }
+
+    it "returns rate limit stats for Github REST API (V3)" do
+      expect(limit_stats[:v3]).to eq(4999)
+    end
+
+    it "returns rate limit stats for Github GraphQL API (V4)" do
+      expect(limit_stats[:v4]).to eq(4998)
+    end
+  end
 end


### PR DESCRIPTION
Octokit hides the [full details](https://docs.github.com/en/rest/rate-limit/rate-limit?apiVersion=2022-11-28) we can get from this endpoint, but we can inspect the full response and check a token's rate limit for both REST and GraphQL from the same request.

This means we don't have to involve both APIs just for checking if a token can be used, and cut down some code paths.