### PR TITLE
Add one off rake task to delete ignored Maven versions and resync aff…

### DIFF
--- a/lib/tasks/one_off.rake
+++ b/lib/tasks/one_off.rake
@@ -257,4 +257,46 @@ namespace :one_off do
     puts "Total packages checked: #{input_tsv_file.count}"
     puts "Versions corrected: #{corrected_count}"
   end
+
+  desc "Delete ignored Maven versions and resync packages"
+  task :delete_ignored_maven_versions_and_resync_packages, %i[commit] => :environment do |_t, args|
+    commit = args.commit.present? && args.commit == "yes"
+
+    puts "DRY RUN" unless commit
+
+    # Retrieve the projects where at least one version's repository_sources is not solely ["Maven"] or ["Google"]
+    affected_projects = Project
+      .joins(:versions)
+      .where(platform: "Maven")
+      .where(%(versions.repository_sources != '["Maven"]' AND versions.repository_sources != '["Google"]' OR repository_sources IS NULL))
+      .distinct
+
+    puts "Count of projects with versions to re-process: #{affected_projects.count}"
+
+    batch_size = 50
+    processed_count = 0
+
+    puts "Processing...."
+    affected_projects.in_batches(of: batch_size).each do |batch|
+      batch.each do |project|
+        affected_versions = project.versions.where(%(repository_sources != '["Maven"]' AND repository_sources != '["Google"]' OR repository_sources IS NULL))
+
+        puts "Destroying #{affected_versions.count} versions for #{project.platform}/#{project.name}."
+        affected_versions.destroy_all if commit
+
+        # Use versions count manually because it might be unsafe to trust
+        # cached project.versions_count value immediately after doing deletions
+        if project.versions.count > 0
+          puts "Versions remaining for #{project.platform}/#{project.name}: Trying manual sync."
+          project.try(:manual_sync) if commit
+        else
+          puts "No versions remaining for #{project.platform}/#{project.name}: Destroying project."
+          project.destroy! if commit
+        end
+      end
+
+      processed_count += [batch_size, batch.size].min
+      puts "Processed #{processed_count} projects"
+    end
+  end
 end

--- a/lib/tasks/one_off.rake
+++ b/lib/tasks/one_off.rake
@@ -268,7 +268,7 @@ namespace :one_off do
     affected_projects = Project
       .joins(:versions)
       .where(platform: "Maven")
-      .where(%(versions.repository_sources != '["Maven"]' AND versions.repository_sources != '["Google"]' OR repository_sources IS NULL))
+      .where(%((versions.repository_sources != '["Maven"]' AND versions.repository_sources != '["Google"]') OR repository_sources IS NULL))
       .distinct
 
     puts "Count of projects with versions to re-process: #{affected_projects.count}"
@@ -279,7 +279,7 @@ namespace :one_off do
     puts "Processing...."
     affected_projects.in_batches(of: batch_size).each do |batch|
       batch.each do |project|
-        affected_versions = project.versions.where(%(repository_sources != '["Maven"]' AND repository_sources != '["Google"]' OR repository_sources IS NULL))
+        affected_versions = project.versions.where(%((repository_sources != '["Maven"]' AND repository_sources != '["Google"]') OR repository_sources IS NULL))
 
         puts "Destroying #{affected_versions.count} versions for #{project.platform}/#{project.name}."
         affected_versions.destroy_all if commit

--- a/lib/tasks/one_off.rake
+++ b/lib/tasks/one_off.rake
@@ -283,20 +283,19 @@ namespace :one_off do
 
         puts "Destroying #{affected_versions.count} versions for #{project.platform}/#{project.name}."
         affected_versions.destroy_all if commit
+        puts "Trying manual sync for #{project.platform}/#{project.name}."
+        project.try(:manual_sync) if commit
 
         # Use versions count manually because it might be unsafe to trust
         # cached project.versions_count value immediately after doing deletions
-        if project.versions.count > 0
-          puts "Versions remaining for #{project.platform}/#{project.name}: Trying manual sync."
-          project.try(:manual_sync) if commit
-        else
+        if project.versions.count == 0
           puts "No versions remaining for #{project.platform}/#{project.name}: Destroying project."
           project.destroy! if commit
         end
       end
 
       processed_count += [batch_size, batch.size].min
-      puts "Processed #{processed_count} projects"
+      puts "Processed #{processed_count} projects."
     end
   end
 end

--- a/spec/tasks/one_off_spec.rb
+++ b/spec/tasks/one_off_spec.rb
@@ -113,8 +113,8 @@ describe "one_off" do
       end
 
       context "with only ignored versions" do
-        let!(:no_source_version) { create(:version, project: project, number: "1.0.0", repository_sources: nil) }
-        let!(:ignored_source_version) { create(:version, project: project, number: "2.0.0", repository_sources: ["Other"]) }
+        let(:no_source_version) { create(:version, project: project, number: "1.0.0", repository_sources: nil) }
+        let(:ignored_source_version) { create(:version, project: project, number: "2.0.0", repository_sources: ["Other"]) }
 
         it "deletes ignored versions and the project" do
           expect { Rake::Task["one_off:delete_ignored_maven_versions_and_resync_packages"].invoke("yes") }


### PR DESCRIPTION
The intent is for this rake task and its specs to be deleted after it is run.

This will find all Maven versions that are not from only Maven or Google as a source, delete them, resync the packages associated with these versions, then delete the package if no versions remain.