### PR TITLE
Split up Maven cleanup one-off into two tasks

### DIFF
--- a/lib/tasks/one_off.rake
+++ b/lib/tasks/one_off.rake
@@ -305,12 +305,17 @@ namespace :one_off do
     processed_count = 0
 
     affected_projects = Project.where(platform: "Maven").without_versions
-    puts "Count of projects without versions to destroy: #{affected_projects.count}"
+    affected_projects_count = affected_projects.count
+    puts "Count of projects without versions to destroy: #{affected_projects_count}"
     puts "Processing...."
     affected_projects.in_batches(of: batch_size).each do |batch|
-      batch.destroy_all if commit
       processed_count += batch.size
-      puts "Destroyed #{processed_count} of #{affected_projects.count} projects."
+      if commit
+        batch.destroy_all
+      else
+        puts batch
+      end
+      puts "Destroyed #{processed_count} of #{affected_projects_count} projects."
     end
   end
 end

--- a/lib/tasks/one_off.rake
+++ b/lib/tasks/one_off.rake
@@ -289,7 +289,7 @@ namespace :one_off do
         project.try(:manual_sync) if commit
       end
 
-      processed_count += [batch_size, batch.size].min
+      processed_count += batch.size
       puts "Processed #{processed_count} projects."
     end
   end
@@ -309,7 +309,7 @@ namespace :one_off do
     puts "Processing...."
     affected_projects.in_batches(of: batch_size).each do |batch|
       batch.destroy_all if commit
-      processed_count += [batch_size, batch.size].min
+      processed_count += batch.size
       puts "Destroyed #{processed_count} of #{affected_projects.count} projects."
     end
   end


### PR DESCRIPTION
In the original rake task, the `project.manual_sync` was an asynchronous process, meaning that it could be potentially unsafe to delete a `project` if it had no versions without the `manual_sync` finishing, since that could potentially create new versions again. This splits the work into two rake tasks; one to delete the versions, then a second to delete Maven projects without versions after the async workers are finished.