### PR TITLE
Update Maven cleanup rake task to update and not delete versions with ignored and non-ignored sources

### DIFF
--- a/spec/tasks/one_off_spec.rb
+++ b/spec/tasks/one_off_spec.rb
@@ -121,7 +121,7 @@ describe "one_off" do
         let(:multiple_sources_version) { create(:version, project: project, number: "1.0.0", repository_sources: %w[Maven Other]) }
 
         it "deletes ignored source but does not delete version" do
-          expect(Version.all).to match_array(multiple_sources_version)
+          expect(Version.all).to match_array([multiple_sources_version])
           expect { Rake::Task["one_off:delete_ignored_maven_versions_and_resync_packages"].invoke("", "yes") }
             .not_to change(Version, :count)
 

--- a/spec/tasks/one_off_spec.rb
+++ b/spec/tasks/one_off_spec.rb
@@ -116,6 +116,18 @@ describe "one_off" do
             .to change(Version, :all).from([no_source_version, ignored_source_version]).to([])
         end
       end
+
+      context "with versions with sources that are ignored and not-ignored" do
+        let(:multiple_sources_version) { create(:version, project: project, number: "1.0.0", repository_sources: %w[Maven Other]) }
+
+        it "deletes ignored source but does not delete version" do
+          expect(Version.all).to match_array(multiple_sources_version)
+          expect { Rake::Task["one_off:delete_ignored_maven_versions_and_resync_packages"].invoke("", "yes") }
+            .not_to change(Version, :count)
+
+          expect(multiple_sources_version.reload.repository_sources).to match_array(["Maven"])
+        end
+      end
     end
   end
 

--- a/spec/tasks/one_off_spec.rb
+++ b/spec/tasks/one_off_spec.rb
@@ -64,8 +64,7 @@ describe "one_off" do
     end
   end
 
-  # TODO
-  describe "delete_ignored_maven_versions_and_resync_packages", skip: "Temporarily skip: Leaky" do
+  describe "delete_ignored_maven_versions_and_resync_packages" do
     after(:each) do
       Rake::Task["one_off:delete_ignored_maven_versions_and_resync_packages"].reenable
     end
@@ -131,8 +130,7 @@ describe "one_off" do
     end
   end
 
-  # TODO
-  describe "delete_maven_packages_without_versions", skip: "Temporarily skip: Leaky" do
+  describe "delete_maven_packages_without_versions" do
     after(:each) do
       Rake::Task["one_off:delete_maven_packages_without_versions"].reenable
     end


### PR DESCRIPTION
Previously, if there was a version with multiple repository sources, and one was ignored and another wasn't, this rake task would delete the version. Now, it doesn't do that, and instead just deletes the ignored repository sources.