### PR TITLE
Ensure sort order of output for consistent testing

### DIFF
--- a/lib/tasks/version_scheme_counter.rake
+++ b/lib/tasks/version_scheme_counter.rake
@@ -141,7 +141,7 @@ namespace :version do
             detected_scheme = maxes[0]
           end
 
-          unknown_schemes.push([project_platform, project_name, project.versions.map(&:number)]) if detected_scheme == :unknown
+          unknown_schemes.push([project_platform, project_name, project.versions.map(&:number).sort]) if detected_scheme == :unknown
 
           global_tallies[detected_scheme] += 1
         end

--- a/spec/tasks/version_scheme_counter_spec.rb
+++ b/spec/tasks/version_scheme_counter_spec.rb
@@ -106,7 +106,7 @@ describe "version:scheme_counter" do
       end
 
       context "Unknown" do
-        versions = %w[3.7.1.3.5.6 3.8.1ab 4.11.2-beta-1 4 001]
+        versions = %w[3.7.1.3.5.6 3.8.1ab 4.11.2-beta-1 4 001].sort
         let(:project) { create(:project, name: "unknown_scheme") }
         let(:versions) { versions }
 
@@ -123,7 +123,7 @@ describe "version:scheme_counter" do
       end
 
       context "Not unanimous" do
-        versions = %w[3.7.1 3.8.1 4.11.2 001]
+        versions = %w[3.7.1 3.8.1 4.11.2 001].sort
         let(:project) { create(:project, name: "unknown_scheme") }
         let(:versions) { versions }
 


### PR DESCRIPTION
Spent some time investigating why this test started flaking in case there were any other interactions of state we needed to be concerned about. But, given the only effect is records being created "out of order", and the task output doesn't seem to be dependent on a given order, we just opted to apply a simple sort so we can assert against it consistently