### PR TITLE
Add way to get versions_from_html as opposed to searching through Maven metadata

### DIFF
--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -160,8 +160,6 @@ module PackageManager
       if raw_project && raw_project[:versions]
         raw_project[:versions]
       else
-        # TODO: Use the commented below instead when specs are fixed
-        # retrieve_versions(versions_from_html(name), name)
         xml_metadata = maven_metadata(name)
         xml_versions = Nokogiri::XML(xml_metadata).css("version").map(&:text)
         retrieve_versions(xml_versions.filter { |item| !item.ends_with?("-SNAPSHOT") }, name)
@@ -255,12 +253,6 @@ module PackageManager
         .css("versioning > latest, versioning > release, metadata > version")
         .map(&:text)
         .first
-    end
-
-    def self.versions_from_html(name)
-      get_html(MavenUrl.from_name(name, repository_base, NAME_DELIMITER).base).css("a").filter_map do |a|
-        a.text.chomp("/") if a.text.ends_with?("/") && a.text != "../"
-      end
     end
 
     def self.db_platform

--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -160,6 +160,8 @@ module PackageManager
       if raw_project && raw_project[:versions]
         raw_project[:versions]
       else
+        # TODO: Use the commented below instead when specs are fixed
+        # retrieve_versions(versions_from_html(name), name)
         xml_metadata = maven_metadata(name)
         xml_versions = Nokogiri::XML(xml_metadata).css("version").map(&:text)
         retrieve_versions(xml_versions.filter { |item| !item.ends_with?("-SNAPSHOT") }, name)
@@ -253,6 +255,12 @@ module PackageManager
         .css("versioning > latest, versioning > release, metadata > version")
         .map(&:text)
         .first
+    end
+
+    def self.versions_from_html(name)
+      get_html(MavenUrl.from_name(name, repository_base, NAME_DELIMITER).base).css("a").filter_map do |a|
+        a.text.chomp("/") if a.text.ends_with?("/") && a.text != "../"
+      end
     end
 
     def self.db_platform

--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -192,8 +192,9 @@ module PackageManager
       versions
         .map do |version|
           one_version_for_name(version, name)
-      rescue Ox::Error, POMNotFound
-        next
+        rescue Ox::Error, POMNotFound
+          StructuredLog.capture("MAVEN_RETRIEVE_VERSION_FAILURE", { version: version, name: name, message: "Version POM not found or valid" })
+          next
         end
         .compact
     end

--- a/app/models/package_manager/maven/maven_central.rb
+++ b/app/models/package_manager/maven/maven_central.rb
@@ -21,6 +21,8 @@ class PackageManager::Maven::MavenCentral < PackageManager::Maven::Common
     PackageManager::Base::MissingVersionRemover
   end
 
+  # maven-metadata.xml for Maven Central does not appear to be guaranteed to contain all relevant versions for a package
+  # So instead, if needed, we will retrieve the versions from the raw HTML index page
   def self.versions(raw_project, name)
     if raw_project && raw_project[:versions]
       raw_project[:versions]

--- a/app/models/package_manager/maven/maven_central.rb
+++ b/app/models/package_manager/maven/maven_central.rb
@@ -20,4 +20,18 @@ class PackageManager::Maven::MavenCentral < PackageManager::Maven::Common
   def self.missing_version_remover
     PackageManager::Base::MissingVersionRemover
   end
+
+  def self.versions(raw_project, name)
+    if raw_project && raw_project[:versions]
+      raw_project[:versions]
+    else
+      retrieve_versions(versions_from_html(name), name)
+    end
+  end
+
+  def self.versions_from_html(name)
+    get_html(MavenUrl.from_name(name, repository_base, NAME_DELIMITER).base).css("a").filter_map do |a|
+      a.text.chomp("/") if a.text.ends_with?("/") && a.text != "../"
+    end
+  end
 end

--- a/spec/fixtures/vcr_cassettes/google-maven/memory-advice.yml
+++ b/spec/fixtures/vcr_cassettes/google-maven/memory-advice.yml
@@ -8,15 +8,17 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.15.4
+      - Faraday v0.17.6
       Accept-Encoding:
       - gzip,deflate,br
       X-Datadog-Trace-Id:
-      - '271378513063810383'
+      - '3299909264348543043'
       X-Datadog-Parent-Id:
-      - '1166487086939401214'
+      - '3897989116006837867'
       X-Datadog-Sampling-Priority:
       - '1'
+      X-Datadog-Tags:
+      - _dd.p.dm=-0
       Expect:
       - ''
   response:
@@ -28,22 +30,24 @@ http_interactions:
       - https://dl.google.com/dl/android/maven2/com/google/android/games/group-index.xml
       Cross-Origin-Resource-Policy:
       - cross-origin
-      Content-Type:
-      - text/html; charset=UTF-8
       X-Content-Type-Options:
       - nosniff
-      Date:
-      - Tue, 14 Mar 2023 17:13:40 GMT
-      Expires:
-      - Tue, 14 Mar 2023 17:43:40 GMT
-      Cache-Control:
-      - public, max-age=1800
       Server:
       - sffe
       Content-Length:
       - '277'
       X-Xss-Protection:
       - '0'
+      Date:
+      - Tue, 14 Nov 2023 20:23:09 GMT
+      Expires:
+      - Tue, 14 Nov 2023 20:53:09 GMT
+      Cache-Control:
+      - public, max-age=1800
+      Content-Type:
+      - text/html; charset=UTF-8
+      Age:
+      - '222'
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
     body:
@@ -51,8 +55,7 @@ http_interactions:
       string: "<HTML><HEAD><meta http-equiv=\"content-type\" content=\"text/html;charset=utf-8\">\n<TITLE>301
         Moved</TITLE></HEAD><BODY>\n<H1>301 Moved</H1>\nThe document has moved\n<A
         HREF=\"https://dl.google.com/dl/android/maven2/com/google/android/games/group-index.xml\">here</A>.\r\n</BODY></HTML>\r\n"
-    http_version:
-  recorded_at: Tue, 14 Mar 2023 17:13:40 GMT
+  recorded_at: Tue, 14 Nov 2023 20:26:51 GMT
 - request:
     method: get
     uri: https://dl.google.com/dl/android/maven2/com/google/android/games/group-index.xml
@@ -61,15 +64,17 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.15.4
+      - Faraday v0.17.6
       Accept-Encoding:
       - gzip,deflate,br
       X-Datadog-Trace-Id:
-      - '4247306432024612484'
+      - '3798022735727065520'
       X-Datadog-Parent-Id:
-      - '2929971138458564536'
+      - '1167652035270471276'
       X-Datadog-Sampling-Priority:
       - '1'
+      X-Datadog-Tags:
+      - _dd.p.dm=-0
       Expect:
       - ''
   response:
@@ -79,24 +84,14 @@ http_interactions:
     headers:
       Accept-Ranges:
       - bytes
-      Cache-Control:
-      - public,max-age=86400
       Content-Disposition:
       - attachment
       Content-Length:
       - '221'
       Content-Security-Policy:
       - default-src 'none'
-      Content-Type:
-      - application/xml
-      Etag:
-      - '"adc662"'
-      Last-Modified:
-      - Fri, 15 Oct 2021 16:16:22 GMT
       Server:
       - downloads
-      Vary:
-      - Origin
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -104,7 +99,19 @@ http_interactions:
       X-Xss-Protection:
       - '0'
       Date:
-      - Tue, 14 Mar 2023 17:13:40 GMT
+      - Tue, 14 Nov 2023 20:26:51 GMT
+      Cache-Control:
+      - public,max-age=86400
+      Last-Modified:
+      - Fri, 15 Oct 2021 16:16:22 GMT
+      Etag:
+      - '"adc662"'
+      Content-Type:
+      - application/xml
+      Vary:
+      - Origin
+      Age:
+      - '0'
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
     body:
@@ -115,8 +122,7 @@ http_interactions:
           <memory-advice versions="0.13,0.14,0.15,0.22,0.23,0.24"/>
           <memory-advice-common versions="0.13,0.14,0.15,0.22,0.23,0.24"/>
         </com.google.android.games>
-    http_version:
-  recorded_at: Tue, 14 Mar 2023 17:13:40 GMT
+  recorded_at: Tue, 14 Nov 2023 20:26:51 GMT
 - request:
     method: get
     uri: https://dl.google.com/dl/android/maven2/com/google/android/games/memory-advice/0.24/memory-advice-0.24.pom
@@ -125,15 +131,17 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.15.4
+      - Faraday v0.17.6
       Accept-Encoding:
       - gzip,deflate,br
       X-Datadog-Trace-Id:
-      - '4364342007873828035'
+      - '3940907107568498289'
       X-Datadog-Parent-Id:
-      - '4154079452063664978'
+      - '3191105367168775837'
       X-Datadog-Sampling-Priority:
       - '1'
+      X-Datadog-Tags:
+      - _dd.p.dm=-0
       Expect:
       - ''
   response:
@@ -168,7 +176,7 @@ http_interactions:
       X-Xss-Protection:
       - '0'
       Date:
-      - Tue, 14 Mar 2023 17:13:40 GMT
+      - Tue, 14 Nov 2023 20:26:52 GMT
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
     body:
@@ -230,8 +238,7 @@ http_interactions:
             </dependency>
           </dependencies>
         </project>
-    http_version:
-  recorded_at: Tue, 14 Mar 2023 17:13:41 GMT
+  recorded_at: Tue, 14 Nov 2023 20:26:52 GMT
 - request:
     method: get
     uri: https://dl.google.com/dl/android/maven2/com/google/android/games/memory-advice/0.22/memory-advice-0.22.pom
@@ -240,15 +247,17 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.15.4
+      - Faraday v0.17.6
       Accept-Encoding:
       - gzip,deflate,br
       X-Datadog-Trace-Id:
-      - '3321308180289245601'
+      - '1091719623440894595'
       X-Datadog-Parent-Id:
-      - '358848893792142024'
+      - '4170468601176143246'
       X-Datadog-Sampling-Priority:
       - '1'
+      X-Datadog-Tags:
+      - _dd.p.dm=-0
       Expect:
       - ''
   response:
@@ -283,7 +292,7 @@ http_interactions:
       X-Xss-Protection:
       - '0'
       Date:
-      - Tue, 14 Mar 2023 17:13:41 GMT
+      - Tue, 14 Nov 2023 20:26:52 GMT
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
     body:
@@ -345,6 +354,5 @@ http_interactions:
             </dependency>
           </dependencies>
         </project>
-    http_version:
-  recorded_at: Tue, 14 Mar 2023 17:13:41 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Tue, 14 Nov 2023 20:26:52 GMT
+recorded_with: VCR 6.2.0

--- a/spec/fixtures/vcr_cassettes/maven-central/lambda-tracer.yml
+++ b/spec/fixtures/vcr_cassettes/maven-central/lambda-tracer.yml
@@ -12,11 +12,13 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate,br
       X-Datadog-Trace-Id:
-      - '2171900796462988569'
+      - '4235928741519309556'
       X-Datadog-Parent-Id:
-      - '1653901409958188171'
+      - '1319147838806452338'
       X-Datadog-Sampling-Priority:
       - '1'
+      X-Datadog-Tags:
+      - _dd.p.dm=-0
       Expect:
       - ''
   response:
@@ -34,22 +36,22 @@ http_interactions:
       - a7b4a205a5b860caf023e57189a3d219
       X-Checksum-Sha1:
       - f0109412f2b4f8fa2e5ee96dced5ad7ec183611c
+      Via:
+      - 1.1 varnish, 1.1 varnish
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 06 Oct 2023 18:45:56 GMT
-      Via:
-      - 1.1 varnish
+      - Tue, 14 Nov 2023 18:33:52 GMT
       Age:
-      - '1765714'
+      - '0'
       X-Served-By:
-      - cache-iad-kjyo7100092-IAD
+      - cache-iad-kiad7000048-IAD, cache-bos4684-BOS
       X-Cache:
-      - HIT
+      - HIT, MISS
       X-Cache-Hits:
-      - '1'
+      - 133, 0
       X-Timer:
-      - S1696617957.690418,VS0,VE2
+      - S1699986833.928412,VS0,VE13
       Content-Length:
       - '526'
     body:
@@ -73,7 +75,7 @@ http_interactions:
             <lastUpdated>20201102225343</lastUpdated>
           </versioning>
         </metadata>
-  recorded_at: Fri, 06 Oct 2023 18:45:56 GMT
+  recorded_at: Tue, 14 Nov 2023 18:33:52 GMT
 - request:
     method: get
     uri: https://repo1.maven.org/maven2/com/appdynamics/lambda-tracer/20.11.1400/lambda-tracer-20.11.1400.pom
@@ -86,11 +88,13 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate,br
       X-Datadog-Trace-Id:
-      - '840148521793714374'
+      - '725293561509775665'
       X-Datadog-Parent-Id:
-      - '1718767627243034159'
+      - '2005814853203144126'
       X-Datadog-Sampling-Priority:
       - '1'
+      X-Datadog-Tags:
+      - _dd.p.dm=-0
       Expect:
       - ''
   response:
@@ -108,22 +112,22 @@ http_interactions:
       - 6621e5453c92c317fd6526cff482435b
       X-Checksum-Sha1:
       - 30c714c122483ef6d127d64b82b991b35c8e2a32
+      Via:
+      - 1.1 varnish, 1.1 varnish
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 06 Oct 2023 18:45:56 GMT
-      Via:
-      - 1.1 varnish
+      - Tue, 14 Nov 2023 18:33:52 GMT
       Age:
-      - '304334'
+      - '0'
       X-Served-By:
-      - cache-iad-kjyo7100092-IAD
+      - cache-iad-kiad7000076-IAD, cache-bos4684-BOS
       X-Cache:
-      - HIT
+      - HIT, MISS
       X-Cache-Hits:
-      - '1'
+      - 10, 0
       X-Timer:
-      - S1696617957.718630,VS0,VE1
+      - S1699986833.964902,VS0,VE19
       Content-Length:
       - '1315'
     body:
@@ -166,10 +170,10 @@ http_interactions:
             </dependencies>
           </dependencyManagement>
         </project>
-  recorded_at: Fri, 06 Oct 2023 18:45:56 GMT
+  recorded_at: Tue, 14 Nov 2023 18:33:52 GMT
 - request:
     method: get
-    uri: https://repo1.maven.org/maven2/com/appdynamics/lambda-tracer/maven-metadata.xml
+    uri: https://repo1.maven.org/maven2/com/appdynamics/lambda-tracer
     body:
       encoding: US-ASCII
       string: ''
@@ -179,11 +183,84 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate,br
       X-Datadog-Trace-Id:
-      - '729269046303043636'
+      - '2819566557079577265'
       X-Datadog-Parent-Id:
-      - '3317148510334575109'
+      - '1963954543615842183'
       X-Datadog-Sampling-Priority:
       - '1'
+      X-Datadog-Tags:
+      - _dd.p.dm=-0
+      Expect:
+      - ''
+  response:
+    status:
+      code: 302
+      message: ''
+    headers:
+      X-Amz-Error-Code:
+      - Found
+      X-Amz-Error-Message:
+      - Resource Found
+      Location:
+      - "/maven2/com/appdynamics/lambda-tracer/"
+      Content-Type:
+      - text/html; charset=utf-8
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 14 Nov 2023 18:33:53 GMT
+      Age:
+      - '246'
+      X-Served-By:
+      - cache-iad-kcgs7200059-IAD, cache-bos4684-BOS
+      X-Cache:
+      - MISS, HIT
+      X-Cache-Hits:
+      - 0, 1
+      X-Timer:
+      - S1699986833.118977,VS0,VE1
+      Vary:
+      - Fastly-SSL,
+      Content-Length:
+      - '313'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        <html>
+        <head><title>302 Moved Temporarily</title></head>
+        <body>
+        <h1>302 Moved Temporarily</h1>
+        <ul>
+        <li>Code: Found</li>
+        <li>Message: Resource Found</li>
+        <li>RequestId: JKTQ635VFD5SB929</li>
+        <li>HostId: kc4SnLrb4bwjNzR0s8fHcd6PO+DjStMkggag5sTzt2ayYdQ4mzhW9kDOSSmOS/v9ZKwMbve87L4=</li>
+        </ul>
+        <hr/>
+        </body>
+        </html>
+  recorded_at: Tue, 14 Nov 2023 18:33:53 GMT
+- request:
+    method: get
+    uri: https://repo1.maven.org/maven2/com/appdynamics/lambda-tracer/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.6
+      Accept-Encoding:
+      - gzip,deflate,br
+      X-Datadog-Trace-Id:
+      - '1192687131530459947'
+      X-Datadog-Parent-Id:
+      - '2745761063158960858'
+      X-Datadog-Sampling-Priority:
+      - '1'
+      X-Datadog-Tags:
+      - _dd.p.dm=-0
       Expect:
       - ''
   response:
@@ -191,220 +268,50 @@ http_interactions:
       code: 200
       message: ''
     headers:
-      Etag:
-      - '"a7b4a205a5b860caf023e57189a3d219"'
-      Content-Type:
-      - text/xml
       Last-Modified:
-      - Mon, 02 Nov 2020 22:53:44 GMT
-      X-Checksum-Md5:
-      - a7b4a205a5b860caf023e57189a3d219
-      X-Checksum-Sha1:
-      - f0109412f2b4f8fa2e5ee96dced5ad7ec183611c
-      Accept-Ranges:
-      - bytes
-      Date:
-      - Fri, 06 Oct 2023 18:45:56 GMT
-      Via:
-      - 1.1 varnish
-      Age:
-      - '1765714'
-      X-Served-By:
-      - cache-iad-kjyo7100092-IAD
-      X-Cache:
-      - HIT
-      X-Cache-Hits:
-      - '2'
-      X-Timer:
-      - S1696617957.878424,VS0,VE0
-      Content-Length:
-      - '526'
-    body:
-      encoding: ASCII-8BIT
-      string: |
-        <?xml version="1.0" encoding="UTF-8"?>
-        <metadata>
-          <groupId>com.appdynamics</groupId>
-          <artifactId>lambda-tracer</artifactId>
-          <versioning>
-            <latest>20.11.1400</latest>
-            <release>20.11.1400</release>
-            <versions>
-              <version>1.0.2-1357</version>
-              <version>1.0.2-1361</version>
-              <version>1.1.1363</version>
-              <version>1.2.1390</version>
-              <version>20.03.1391</version>
-              <version>20.11.1400</version>
-            </versions>
-            <lastUpdated>20201102225343</lastUpdated>
-          </versioning>
-        </metadata>
-  recorded_at: Fri, 06 Oct 2023 18:45:56 GMT
-- request:
-    method: get
-    uri: https://repo1.maven.org/maven2/com/appdynamics/lambda-tracer/1.0.2-1357/lambda-tracer-1.0.2-1357.pom
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.17.6
-      Accept-Encoding:
-      - gzip,deflate,br
-      X-Datadog-Trace-Id:
-      - '3361212282044803059'
-      X-Datadog-Parent-Id:
-      - '1532456179166106276'
-      X-Datadog-Sampling-Priority:
-      - '1'
-      Expect:
-      - ''
-  response:
-    status:
-      code: 404
-      message: ''
-    headers:
-      Last-Modified:
-      - Wed, 10 Aug 2016 15:08:35 GMT
-      X-Amz-Version-Id:
-      - 'null'
+      - Mon, 02 Nov 2020 23:49:53 GMT
       Etag:
-      - '"1fb066da6a67c7c02962f59b4b8cd1ee"'
-      X-Amz-Error-Code:
-      - NoSuchKey
-      X-Amz-Error-Message:
-      - The specified key does not exist.
-      X-Amz-Error-Detail-Key:
-      - maven2/com/appdynamics/lambda-tracer/1.0.2-1357/lambda-tracer-1.0.2-1357.pom
-      X-Amz-Request-Id:
-      - TBSPA1VJ42HMEYAE
-      X-Amz-Id-2:
-      - ci/iQhreyHJlxAUIVuJe3z9x3fI2N+xhYFrjfAus9MTzzUsDpILdhkzqNK6V1miq3iXK9oLSjS4=
+      - '"631ce5b06336580ab92c577c170495a9"'
       Content-Type:
       - text/html
-      Server:
-      - AmazonS3
+      Via:
+      - 1.1 varnish, 1.1 varnish
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 06 Oct 2023 18:45:56 GMT
-      Via:
-      - 1.1 varnish
+      - Tue, 14 Nov 2023 18:33:53 GMT
       Age:
-      - '0'
+      - '246'
       X-Served-By:
-      - cache-iad-kjyo7100092-IAD
+      - cache-iad-kcgs7200123-IAD, cache-bos4684-BOS
       X-Cache:
-      - MISS
+      - HIT, HIT
       X-Cache-Hits:
-      - '0'
+      - 121, 1
       X-Timer:
-      - S1696617957.894273,VS0,VE56
+      - S1699986833.134883,VS0,VE1
       Content-Length:
-      - '554'
+      - '1663'
     body:
       encoding: ASCII-8BIT
-      string: |+
-        <html>
-        <head><title>404 Not Found</title></head>
-        <body bgcolor="white">
-        <center><h1>404 Not Found</h1></center>
-        <hr><center>nginx</center>
-        </body>
-        </html>
-        <!-- a padding to disable MSIE and Chrome friendly error page -->
-        <!-- a padding to disable MSIE and Chrome friendly error page -->
-        <!-- a padding to disable MSIE and Chrome friendly error page -->
-        <!-- a padding to disable MSIE and Chrome friendly error page -->
-        <!-- a padding to disable MSIE and Chrome friendly error page -->
-        <!-- a padding to disable MSIE and Chrome friendly error page -->
-
-
-
-  recorded_at: Fri, 06 Oct 2023 18:45:56 GMT
-- request:
-    method: get
-    uri: https://repo1.maven.org/maven2/com/appdynamics/lambda-tracer/1.0.2-1361/lambda-tracer-1.0.2-1361.pom
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.17.6
-      Accept-Encoding:
-      - gzip,deflate,br
-      X-Datadog-Trace-Id:
-      - '3034407789495924022'
-      X-Datadog-Parent-Id:
-      - '3797068597907531456'
-      X-Datadog-Sampling-Priority:
-      - '1'
-      Expect:
-      - ''
-  response:
-    status:
-      code: 404
-      message: ''
-    headers:
-      Last-Modified:
-      - Wed, 10 Aug 2016 15:08:35 GMT
-      X-Amz-Version-Id:
-      - 'null'
-      Etag:
-      - '"1fb066da6a67c7c02962f59b4b8cd1ee"'
-      X-Amz-Error-Code:
-      - NoSuchKey
-      X-Amz-Error-Message:
-      - The specified key does not exist.
-      X-Amz-Error-Detail-Key:
-      - maven2/com/appdynamics/lambda-tracer/1.0.2-1361/lambda-tracer-1.0.2-1361.pom
-      X-Amz-Request-Id:
-      - TBSYFV443ZXABXY3
-      X-Amz-Id-2:
-      - "/3uZbiyVvRdaJrTbYUlRnhcVNouap9DtUNVprSy0EvW7q5Zh6vXzLWbg9wmlvTAF7FvgsJVBnKI="
-      Content-Type:
-      - text/html
-      Server:
-      - AmazonS3
-      Accept-Ranges:
-      - bytes
-      Date:
-      - Fri, 06 Oct 2023 18:45:57 GMT
-      Via:
-      - 1.1 varnish
-      Age:
-      - '0'
-      X-Served-By:
-      - cache-iad-kjyo7100092-IAD
-      X-Cache:
-      - MISS
-      X-Cache-Hits:
-      - '0'
-      X-Timer:
-      - S1696617957.981941,VS0,VE20
-      Content-Length:
-      - '554'
-    body:
-      encoding: ASCII-8BIT
-      string: |+
-        <html>
-        <head><title>404 Not Found</title></head>
-        <body bgcolor="white">
-        <center><h1>404 Not Found</h1></center>
-        <hr><center>nginx</center>
-        </body>
-        </html>
-        <!-- a padding to disable MSIE and Chrome friendly error page -->
-        <!-- a padding to disable MSIE and Chrome friendly error page -->
-        <!-- a padding to disable MSIE and Chrome friendly error page -->
-        <!-- a padding to disable MSIE and Chrome friendly error page -->
-        <!-- a padding to disable MSIE and Chrome friendly error page -->
-        <!-- a padding to disable MSIE and Chrome friendly error page -->
-
-
-
-  recorded_at: Fri, 06 Oct 2023 18:45:57 GMT
+      string: "<!DOCTYPE html>\n<html>\n\n<head>\n\t<title>Central Repository: com/appdynamics/lambda-tracer</title>\n\t<meta
+        name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\n\t<style>\nbody
+        {\n\tbackground: #fff;\n}\n\t</style>\n</head>\n\n<body>\n\t<header>\n\t\t<h1>com/appdynamics/lambda-tracer</h1>\n\t</header>\n\t<hr/>\n\t<main>\n\t\t<pre
+        id=\"contents\">\n<a href=\"../\">../</a>\n<a href=\"1.1.1363/\" title=\"1.1.1363/\">1.1.1363/</a>
+        \                                        2019-06-26 21:58         -      \n<a
+        href=\"1.2.1390/\" title=\"1.2.1390/\">1.2.1390/</a>                                         2020-02-20
+        21:00         -      \n<a href=\"20.03.1391/\" title=\"20.03.1391/\">20.03.1391/</a>
+        \                                      2020-03-17 16:06         -      \n<a
+        href=\"20.11.1400/\" title=\"20.11.1400/\">20.11.1400/</a>                                       2020-11-02
+        22:43         -      \n<a href=\"maven-metadata.xml\" title=\"maven-metadata.xml\">maven-metadata.xml</a>
+        \                               2020-11-02 22:53       526      \n<a href=\"maven-metadata.xml.md5\"
+        title=\"maven-metadata.xml.md5\">maven-metadata.xml.md5</a>                            2020-11-02
+        22:53        32      \n<a href=\"maven-metadata.xml.sha1\" title=\"maven-metadata.xml.sha1\">maven-metadata.xml.sha1</a>
+        \                          2020-11-02 22:53        40      \n<a href=\"maven-metadata.xml.sha256\"
+        title=\"maven-metadata.xml.sha256\">maven-metadata.xml.sha256</a>                         2020-11-02
+        22:53        64      \n<a href=\"maven-metadata.xml.sha512\" title=\"maven-metadata.xml.sha512\">maven-metadata.xml.sha512</a>
+        \                        2020-11-02 22:53       128      \n\t\t</pre>\n\t</main>\n\t<hr/>\n</body>\n\n</html>"
+  recorded_at: Tue, 14 Nov 2023 18:33:53 GMT
 - request:
     method: get
     uri: https://repo1.maven.org/maven2/com/appdynamics/lambda-tracer/1.1.1363/lambda-tracer-1.1.1363.pom
@@ -417,11 +324,13 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate,br
       X-Datadog-Trace-Id:
-      - '1913304040379827017'
+      - '2821793639989170820'
       X-Datadog-Parent-Id:
-      - '961657344126420307'
+      - '3969972856700017117'
       X-Datadog-Sampling-Priority:
       - '1'
+      X-Datadog-Tags:
+      - _dd.p.dm=-0
       Expect:
       - ''
   response:
@@ -439,22 +348,22 @@ http_interactions:
       - 0a8559bd12731ce41c36965f6e1e1894
       X-Checksum-Sha1:
       - a356dba2b712f8e879bb888a18cc1bb8eaf8ab2e
+      Via:
+      - 1.1 varnish, 1.1 varnish
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 06 Oct 2023 18:45:57 GMT
-      Via:
-      - 1.1 varnish
+      - Tue, 14 Nov 2023 18:33:53 GMT
       Age:
-      - '411176'
+      - '0'
       X-Served-By:
-      - cache-iad-kjyo7100092-IAD
+      - cache-iad-kjyo7100170-IAD, cache-bos4684-BOS
       X-Cache:
-      - HIT
+      - HIT, MISS
       X-Cache-Hits:
-      - '1'
+      - 35, 0
       X-Timer:
-      - S1696617957.027181,VS0,VE2
+      - S1699986833.151111,VS0,VE13
       Content-Length:
       - '1313'
     body:
@@ -497,7 +406,7 @@ http_interactions:
             </dependencies>
           </dependencyManagement>
         </project>
-  recorded_at: Fri, 06 Oct 2023 18:45:57 GMT
+  recorded_at: Tue, 14 Nov 2023 18:33:53 GMT
 - request:
     method: get
     uri: https://repo1.maven.org/maven2/com/appdynamics/lambda-tracer/1.2.1390/lambda-tracer-1.2.1390.pom
@@ -510,11 +419,13 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate,br
       X-Datadog-Trace-Id:
-      - '3276743396009117167'
+      - '2564397983334011195'
       X-Datadog-Parent-Id:
-      - '891073980308940452'
+      - '3670720560715608415'
       X-Datadog-Sampling-Priority:
       - '1'
+      X-Datadog-Tags:
+      - _dd.p.dm=-0
       Expect:
       - ''
   response:
@@ -532,22 +443,22 @@ http_interactions:
       - 940f720a9b5970071befe5f9e1ff11a3
       X-Checksum-Sha1:
       - 5ec381f4a0fff6dd6be3ed561282971c4c89722b
+      Via:
+      - 1.1 varnish, 1.1 varnish
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 06 Oct 2023 18:45:57 GMT
-      Via:
-      - 1.1 varnish
+      - Tue, 14 Nov 2023 18:33:53 GMT
       Age:
-      - '779292'
+      - '0'
       X-Served-By:
-      - cache-iad-kjyo7100092-IAD
+      - cache-iad-kiad7000120-IAD, cache-bos4684-BOS
       X-Cache:
-      - HIT
+      - HIT, MISS
       X-Cache-Hits:
-      - '1'
+      - 25, 0
       X-Timer:
-      - S1696617957.054958,VS0,VE2
+      - S1699986833.181021,VS0,VE24
       Content-Length:
       - '1313'
     body:
@@ -590,7 +501,7 @@ http_interactions:
             </dependencies>
           </dependencyManagement>
         </project>
-  recorded_at: Fri, 06 Oct 2023 18:45:57 GMT
+  recorded_at: Tue, 14 Nov 2023 18:33:53 GMT
 - request:
     method: get
     uri: https://repo1.maven.org/maven2/com/appdynamics/lambda-tracer/20.03.1391/lambda-tracer-20.03.1391.pom
@@ -603,11 +514,13 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate,br
       X-Datadog-Trace-Id:
-      - '847604396885963111'
+      - '2520756335764367846'
       X-Datadog-Parent-Id:
-      - '904938222952720595'
+      - '3130251109357192676'
       X-Datadog-Sampling-Priority:
       - '1'
+      X-Datadog-Tags:
+      - _dd.p.dm=-0
       Expect:
       - ''
   response:
@@ -625,22 +538,22 @@ http_interactions:
       - f82b0c5755a1877e30d019ac860c30a8
       X-Checksum-Sha1:
       - d89abc7fa315841387016898ebb8a8965c5fc3c3
+      Via:
+      - 1.1 varnish, 1.1 varnish
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 06 Oct 2023 18:45:57 GMT
-      Via:
-      - 1.1 varnish
+      - Tue, 14 Nov 2023 18:33:53 GMT
       Age:
-      - '298241'
+      - '0'
       X-Served-By:
-      - cache-iad-kjyo7100092-IAD
+      - cache-iad-kcgs7200116-IAD, cache-bos4684-BOS
       X-Cache:
-      - HIT
+      - HIT, MISS
       X-Cache-Hits:
-      - '1'
+      - 24, 0
       X-Timer:
-      - S1696617957.079317,VS0,VE4
+      - S1699986833.227294,VS0,VE14
       Content-Length:
       - '1315'
     body:
@@ -683,7 +596,7 @@ http_interactions:
             </dependencies>
           </dependencyManagement>
         </project>
-  recorded_at: Fri, 06 Oct 2023 18:45:57 GMT
+  recorded_at: Tue, 14 Nov 2023 18:33:53 GMT
 - request:
     method: get
     uri: https://repo1.maven.org/maven2/com/appdynamics/lambda-tracer/20.11.1400/lambda-tracer-20.11.1400.pom
@@ -696,11 +609,13 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate,br
       X-Datadog-Trace-Id:
-      - '1176030230460978932'
+      - '3513296333894628666'
       X-Datadog-Parent-Id:
-      - '2249563595237073568'
+      - '2948478668425562620'
       X-Datadog-Sampling-Priority:
       - '1'
+      X-Datadog-Tags:
+      - _dd.p.dm=-0
       Expect:
       - ''
   response:
@@ -718,22 +633,22 @@ http_interactions:
       - 6621e5453c92c317fd6526cff482435b
       X-Checksum-Sha1:
       - 30c714c122483ef6d127d64b82b991b35c8e2a32
+      Via:
+      - 1.1 varnish, 1.1 varnish
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 06 Oct 2023 18:45:57 GMT
-      Via:
-      - 1.1 varnish
+      - Tue, 14 Nov 2023 18:33:53 GMT
       Age:
-      - '304334'
+      - '0'
       X-Served-By:
-      - cache-iad-kjyo7100092-IAD
+      - cache-iad-kiad7000076-IAD, cache-bos4684-BOS
       X-Cache:
-      - HIT
+      - HIT, HIT
       X-Cache-Hits:
-      - '2'
+      - 10, 1
       X-Timer:
-      - S1696617957.110334,VS0,VE0
+      - S1699986833.257606,VS0,VE0
       Content-Length:
       - '1315'
     body:
@@ -776,7 +691,7 @@ http_interactions:
             </dependencies>
           </dependencyManagement>
         </project>
-  recorded_at: Fri, 06 Oct 2023 18:45:57 GMT
+  recorded_at: Tue, 14 Nov 2023 18:33:53 GMT
 - request:
     method: get
     uri: https://repo1.maven.org/maven2/com/appdynamics/lambda-tracer/1.1.1363/lambda-tracer-1.1.1363.pom
@@ -789,11 +704,13 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate,br
       X-Datadog-Trace-Id:
-      - '4439240935651118189'
+      - '3466144632753936703'
       X-Datadog-Parent-Id:
-      - '4605878410114513462'
+      - '2955380507480321190'
       X-Datadog-Sampling-Priority:
       - '1'
+      X-Datadog-Tags:
+      - _dd.p.dm=-0
       Expect:
       - ''
   response:
@@ -811,22 +728,22 @@ http_interactions:
       - 0a8559bd12731ce41c36965f6e1e1894
       X-Checksum-Sha1:
       - a356dba2b712f8e879bb888a18cc1bb8eaf8ab2e
+      Via:
+      - 1.1 varnish, 1.1 varnish
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 06 Oct 2023 18:45:57 GMT
-      Via:
-      - 1.1 varnish
+      - Tue, 14 Nov 2023 18:33:53 GMT
       Age:
-      - '411176'
+      - '0'
       X-Served-By:
-      - cache-iad-kjyo7100092-IAD
+      - cache-iad-kjyo7100170-IAD, cache-bos4684-BOS
       X-Cache:
-      - HIT
+      - HIT, HIT
       X-Cache-Hits:
-      - '2'
+      - 35, 1
       X-Timer:
-      - S1696617957.195041,VS0,VE0
+      - S1699986833.307208,VS0,VE0
       Content-Length:
       - '1313'
     body:
@@ -869,7 +786,7 @@ http_interactions:
             </dependencies>
           </dependencyManagement>
         </project>
-  recorded_at: Fri, 06 Oct 2023 18:45:57 GMT
+  recorded_at: Tue, 14 Nov 2023 18:33:53 GMT
 - request:
     method: get
     uri: https://repo1.maven.org/maven2/com/appdynamics/lambda-tracer/1.2.1390/lambda-tracer-1.2.1390.pom
@@ -882,11 +799,13 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate,br
       X-Datadog-Trace-Id:
-      - '4122331297460348603'
+      - '1182779076227606475'
       X-Datadog-Parent-Id:
-      - '1254797055677593923'
+      - '4486714259580522009'
       X-Datadog-Sampling-Priority:
       - '1'
+      X-Datadog-Tags:
+      - _dd.p.dm=-0
       Expect:
       - ''
   response:
@@ -904,22 +823,22 @@ http_interactions:
       - 940f720a9b5970071befe5f9e1ff11a3
       X-Checksum-Sha1:
       - 5ec381f4a0fff6dd6be3ed561282971c4c89722b
+      Via:
+      - 1.1 varnish, 1.1 varnish
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 06 Oct 2023 18:45:57 GMT
-      Via:
-      - 1.1 varnish
+      - Tue, 14 Nov 2023 18:33:53 GMT
       Age:
-      - '779292'
+      - '0'
       X-Served-By:
-      - cache-iad-kjyo7100092-IAD
+      - cache-iad-kiad7000120-IAD, cache-bos4684-BOS
       X-Cache:
-      - HIT
+      - HIT, HIT
       X-Cache-Hits:
-      - '2'
+      - 25, 1
       X-Timer:
-      - S1696617957.283893,VS0,VE0
+      - S1699986833.369255,VS0,VE0
       Content-Length:
       - '1313'
     body:
@@ -962,7 +881,7 @@ http_interactions:
             </dependencies>
           </dependencyManagement>
         </project>
-  recorded_at: Fri, 06 Oct 2023 18:45:57 GMT
+  recorded_at: Tue, 14 Nov 2023 18:33:53 GMT
 - request:
     method: get
     uri: https://repo1.maven.org/maven2/com/appdynamics/lambda-tracer/20.03.1391/lambda-tracer-20.03.1391.pom
@@ -975,11 +894,13 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate,br
       X-Datadog-Trace-Id:
-      - '223941440561283747'
+      - '389998858112681443'
       X-Datadog-Parent-Id:
-      - '1845257705565591295'
+      - '3998382217038005796'
       X-Datadog-Sampling-Priority:
       - '1'
+      X-Datadog-Tags:
+      - _dd.p.dm=-0
       Expect:
       - ''
   response:
@@ -997,22 +918,22 @@ http_interactions:
       - f82b0c5755a1877e30d019ac860c30a8
       X-Checksum-Sha1:
       - d89abc7fa315841387016898ebb8a8965c5fc3c3
+      Via:
+      - 1.1 varnish, 1.1 varnish
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 06 Oct 2023 18:45:57 GMT
-      Via:
-      - 1.1 varnish
+      - Tue, 14 Nov 2023 18:33:53 GMT
       Age:
-      - '298241'
+      - '0'
       X-Served-By:
-      - cache-iad-kjyo7100092-IAD
+      - cache-iad-kcgs7200116-IAD, cache-bos4684-BOS
       X-Cache:
-      - HIT
+      - HIT, HIT
       X-Cache-Hits:
-      - '2'
+      - 24, 1
       X-Timer:
-      - S1696617957.326273,VS0,VE0
+      - S1699986833.406996,VS0,VE0
       Content-Length:
       - '1315'
     body:
@@ -1055,7 +976,7 @@ http_interactions:
             </dependencies>
           </dependencyManagement>
         </project>
-  recorded_at: Fri, 06 Oct 2023 18:45:57 GMT
+  recorded_at: Tue, 14 Nov 2023 18:33:53 GMT
 - request:
     method: get
     uri: https://repo1.maven.org/maven2/com/appdynamics/lambda-tracer/20.11.1400/lambda-tracer-20.11.1400.pom
@@ -1068,11 +989,13 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate,br
       X-Datadog-Trace-Id:
-      - '2520170969722955541'
+      - '2127390582545979276'
       X-Datadog-Parent-Id:
-      - '3000733677263512068'
+      - '2615287101019223361'
       X-Datadog-Sampling-Priority:
       - '1'
+      X-Datadog-Tags:
+      - _dd.p.dm=-0
       Expect:
       - ''
   response:
@@ -1090,22 +1013,22 @@ http_interactions:
       - 6621e5453c92c317fd6526cff482435b
       X-Checksum-Sha1:
       - 30c714c122483ef6d127d64b82b991b35c8e2a32
+      Via:
+      - 1.1 varnish, 1.1 varnish
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 06 Oct 2023 18:45:57 GMT
-      Via:
-      - 1.1 varnish
+      - Tue, 14 Nov 2023 18:33:53 GMT
       Age:
-      - '304335'
+      - '0'
       X-Served-By:
-      - cache-iad-kjyo7100092-IAD
+      - cache-iad-kiad7000076-IAD, cache-bos4684-BOS
       X-Cache:
-      - HIT
+      - HIT, HIT
       X-Cache-Hits:
-      - '3'
+      - 10, 2
       X-Timer:
-      - S1696617957.364257,VS0,VE0
+      - S1699986833.433395,VS0,VE0
       Content-Length:
       - '1315'
     body:
@@ -1148,7 +1071,7 @@ http_interactions:
             </dependencies>
           </dependencyManagement>
         </project>
-  recorded_at: Fri, 06 Oct 2023 18:45:57 GMT
+  recorded_at: Tue, 14 Nov 2023 18:33:53 GMT
 - request:
     method: get
     uri: https://repo1.maven.org/maven2/com/appdynamics/lambda-tracer/1.0.2-1361/lambda-tracer-1.0.2-1361.pom
@@ -1161,11 +1084,13 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate,br
       X-Datadog-Trace-Id:
-      - '243299241191051528'
+      - '4310615569623405557'
       X-Datadog-Parent-Id:
-      - '2927817012117263129'
+      - '2061021909246129839'
       X-Datadog-Sampling-Priority:
       - '1'
+      X-Datadog-Tags:
+      - _dd.p.dm=-0
       Expect:
       - ''
   response:
@@ -1186,29 +1111,29 @@ http_interactions:
       X-Amz-Error-Detail-Key:
       - maven2/com/appdynamics/lambda-tracer/1.0.2-1361/lambda-tracer-1.0.2-1361.pom
       X-Amz-Request-Id:
-      - TBSYFV443ZXABXY3
+      - C2GA8QVJD8QS9R71
       X-Amz-Id-2:
-      - "/3uZbiyVvRdaJrTbYUlRnhcVNouap9DtUNVprSy0EvW7q5Zh6vXzLWbg9wmlvTAF7FvgsJVBnKI="
+      - ueO14jspgtdDWBqQ2O3UoWgKc63Vy6QnP+6UWJhD8v5X0SmwnBwyRcHqX9usOzhyNnHGb3aPVEI=
       Content-Type:
       - text/html
       Server:
       - AmazonS3
+      Via:
+      - 1.1 varnish, 1.1 varnish
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 06 Oct 2023 18:45:57 GMT
-      Via:
-      - 1.1 varnish
+      - Tue, 14 Nov 2023 18:33:53 GMT
       Age:
       - '0'
       X-Served-By:
-      - cache-iad-kjyo7100092-IAD
+      - cache-iad-kcgs7200059-IAD, cache-bos4684-BOS
       X-Cache:
-      - HIT
+      - MISS, MISS
       X-Cache-Hits:
-      - '1'
+      - 0, 0
       X-Timer:
-      - S1696617957.402381,VS0,VE0
+      - S1699986833.466671,VS0,VE61
       Content-Length:
       - '554'
     body:
@@ -1230,6 +1155,6 @@ http_interactions:
 
 
 
-  recorded_at: Fri, 06 Oct 2023 18:45:57 GMT
+  recorded_at: Tue, 14 Nov 2023 18:33:53 GMT
 recorded_with: VCR 6.2.0
 ...

--- a/spec/models/package_manager/maven/google_spec.rb
+++ b/spec/models/package_manager/maven/google_spec.rb
@@ -47,4 +47,13 @@ describe PackageManager::Maven::Google do
       ])
     end
   end
+
+  describe ".latest_version" do
+    it "retrieves latest version from Google maven-metadata.xml" do
+      VCR.use_cassette("google-maven/memory-advice") do
+        # Matching latest version as of November 2023
+        expect(described_class.latest_version("com.google.android.games:memory-advice")).to eq("0.24")
+      end
+    end
+  end
 end

--- a/spec/models/package_manager/maven/maven_central_spec.rb
+++ b/spec/models/package_manager/maven/maven_central_spec.rb
@@ -29,4 +29,13 @@ describe PackageManager::Maven::MavenCentral do
       end
     end
   end
+
+  describe ".versions_from_html" do
+    it "retrieves versions from Maven Central index HTML" do
+      VCR.use_cassette("maven-central/lambda-tracer") do
+        # Matching versions as of November 2023
+        expect(described_class.versions_from_html("com.appdynamics:lambda-tracer")).to match_array(%w[1.1.1363 1.2.1390 20.03.1391 20.11.1400])
+      end
+    end
+  end
 end

--- a/spec/models/package_manager/maven/maven_central_spec.rb
+++ b/spec/models/package_manager/maven/maven_central_spec.rb
@@ -13,7 +13,7 @@ describe PackageManager::Maven::MavenCentral do
       # a version that was removed on Maven Central that we still know about
       let!(:remotely_removed_version) { project.versions.create(number: "1.0.2-1361", status: nil) }
 
-      # a version that, as of October 2023, was still available on Maven Central
+      # a version that, as of November 2023, was still available on Maven Central
       let!(:existing_version) { project.versions.create(number: "1.1.1363", status: nil) }
 
       it "marks the remotely removed version as Removed" do


### PR DESCRIPTION
For Maven Central, search through HTML index directory for versions instead of using Maven metadata. This is required because Maven Central metadata is not guaranteed to include all versions.