### PR TITLE
Fix Packagist dependencies update.

### DIFF
--- a/app/models/package_manager/packagist.rb
+++ b/app/models/package_manager/packagist.rb
@@ -105,7 +105,7 @@ module PackageManager
     end
 
     def self.dependencies(_name, version, mapped_project)
-      vers = mapped_project[:versions][version]
+      vers = mapped_project[:versions].find { |v| v["version"] == version }
       return [] if vers.nil?
 
       map_dependencies(vers.fetch("require", {}).reject { |k, _v| k == "php" }, "runtime") +


### PR DESCRIPTION
fixes this error, which is getting silenced into logs only, and which has happened about 1 million times in the past 2 weeks: `"ERROR Error while trying to get dependencies for Packagist/PACKAGE/NAME@1.0.0: no implicit conversion of String into Integer"`.
