### PR TITLE
Log how often we update projects without/with changes.

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -392,7 +392,7 @@ class Project < ApplicationRecord
 
   def send_project_updated
     # monitor how often this happens, temporarily, to see how often we might be sending useless webhooks.
-    StructuredLog.capture("PROJECT_UPDATED_WITHOUT_CHANGES", { platform: platform, name: name, id: id, has_changes: changes.present?})
+    StructuredLog.capture("PROJECT_SAVED", { platform: platform, name: name, id: id, has_changes: changes.present?})
 
     # this should be a cheap no-op if we remove all the
     # receives_all_project_updates WebHook, so that's an emergency off switch if

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -391,6 +391,9 @@ class Project < ApplicationRecord
   end
 
   def send_project_updated
+    # monitor how often this happens, temporarily, to see how often we might be sending useless webhooks.
+    StructuredLog.capture("PROJECT_UPDATED_WITHOUT_CHANGES", { platform: platform, name: name, id: id, has_changes: changes.present?})
+
     # this should be a cheap no-op if we remove all the
     # receives_all_project_updates WebHook, so that's an emergency off switch if
     # required. Each webhook must be its own sidekiq job so it can be


### PR DESCRIPTION
log every time a project would be sending webhooks, to see how often we send webhooks when a project hasn't vs has changed.

(the project's changes itself aren't the full story, as there might be version, dependency, etc changes as well)