### PR TITLE
Silence sidekiq deprecation message

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -54,7 +54,7 @@ Sidekiq.default_job_options = {
   backtrace: true,
 }
 
-Sidekiq.default_worker_options = {
+Sidekiq.default_job_options = {
   backtrace: true,
 }
 


### PR DESCRIPTION
`DEPRECATION WARNING: default_worker_options= is deprecated and will be removed from Sidekiq 7.0 (use default_job_options= instead)`
