### PR TITLE
Adds some useful debugging for initial missing deps bug.

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -260,7 +260,7 @@ module PackageManager
       db_versions = db_versions.where(number: sync_version) unless sync_version == :all
 
       if db_versions.empty?
-        StructuredLog.capture("SAVE_DEPENDENCIES_FAILURE", { platform: db_platform, name: name, version: version, message: "no versions found" })
+        StructuredLog.capture("SAVE_DEPENDENCIES_FAILURE", { platform: db_platform, name: name, version: sync_version, message: "no versions found" })
       end
 
       db_versions.each do |db_version|

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -258,6 +258,11 @@ module PackageManager
       db_project = Project.find_by(name: name, platform: db_platform)
       db_versions = db_project.versions.includes(:dependencies)
       db_versions = db_versions.where(number: sync_version) unless sync_version == :all
+
+      if db_versions.size.zero?
+        StructuredLog.capture("DEBUGGING_MISSING_DEPENDENCIES", { platform: db_platform, name: name, version: version, message: "no versions found"})
+      end
+
       db_versions.each do |db_version|
         next if db_version.dependencies.any? && !force_sync_dependencies
 

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -259,8 +259,8 @@ module PackageManager
       db_versions = db_project.versions.includes(:dependencies)
       db_versions = db_versions.where(number: sync_version) unless sync_version == :all
 
-      if db_versions.size.zero?
-        StructuredLog.capture("DEBUGGING_MISSING_DEPENDENCIES", { platform: db_platform, name: name, version: version, message: "no versions found"})
+      if db_versions.empty?
+        StructuredLog.capture("SAVE_DEPENDENCIES_FAILURE", { platform: db_platform, name: name, version: version, message: "no versions found" })
       end
 
       db_versions.each do |db_version|

--- a/app/models/package_manager/haxelib.rb
+++ b/app/models/package_manager/haxelib.rb
@@ -66,7 +66,7 @@ module PackageManager
         }
       end
     rescue StandardError => e
-      StructuredLog.capture("DEPENDENCIES_FAILURE", { platform: db_platform, name: name, version: version, error_klass: e.class.to_s, error: e.message})
+      StructuredLog.capture("DEPENDENCIES_FAILURE", { platform: db_platform, name: name, version: version, error_klass: e.class.to_s, error: e.message })
       []
     end
   end

--- a/app/models/package_manager/haxelib.rb
+++ b/app/models/package_manager/haxelib.rb
@@ -65,7 +65,8 @@ module PackageManager
           platform: self.name.demodulize,
         }
       end
-    rescue StandardError
+    rescue StandardError => e
+      StructuredLog.capture("DEPENDENCIES_FAILURE", { platform: db_platform, name: name, version: version, error_klass: e.class.to_s, error: e.message})
       []
     end
   end

--- a/app/models/package_manager/npm.rb
+++ b/app/models/package_manager/npm.rb
@@ -118,7 +118,10 @@ module PackageManager
 
     def self.dependencies(_name, version, mapped_project)
       vers = mapped_project.fetch(:versions, {})[version]
-      return [] if vers.nil?
+      if vers.nil?
+        StructuredLog.capture("DEBUGGING_MISSING_DEPENDENCIES", { platform: db_platform, name: name, version: version, message: "version not found in upstream"})
+        return []
+      end
 
       map_dependencies(vers.fetch("dependencies", {}), "runtime") +
         map_dependencies(vers.fetch("devDependencies", {}), "Development") +

--- a/app/models/package_manager/npm.rb
+++ b/app/models/package_manager/npm.rb
@@ -119,7 +119,7 @@ module PackageManager
     def self.dependencies(_name, version, mapped_project)
       vers = mapped_project.fetch(:versions, {})[version]
       if vers.nil?
-        StructuredLog.capture("DEBUGGING_MISSING_DEPENDENCIES", { platform: db_platform, name: name, version: version, message: "version not found in upstream"})
+        StructuredLog.capture("DEPENDENCIES_FAILURE", { platform: db_platform, name: name, version: version, message: "version not found in upstream" })
         return []
       end
 

--- a/app/models/package_manager/rubygems.rb
+++ b/app/models/package_manager/rubygems.rb
@@ -81,7 +81,7 @@ module PackageManager
       deps = json["dependencies"]
       map_dependencies(deps["development"], "Development") + map_dependencies(deps["runtime"], "runtime")
     rescue StandardError => e
-      StructuredLog.capture("DEBUGGING_MISSING_DEPENDENCIES", { platform: db_platform, name: name, version: version, error_klass: e.class.to_s, error: e.message})
+      StructuredLog.capture("DEPENDENCIES_FAILURE", { platform: db_platform, name: name, version: version, error_klass: e.class.to_s, error: e.message })
       []
     end
 

--- a/app/models/package_manager/rubygems.rb
+++ b/app/models/package_manager/rubygems.rb
@@ -80,7 +80,8 @@ module PackageManager
 
       deps = json["dependencies"]
       map_dependencies(deps["development"], "Development") + map_dependencies(deps["runtime"], "runtime")
-    rescue StandardError
+    rescue StandardError => e
+      StructuredLog.capture("DEBUGGING_MISSING_DEPENDENCIES", { platform: db_platform, name: name, version: version, error_klass: e.class.to_s, error: e.message})
       []
     end
 


### PR DESCRIPTION
there's an occasional bug we have where a version is ingested (via PackageManagerDownloadWorker) but the dependencies aren't saved on the initial download.

It's not clear why this is happening, so this PR adds some debugging code to monitor these a bit.