### PR TITLE
Set a reasonable 5-second timeout for CRAN requests.

### DIFF
--- a/app/models/package_manager/cran.rb
+++ b/app/models/package_manager/cran.rb
@@ -25,7 +25,7 @@ module PackageManager
     end
 
     def self.project_names
-      html = get_html("https://cran.r-project.org/web/packages/available_packages_by_date.html")
+      html = get_html("https://cran.r-project.org/web/packages/available_packages_by_date.html", request: {timeout: 5})
       html.css("tr")[1..].map { |tr| tr.css("td")[1].text.strip }
     end
 
@@ -34,7 +34,7 @@ module PackageManager
     end
 
     def self.project(name)
-      html = get_html("https://cran.r-project.org/web/packages/#{name}/index.html")
+      html = get_html("https://cran.r-project.org/web/packages/#{name}/index.html", request: {timeout: 5})
       info = {}
       table = html.css("table")[0]
       return nil if table.nil?
@@ -65,7 +65,7 @@ module PackageManager
     end
 
     def self.find_old_versions(project)
-      archive_page = get_html("https://cran.r-project.org/src/contrib/Archive/#{project[:name]}/")
+      archive_page = get_html("https://cran.r-project.org/src/contrib/Archive/#{project[:name]}/", request: {timeout: 5})
       trs = archive_page.css("table").css("tr").select do |tr|
         tds = tr.css("td")
         tds[1]&.text&.match(/tar\.gz$/)


### PR DESCRIPTION
CRAN is offline for maintenance today, so set a default timeout for HTML requests (the default seems to be a few minutes).