### PR TITLE
PackageManager::CPAN.dependencies(): fix this by passing the CPAN API "_source" instead of "field"

### DIFF
--- a/app/models/package_manager/cpan.rb
+++ b/app/models/package_manager/cpan.rb
@@ -46,19 +46,19 @@ module PackageManager
     end
 
     def self.versions(raw_project, _name)
-      versions = get("https://fastapi.metacpan.org/v1/release/_search?q=distribution:#{raw_project['distribution']}&size=5000&fields=version,date")["hits"]["hits"]
+      versions = get("https://fastapi.metacpan.org/v1/release/_search?q=distribution:#{raw_project['distribution']}&size=5000&_source=version,date")["hits"]["hits"]
       versions.map do |version|
         {
-          number: version["fields"]["version"],
-          published_at: version["fields"]["date"],
+          number: version["_source"]["version"],
+          published_at: version["_source"]["date"],
         }
       end
     end
 
     def self.dependencies(_name, version, mapped_project)
-      versions = mapped_project[:versions]
-      version_data = versions.find { |v| v["fields"]["version"] == version }
-      version_data["fields"]["dependency"].select { |dep| dep["relationship"] == "requires" }.map do |dep|
+      versions = get("https://fastapi.metacpan.org/v1/release/_search?q=distribution:#{mapped_project[:name]}&size=5000&_source=version,dependency")["hits"]["hits"]
+      version_data = versions.find { |v| v["_source"]["version"] == version }
+      version_data["_source"]["dependency"].select { |dep| dep["relationship"] == "requires" }.map do |dep|
         {
           project_name: dep["module"].gsub("::", "-"),
           requirements: dep["version"],

--- a/app/models/package_manager/cran.rb
+++ b/app/models/package_manager/cran.rb
@@ -25,7 +25,7 @@ module PackageManager
     end
 
     def self.project_names
-      html = get_html("https://cran.r-project.org/web/packages/available_packages_by_date.html", request: {timeout: 5})
+      html = get_html("https://cran.r-project.org/web/packages/available_packages_by_date.html", request: { timeout: 5 })
       html.css("tr")[1..].map { |tr| tr.css("td")[1].text.strip }
     end
 
@@ -34,7 +34,7 @@ module PackageManager
     end
 
     def self.project(name)
-      html = get_html("https://cran.r-project.org/web/packages/#{name}/index.html", request: {timeout: 5})
+      html = get_html("https://cran.r-project.org/web/packages/#{name}/index.html", request: { timeout: 5 })
       info = {}
       table = html.css("table")[0]
       return nil if table.nil?
@@ -65,7 +65,7 @@ module PackageManager
     end
 
     def self.find_old_versions(project)
-      archive_page = get_html("https://cran.r-project.org/src/contrib/Archive/#{project[:name]}/", request: {timeout: 5})
+      archive_page = get_html("https://cran.r-project.org/src/contrib/Archive/#{project[:name]}/", request: { timeout: 5 })
       trs = archive_page.css("table").css("tr").select do |tr|
         tds = tr.css("td")
         tds[1]&.text&.match(/tar\.gz$/)


### PR DESCRIPTION
we need to select "dependency" as a returned field from their ES API, but "dependency" is an Object itself so ES complains that it's not a leaf node. Using `_source` lets us return that field specifically.

[docs on _source vs field](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html)
[docs on metacpan's API](https://github.com/metacpan/metacpan-api/blob/master/docs/API-docs.md)