### PR TITLE
Implements Version#dependencies_count

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -291,8 +291,9 @@ module PackageManager
             &.id
           db_version.dependencies.create!(dep.merge(project_id: named_project_id.try(:strip)))
         end
-        db_version.set_runtime_dependencies_count if deps.any?
-        db_version.set_dependencies_count # this serves as a marker that we have saved Version#dependencies or not, even if there are zero (other)
+        # this serves as a marker that we have saved Version#dependencies or not, even if there are zero (other)
+        db_version.set_runtime_dependencies_count
+        db_version.set_dependencies_count
       end
     end
 

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -292,6 +292,7 @@ module PackageManager
           db_version.dependencies.create!(dep.merge(project_id: named_project_id.try(:strip)))
         end
         db_version.set_runtime_dependencies_count if deps.any?
+        db_version.set_dependencies_count # this serves as a marker that we have saved Version#dependencies or not, even if there are zero (other)
       end
     end
 

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -5,6 +5,7 @@
 # Table name: versions
 #
 #  id                         :integer          not null, primary key
+#  dependencies_count         :integer
 #  number                     :string
 #  original_license           :jsonb
 #  published_at               :datetime

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -211,4 +211,8 @@ class Version < ApplicationRecord
   def set_runtime_dependencies_count
     update_column(:runtime_dependencies_count, runtime_dependencies.count)
   end
+
+  def set_dependencies_count
+    update_column(:dependencies_count, dependencies.count)
+  end
 end

--- a/db/migrate/20231116161641_add_dependencies_count_to_version.rb
+++ b/db/migrate/20231116161641_add_dependencies_count_to_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddDependenciesCountToVersion < ActiveRecord::Migration[7.0]
   def change
     add_column :versions, :dependencies_count, :integer

--- a/db/migrate/20231116161641_add_dependencies_count_to_version.rb
+++ b/db/migrate/20231116161641_add_dependencies_count_to_version.rb
@@ -1,0 +1,5 @@
+class AddDependenciesCountToVersion < ActiveRecord::Migration[7.0]
+  def change
+    add_column :versions, :dependencies_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -409,6 +409,7 @@ ActiveRecord::Schema[6.1].define(version: 2023_07_31_220834) do
     t.datetime "researched_at"
     t.jsonb "repository_sources"
     t.string "status"
+    t.integer "dependencies_count"
     t.index ["project_id", "number"], name: "index_versions_on_project_id_and_number", unique: true
     t.index ["updated_at"], name: "index_versions_on_updated_at"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[6.1].define(version: 2023_07_31_220834) do
-
+ActiveRecord::Schema[7.0].define(version: 2023_11_16_161641) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"

--- a/lib/tasks/one_off.rake
+++ b/lib/tasks/one_off.rake
@@ -112,7 +112,7 @@ namespace :one_off do
     print "Total examined: #{packages.count}, Total created: #{processed}"
   end
 
-  desc "Backfill Version.dependencies_count"
+  desc "Backfill Version#dependencies_count"
   task backfill_version_dependencies_count: :environment do
     versions = Version.where(dependencies_count: nil).where.associated(:dependencies).group("versions.id")
 

--- a/lib/tasks/one_off.rake
+++ b/lib/tasks/one_off.rake
@@ -118,12 +118,12 @@ namespace :one_off do
 
     puts "Updating #{versions.count.size} versions..."
 
-    versions.in_batches(of: 100).each_with_index{ |batch, idx|  
+    versions.in_batches(of: 100).each_with_index do |batch, idx|
       batch.update_all("dependencies_count = (SELECT count(*) FROM dependencies WHERE dependencies.version_id = versions.id)")
       if idx % 10 == 0
         puts "#{versions.count.size} versions remaining...."
       end
-    }
+    end
     puts "Finished updating versions"
   end
 

--- a/lib/tasks/one_off.rake
+++ b/lib/tasks/one_off.rake
@@ -118,9 +118,9 @@ namespace :one_off do
 
     puts "Updating #{versions.count.size} versions..."
 
-    versions.in_batches(of: 100).each_with_index do |batch, idx|
+    versions.in_batches(of: 1000).each_with_index do |batch, idx|
       batch.update_all("dependencies_count = (SELECT count(*) FROM dependencies WHERE dependencies.version_id = versions.id)")
-      if idx % 10 == 0
+      if idx % 100 == 0
         puts "#{versions.count.size} versions remaining...."
       end
     end

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -228,7 +228,6 @@ describe PackageManager::Pypi do
         expect(version.dependencies.count).to be 6
       end
 
-
       it "updates the dependencies counters" do
         expect(version.dependencies.count).to be 1
 
@@ -238,7 +237,7 @@ describe PackageManager::Pypi do
           end
         end
           .to change { version.reload.dependencies_count }.to(6)
-          .and change { version.runtime_dependencies_count}.to(4)
+          .and change { version.runtime_dependencies_count }.to(4)
       end
 
       it "leaves dependencies with force flag off" do

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -228,6 +228,19 @@ describe PackageManager::Pypi do
         expect(version.dependencies.count).to be 6
       end
 
+
+      it "updates the dependencies counters" do
+        expect(version.dependencies.count).to be 1
+
+        expect do
+          VCR.use_cassette("pypi_dependencies_requests") do
+            described_class.save_dependencies(mapped_project, sync_version: version_number, force_sync_dependencies: true)
+          end
+        end
+          .to change { version.reload.dependencies_count }.to(6)
+          .and change { version.runtime_dependencies_count}.to(4)
+      end
+
       it "leaves dependencies with force flag off" do
         expect(version.dependencies.count).to be 1
 

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -240,6 +240,15 @@ describe PackageManager::Pypi do
           .and change { version.runtime_dependencies_count }.to(4)
       end
 
+      it "updates the dependencies counters when there are zero deps" do
+        expect(PackageManager::Pypi).to receive(:dependencies).and_return([])
+        expect do
+          described_class.save_dependencies(mapped_project, sync_version: version_number, force_sync_dependencies: true)
+        end
+          .to change { version.reload.dependencies_count }.to(0)
+          .and change { version.runtime_dependencies_count }.to(0)
+      end
+
       it "leaves dependencies with force flag off" do
         expect(version.dependencies.count).to be 1
 

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -33,7 +33,7 @@ describe Version, type: :model do
 
   context "with dependencies" do
     let(:version) { create(:version) }
-    
+
     before do
       create(:dependency, version: version, requirements: "> 0", kind: "runtime")
       create(:dependency, version: version, requirements: "> 0", kind: "test")

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -30,4 +30,21 @@ describe Version, type: :model do
       expect(version.spdx_expression).to eq "NOASSERTION"
     end
   end
+
+  context "with dependencies" do
+    let(:version) { create(:version) }
+    
+    before do
+      create(:dependency, version: version, requirements: "> 0", kind: "runtime")
+      create(:dependency, version: version, requirements: "> 0", kind: "test")
+    end
+
+    it "can update its dependencies_count" do
+      expect { version.set_dependencies_count }.to change { version.dependencies_count }.to(2)
+    end
+
+    it "can update its runtime_dependencies_count" do
+      expect { version.set_runtime_dependencies_count }.to change { version.runtime_dependencies_count }.to(1)
+    end
+  end
 end

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -11,6 +11,9 @@ describe "Api::ProjectsController" do
   let!(:dependency) { create(:dependency, version: version, project: dependent_project) }
   let!(:internal_user) { create(:user) }
 
+  let!(:project_with_unknown_deps) { create(:project, name: "a-freshly-ingested-project") }
+  let!(:version_with_unknown_deps) { create(:version, project: project_with_unknown_deps, repository_sources: ["Rubygems"]) }
+
   before :each do
     internal_user.current_api_key.update_attribute(:is_internal, true)
     project.reload
@@ -79,6 +82,11 @@ describe "Api::ProjectsController" do
             platform: dependent_project.platform,
             name: dependent_project.name,
             updated_at: dependent_project.updated_at.utc.iso8601(3),
+          },
+          {
+            platform: project_with_unknown_deps.platform,
+            name: project_with_unknown_deps.name,
+            updated_at: project_with_unknown_deps.updated_at.utc.iso8601(3),
           },
         ],
         deleted: [],
@@ -254,6 +262,10 @@ describe "Api::ProjectsController" do
                # 404 on name
                { name: "noooooo",
                  platform: "rubygems" },
+               # deps haven't been saved yet
+               { name: project_with_unknown_deps.name,
+                 platform: project_with_unknown_deps.platform },
+
         ],
       }
       expect(response).to have_http_status(:success)
@@ -316,6 +328,13 @@ describe "Api::ProjectsController" do
             "name": "noooooo",
             "platform": "rubygems",
             "dependencies_for_version": "latest",
+          } },
+        { status: 200,
+          body: {
+            "name": project_with_unknown_deps.name,
+            "platform": project_with_unknown_deps.platform,
+            "dependencies_for_version": version_with_unknown_deps.number,
+            "dependencies": nil,
           } },
         ].to_json)
     end

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -147,6 +147,11 @@ describe "Api::ProjectsController" do
             name: dependent_project.name,
             updated_at: dependent_project.updated_at.utc.iso8601(3),
           },
+          {
+            platform: project_with_unknown_deps.platform,
+            name: project_with_unknown_deps.name,
+            updated_at: project_with_unknown_deps.updated_at.utc.iso8601(3),
+          },
         ],
         deleted: [
           {
@@ -334,7 +339,7 @@ describe "Api::ProjectsController" do
             "name": project_with_unknown_deps.name,
             "platform": project_with_unknown_deps.platform,
             "dependencies_for_version": version_with_unknown_deps.number,
-            "dependencies": nil,
+            "dependencies": [],
           } },
         ].to_json)
     end

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -11,9 +11,6 @@ describe "Api::ProjectsController" do
   let!(:dependency) { create(:dependency, version: version, project: dependent_project) }
   let!(:internal_user) { create(:user) }
 
-  let!(:project_with_unknown_deps) { create(:project, name: "a-freshly-ingested-project") }
-  let!(:version_with_unknown_deps) { create(:version, project: project_with_unknown_deps, repository_sources: ["Rubygems"]) }
-
   before :each do
     internal_user.current_api_key.update_attribute(:is_internal, true)
     project.reload
@@ -257,10 +254,6 @@ describe "Api::ProjectsController" do
                # 404 on name
                { name: "noooooo",
                  platform: "rubygems" },
-               # deps haven't been saved yet
-               { name: project_with_unknown_deps.name,
-                 platform: project_with_unknown_deps.platform },
-
         ],
       }
       expect(response).to have_http_status(:success)
@@ -323,13 +316,6 @@ describe "Api::ProjectsController" do
             "name": "noooooo",
             "platform": "rubygems",
             "dependencies_for_version": "latest",
-          } },
-        { status: 200,
-          body: {
-            "name": project_with_unknown_deps.name,
-            "platform": project_with_unknown_deps.platform,
-            "dependencies_for_version": version_with_unknown_deps.number,
-            "dependencies": nil,
           } },
         ].to_json)
     end

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -11,6 +11,9 @@ describe "Api::ProjectsController" do
   let!(:dependency) { create(:dependency, version: version, project: dependent_project) }
   let!(:internal_user) { create(:user) }
 
+  let!(:project_with_unknown_deps) { create(:project, name: "a-freshly-ingested-project") }
+  let!(:version_with_unknown_deps) { create(:version, project: project_with_unknown_deps, repository_sources: ["Rubygems"]) }
+
   before :each do
     internal_user.current_api_key.update_attribute(:is_internal, true)
     project.reload
@@ -254,6 +257,10 @@ describe "Api::ProjectsController" do
                # 404 on name
                { name: "noooooo",
                  platform: "rubygems" },
+               # deps haven't been saved yet
+               { name: project_with_unknown_deps.name,
+                 platform: project_with_unknown_deps.platform },
+
         ],
       }
       expect(response).to have_http_status(:success)
@@ -316,6 +323,13 @@ describe "Api::ProjectsController" do
             "name": "noooooo",
             "platform": "rubygems",
             "dependencies_for_version": "latest",
+          } },
+        { status: 200,
+          body: {
+            "name": project_with_unknown_deps.name,
+            "platform": project_with_unknown_deps.platform,
+            "dependencies_for_version": version_with_unknown_deps.number,
+            "dependencies": nil,
           } },
         ].to_json)
     end


### PR DESCRIPTION
we need a "have dependencies been fetched yet?" flag on the Version model. To that end:

* adds `Version#dependencies_count`, which will be `nil` if we haven't fetched its deps yet
  * (note that we have an existing `#runtime_dependencies_count` column)
* adds `Version#set_dependencies_count` method 
* call `Version#set_dependencies_count` after we've fetched a Version's dependencies (whether or not there are zero)
* adds `one_off:backfill_version_dependencies_count` task to backfill this column in batches