### PR TITLE
Api::Projects#dependencies_bulk: return "dependencies: nil" when deps haven't been fetched yet

### DIFF
--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -128,9 +128,8 @@ class Api::ProjectsController < Api::ApplicationController
 
     project_json = serializer.new(project).as_json
     project_json[:dependencies_for_version] = version.number
-    deps = version.dependencies.includes(:project)
     # nil means that we haven't fetched the deps yet, so check back later.
-    project_json[:dependencies] = deps.empty? ? nil : map_dependencies(deps)
+    project_json[:dependencies] = version.dependencies_count.nil? ? nil : map_dependencies(version.dependencies.includes(:project))
 
     project_json
   end

--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -128,7 +128,9 @@ class Api::ProjectsController < Api::ApplicationController
 
     project_json = serializer.new(project).as_json
     project_json[:dependencies_for_version] = version.number
-    project_json[:dependencies] = map_dependencies(version.dependencies.includes(:project) || [])
+    deps = version.dependencies.includes(:project)
+    # nil means that we haven't fetched the deps yet, so check back later.
+    project_json[:dependencies] = deps.empty? ? nil : map_dependencies(deps)
 
     project_json
   end

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -264,7 +264,7 @@ module PackageManager
       end
 
       db_versions.each do |db_version|
-        next if db_version.dependencies.any? && !force_sync_dependencies
+        next if !db_version.dependencies_count.nil? && !force_sync_dependencies
 
         deps = begin
           dependencies(name, db_version.number, mapped_project)

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -217,6 +217,8 @@ describe PackageManager::Pypi do
         }
       end
 
+      before { version.set_dependencies_count }
+
       it "overwrites dependencies with force flag on" do
         expect(version.dependencies.count).to be 1
 

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -339,7 +339,7 @@ describe "Api::ProjectsController" do
             "name": project_with_unknown_deps.name,
             "platform": project_with_unknown_deps.platform,
             "dependencies_for_version": version_with_unknown_deps.number,
-            "dependencies": [],
+            "dependencies": nil,
           } },
         ].to_json)
     end

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -18,6 +18,7 @@ describe "Api::ProjectsController" do
     internal_user.current_api_key.update_attribute(:is_internal, true)
     project.reload
     dependent_project.reload
+    version.set_dependencies_count
   end
 
   describe "GET /api/:platform/:name", type: :request do


### PR DESCRIPTION
when a release's dependencies haven't been fetched yet, return `dependencies: nil` instead of `dependencies: []`, as a signal that the client can try again later.

(followup to https://github.com/librariesio/libraries.io/pull/3255 )