### PR TITLE
Make the Project#set_dependents_count happen in an async callback

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -385,6 +385,7 @@ class Project < ApplicationRecord
   def set_dependents_count
     return if destroyed?
 
+    # TODO: more performant way to do this?
     new_dependents_count = ActiveRecord::Base.connection.with_statement_timeout(60.minutes.to_i) do
       dependents.joins(:version).pluck(Arel.sql("DISTINCT versions.project_id")).count
     end

--- a/app/workers/set_project_dependents_count_worker.rb
+++ b/app/workers/set_project_dependents_count_worker.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class SetProjectDependentsCountWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :small, lock: :until_executed
+
+  def perform(project_id)
+    Project.find_by_id(project_id).try(:set_dependents_count)
+  end
+end

--- a/spec/workers/set_project_dependents_count_worker_spec.rb
+++ b/spec/workers/set_project_dependents_count_worker_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe SetProjectDependentsCountWorker do
-  it "should use the snakk priority queue" do
+  it "should use the small priority queue" do
     is_expected.to be_processed_in :small
   end
 

--- a/spec/workers/set_project_dependents_count_worker_spec.rb
+++ b/spec/workers/set_project_dependents_count_worker_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe SetProjectDependentsCountWorker do
+  it "should use the snakk priority queue" do
+    is_expected.to be_processed_in :small
+  end
+
+  it "should update dependents count for a project" do
+    project = create(:project)
+    expect_any_instance_of(Project).to receive(:set_dependents_count)
+    subject.perform(project.id)
+  end
+end


### PR DESCRIPTION
this method can be pretty expensive, and doesn't make sense to do in an after_save callback.