### PR TITLE
fix: Squish down error message that may contain an entire webpage

### DIFF
--- a/app/models/repository_host/bitbucket.rb
+++ b/app/models/repository_host/bitbucket.rb
@@ -240,7 +240,7 @@ module RepositoryHost
       if error
         log_info.merge!(
           error_class: error.class,
-          error_message: error.message.to_s.gsub(/[\W]/, " ").squish[0..500]
+          error_message: error.message.to_s.gsub(/\W/, " ").squish[0..500]
         )
       end
 

--- a/app/models/repository_host/bitbucket.rb
+++ b/app/models/repository_host/bitbucket.rb
@@ -236,7 +236,13 @@ module RepositoryHost
         request_label: request,
         repository_full_name: repo_name,
       }
-      log_info.merge!(error_message: error.message, error_class: error.class) if error
+
+      if error
+        log_info.merge!(
+          error_class: error.class,
+          error_message: error.message.to_s.gsub(/[\W]/, " ").squish[0..500]
+        )
+      end
 
       StructuredLog.capture("EXTERNAL_REQUEST_FAILED", log_info)
     end


### PR DESCRIPTION
The bitbucket gem returns the response body as the error message, which may be a big blob of webpage source. This strips out non-word characters as a means to brute force sanitize it for the structured logging json.