### PR TITLE
Return [] instead of nil from Homebrew when deps don't match.

### DIFF
--- a/app/models/package_manager/homebrew.rb
+++ b/app/models/package_manager/homebrew.rb
@@ -53,7 +53,7 @@ module PackageManager
     end
 
     def self.dependencies(_name, version, mapped_project)
-      return nil unless version == mapped_project[:version]
+      return [] unless version == mapped_project[:version]
 
       mapped_project[:dependencies].map do |dependency|
         {


### PR DESCRIPTION
I think we always want to return an empty Array instead of nil here.