### PR TITLE
 Fix a "stack level too deep" bug with repository owner org updates.

### DIFF
--- a/app/models/repository_owner/bitbucket.rb
+++ b/app/models/repository_owner/bitbucket.rb
@@ -87,7 +87,7 @@ module RepositoryOwner
       user_by_login = RepositoryUser.host("Bitbucket").login(user_hash[:login]).first
       if user_by_id # its fine
         if user_by_id.login.try(:downcase) != user_hash[:login].downcase || user_by_id.user_type != user_hash[:type]
-          # If the login has changed, and the new login is taken, destroy the existing record (bc the accounts might have swapped). 
+          # If the login has changed, and the new login is taken, destroy the existing record (bc the accounts might have swapped).
           # If the user that used to have this login really exists, it should get re-synced in Repsitory#download_owner eventually.
           user_by_login.destroy if user_by_login && user_by_login != user_by_id
           user_by_id.login = user_hash[:login]
@@ -122,8 +122,10 @@ module RepositoryOwner
       org_by_id = RepositoryOrganisation.where(host_type: "Bitbucket").find_by_uuid(org_hash[:id])
       org_by_login = RepositoryOrganisation.host("Bitbucket").login(org_hash[:login]).first
       if org_by_id # its fine
-        unless org_by_id.login.try(:downcase) == org_hash[:login].downcase
-          org_by_login.destroy if org_by_login && !org_by_login.download_org_from_host
+        if org_by_id.login.try(:downcase) != org_hash[:login].downcase
+          # If the login has changed, and the new login is taken, destroy the existing record (bc the accounts might have swapped).
+          # If the org that used to have this login really exists, it should get re-synced in Repsitory#download_owner eventually.
+          org_by_login.destroy if org_by_login && org_by_login != org_by_id
           org_by_id.login = org_hash[:login]
           org_by_id.save!
         end

--- a/app/models/repository_owner/bitbucket.rb
+++ b/app/models/repository_owner/bitbucket.rb
@@ -87,6 +87,8 @@ module RepositoryOwner
       user_by_login = RepositoryUser.host("Bitbucket").login(user_hash[:login]).first
       if user_by_id # its fine
         if user_by_id.login.try(:downcase) != user_hash[:login].downcase || user_by_id.user_type != user_hash[:type]
+          # If the login has changed, and the new login is taken, destroy the existing record (bc the accounts might have swapped). 
+          # If the user that used to have this login really exists, it should get re-synced in Repsitory#download_owner eventually.
           user_by_login.destroy if user_by_login && user_by_login != user_by_id
           user_by_id.login = user_hash[:login]
           user_by_id.user_type = user_hash[:type]

--- a/app/models/repository_owner/github.rb
+++ b/app/models/repository_owner/github.rb
@@ -79,8 +79,10 @@ module RepositoryOwner
       org_by_id = RepositoryOrganisation.where(host_type: "GitHub").find_by_uuid(org_hash[:id])
       org_by_login = RepositoryOrganisation.host("GitHub").login(org_hash[:login]).first
       if org_by_id # its fine
-        unless org_by_id.login.try(:downcase) == org_hash[:login].downcase
-          org_by_login.destroy if org_by_login && !org_by_login.download_org_from_host
+        if org_by_id.login.try(:downcase) != org_hash[:login].downcase
+          # If the login has changed, and the new login is taken, destroy the existing record (bc the accounts might have swapped).
+          # If the user that used to have this login really exists, it should get re-synced in Repsitory#download_owner eventually.
+          org_by_login.destroy if org_by_login && org_by_login != org_by_id
           org_by_id.login = org_hash[:login]
           org_by_id.save!
         end

--- a/app/models/repository_owner/gitlab.rb
+++ b/app/models/repository_owner/gitlab.rb
@@ -108,6 +108,8 @@ module RepositoryOwner
       user_by_login = RepositoryUser.host("GitLab").login(user_hash[:login]).first
       if user_by_id # its fine
         if user_by_id.login.try(:downcase) != user_hash[:login].downcase || user_by_id.user_type != user_hash[:type]
+          # If the login has changed, and the new login is taken, destroy the existing record (bc the accounts might have swapped). 
+          # If the user that used to have this login really exists, it should get re-synced in Repsitory#download_owner eventually.
           user_by_login.destroy if user_by_login && user_by_login != user_by_id
           user_by_id.login = user_hash[:login]
           user_by_id.user_type = user_hash[:type]

--- a/app/models/repository_owner/gitlab.rb
+++ b/app/models/repository_owner/gitlab.rb
@@ -108,7 +108,7 @@ module RepositoryOwner
       user_by_login = RepositoryUser.host("GitLab").login(user_hash[:login]).first
       if user_by_id # its fine
         if user_by_id.login.try(:downcase) != user_hash[:login].downcase || user_by_id.user_type != user_hash[:type]
-          # If the login has changed, and the new login is taken, destroy the existing record (bc the accounts might have swapped). 
+          # If the login has changed, and the new login is taken, destroy the existing record (bc the accounts might have swapped).
           # If the user that used to have this login really exists, it should get re-synced in Repsitory#download_owner eventually.
           user_by_login.destroy if user_by_login && user_by_login != user_by_id
           user_by_id.login = user_hash[:login]
@@ -144,8 +144,10 @@ module RepositoryOwner
       org_by_id = RepositoryOrganisation.where(host_type: "GitLab").find_by_uuid(org_hash[:id])
       org_by_login = RepositoryOrganisation.host("GitLab").login(org_hash[:login]).first
       if org_by_id # its fine
-        unless org_by_id.login.try(:downcase) == org_hash[:login].downcase
-          org_by_login.destroy if org_by_login && !org_by_login.download_org_from_host
+        if org_by_id.login.try(:downcase) != org_hash[:login].downcase
+          # If the login has changed, and the new login is taken, destroy the existing record (bc the accounts might have swapped).
+          # If the org that used to have this login really exists, it should get re-synced in Repsitory#download_owner eventually.
+          org_by_login.destroy if org_by_login && org_by_login != org_by_id
           org_by_id.login = org_hash[:login]
           org_by_id.save!
         end


### PR DESCRIPTION
fixes bugsnag 65527440cf4e030007888c55

this is the same fix as in https://github.com/librariesio/libraries.io/pull/3271 , but for RepositoryOrganisations instead of RepositoryUsers.

I found a case with an org that had moved their login to a new account, and the old account got a new login. After this fix, the account with the stale login should be deleted, which would then get re-added by Repository#download_owner at some point. These records haven't been updated in 5 years, so fixing them like this is better than having the stale data around.
