### PR TITLE
Remove unnecessary/broken validations on Repository{User,Organisation}

### DIFF
--- a/app/models/repository_organisation.rb
+++ b/app/models/repository_organisation.rb
@@ -41,8 +41,6 @@ class RepositoryOrganisation < ApplicationRecord
   RepositoryOwner::Gitlab # rubocop: disable Lint/Void
 
   validates :uuid, presence: true
-  validate :login_uniqueness_with_case_insensitive_host, if: -> { login_changed? }
-  validates :uuid, uniqueness: { scope: :host_type }, if: -> { uuid_changed? }
 
   after_commit :async_sync, on: :create
 
@@ -58,10 +56,6 @@ class RepositoryOrganisation < ApplicationRecord
            :to_s, :to_param, :github_id, :download_org_from_host, :download_orgs,
            :download_org_from_host_by_login, :download_repos, :download_members,
            :check_status, to: :repository_owner
-
-  def login_uniqueness_with_case_insensitive_host
-    errors.add(:login, "must be unique") if RepositoryOrganisation.host(host_type).login(login).exists?
-  end
 
   def repository_owner
     @repository_owner ||= RepositoryOwner.const_get(host_type.capitalize).new(self)

--- a/app/models/repository_user.rb
+++ b/app/models/repository_user.rb
@@ -48,8 +48,6 @@ class RepositoryUser < ApplicationRecord
   # eager load this module to avoid clashing with Gitlab gem in development
   RepositoryOwner::Gitlab # rubocop: disable Lint/Void
 
-  validate :login_uniqueness_with_case_insensitive_host, if: -> { login_changed? }
-  validates :uuid, uniqueness: { scope: :host_type }, if: -> { uuid_changed? }
   validates :uuid, presence: true
 
   after_commit :async_sync, on: :create
@@ -62,10 +60,6 @@ class RepositoryUser < ApplicationRecord
   delegate :avatar_url, :repository_url, :top_favourite_projects, :top_contributors,
            :to_s, :to_param, :github_id, :download_user_from_host, :download_orgs,
            :download_user_from_host_by_login, :download_repos, :check_status, to: :repository_owner
-
-  def login_uniqueness_with_case_insensitive_host
-    errors.add(:login, "must be unique") if RepositoryUser.host(host_type).login(login).exists?
-  end
 
   def repository_owner
     @repository_owner ||= RepositoryOwner.const_get(host_type.capitalize).new(self)


### PR DESCRIPTION
this removes 4 uniqueness validations on RepositoryUser and RepositoryOrganisation. The two "host_type/login" validations were broken because they don't work for the case where a login changes case (e.g. "FOO" -> "foo"). Another reason is that unique indices already exist for these column pairs (uuid/host_type) (lower(host_type)/lower(login)), so we don't need extra ruby logic to handle these.

fixes bugsnag 656e06f8feff8200073ef0cd