### PR TITLE
Version: replace most in-Ruby sorting

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -200,7 +200,7 @@ class ApplicationController < ActionController::Base
       end
       raise ActiveRecord::RecordNotFound if @tags.empty? && params[:number].present?
     else
-      @versions = @project.versions.order(number: :desc).limit(10)
+      @versions = @project.versions.order(published_at: :desc).limit(10)
       if params[:number].present?
         @version = @project.versions.find_by_number(params[:number])
         raise ActiveRecord::RecordNotFound if @version.nil?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -200,7 +200,7 @@ class ApplicationController < ActionController::Base
       end
       raise ActiveRecord::RecordNotFound if @tags.empty? && params[:number].present?
     else
-      @versions = @project.versions.sort.first(10)
+      @versions = @project.versions.order(number: :desc).limit(10)
       if params[:number].present?
         @version = @project.versions.find_by_number(params[:number])
         raise ActiveRecord::RecordNotFound if @version.nil?

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -82,7 +82,7 @@ class ProjectsController < ApplicationController
     if incorrect_case?
       redirect_to(project_versions_path(@project.to_param), status: :moved_permanently)
     else
-      @versions = @project.versions.sort.paginate(page: page_number)
+      @versions = @project.versions.order(number: :desc).paginate(page: page_number)
       respond_to do |format|
         format.html
         format.atom

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -82,7 +82,7 @@ class ProjectsController < ApplicationController
     if incorrect_case?
       redirect_to(project_versions_path(@project.to_param), status: :moved_permanently)
     else
-      @versions = @project.versions.order(number: :desc).paginate(page: page_number)
+      @versions = @project.versions.order(published_at: :desc).paginate(page: page_number)
       respond_to do |format|
         format.html
         format.atom

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -21,6 +21,7 @@
 # Indexes
 #
 #  index_versions_on_project_id_and_number  (project_id,number) UNIQUE
+#  index_versions_on_published_at           (published_at)
 #  index_versions_on_updated_at             (updated_at)
 #
 class Version < ApplicationRecord

--- a/app/views/projects/_releases.html.erb
+++ b/app/views/projects/_releases.html.erb
@@ -16,7 +16,7 @@
               <%= fa_icon('tag') %>
             <% end %>
           </small>
-          <% if version.previous_version %>
+          <% if @version_count < 1000 && version.previous_version %>
             <small class='text-muted'>
               <%= link_to version.diff_url, class: 'tip', title: "View diff between #{version} and #{version.previous_version}" do %>
                 <span><%= fa_icon('random') %></span>

--- a/app/views/projects/versions.html.erb
+++ b/app/views/projects/versions.html.erb
@@ -31,7 +31,7 @@
             </small>
           </td>
           <td>
-            <% if version.previous_version %>
+            <% if @versions.count < 1000 && version.previous_version %>
               <small class='text-muted'>
                 <%= link_to version.diff_url do %>
                   <%= fa_icon('random') %>

--- a/db/migrate/20231213145217_add_published_at_index_to_versions.rb
+++ b/db/migrate/20231213145217_add_published_at_index_to_versions.rb
@@ -4,6 +4,6 @@ class AddPublishedAtIndexToVersions < ActiveRecord::Migration[7.0]
   disable_ddl_transaction!
 
   def change
-    add_index :versions, :published_at, algorithm: :concurrently
+    add_index :versions, :published_at, algorithm: :concurrently, if_not_exists: true
   end
 end

--- a/db/migrate/20231213145217_add_published_at_index_to_versions.rb
+++ b/db/migrate/20231213145217_add_published_at_index_to_versions.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddPublishedAtIndexToVersions < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :versions, :published_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_16_161641) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_13_145217) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -410,6 +410,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_16_161641) do
     t.string "status"
     t.integer "dependencies_count"
     t.index ["project_id", "number"], name: "index_versions_on_project_id_and_number", unique: true
+    t.index ["published_at"], name: "index_versions_on_published_at"
     t.index ["updated_at"], name: "index_versions_on_updated_at"
   end
 

--- a/spec/tasks/one_off_spec.rb
+++ b/spec/tasks/one_off_spec.rb
@@ -101,8 +101,11 @@ describe "one_off" do
         let(:ignored_source_version) { create(:version, project: project, number: "4.0.0", repository_sources: ["Other"]) }
 
         it "deletes ignored versions but not other versions" do
-          expect { Rake::Task["one_off:delete_ignored_maven_versions_and_resync_packages"].invoke("", "yes") }
-            .to change(Version, :all).from([maven_source_version, google_source_version, no_source_version, ignored_source_version]).to([maven_source_version, google_source_version])
+          expect(Version.all).to match_array([maven_source_version, google_source_version, no_source_version, ignored_source_version])
+
+          Rake::Task["one_off:delete_ignored_maven_versions_and_resync_packages"].invoke("", "yes")
+
+          expect(Version.all).to match_array([maven_source_version, google_source_version])
         end
       end
 


### PR DESCRIPTION
Some projects with many versions (several thousand) will take quite a while to render the `Project` show page. Sort `Versions` by `number` in SQL where possible. Limit the semver diff behavior on number of `Versions`.