### PR TITLE
Disable single version updates for NPM

### DIFF
--- a/app/models/package_manager/npm.rb
+++ b/app/models/package_manager/npm.rb
@@ -9,7 +9,7 @@ module PackageManager
     URL = "https://www.npmjs.com"
     COLOR = "#f1e05a"
     ENTIRE_PACKAGE_CAN_BE_DEPRECATED = true
-    SUPPORTS_SINGLE_VERSION_UPDATE = true
+    SUPPORTS_SINGLE_VERSION_UPDATE = false
 
     def self.missing_version_remover
       PackageManager::Base::MissingVersionRemover

--- a/spec/workers/package_manager_download_worker_spec.rb
+++ b/spec/workers/package_manager_download_worker_spec.rb
@@ -35,13 +35,20 @@ describe PackageManagerDownloadWorker do
     subject.perform("maven_atlassian", "github.com/hi/ima.package", "1.2.3")
   end
 
-  it "should raise an error if version didn't get created after 15 attempts" do
-    expect(PackageManagerDownloadWorker).to_not receive(:perform_in)
-    expect(PackageManager::NPM).to receive(:update).with("a-package", sync_version: "1.2.3", force_sync_dependencies: false)
-    expect(Rails.logger).to receive(:info).with(a_string_matching("Package update"))
-    expect(Rails.logger).to receive(:info).with("[Version Update Failure] platform=npm name=a-package version=1.2.3")
+  context "when the package manager supports single versions updates" do
+    # remove the stub once the NPM::SUPPORTS_SINGLE_VERSION_UPDATE gets sets back to true
+    before do
+      stub_const("PackageManager::NPM::SUPPORTS_SINGLE_VERSION_UPDATE", true)
+    end
 
-    expect { subject.perform("npm", "a-package", "1.2.3", nil, 16) }.to raise_exception(PackageManagerDownloadWorker::VersionUpdateFailure)
+    it "should raise an error if version didn't get created after 15 attempts" do
+      expect(PackageManagerDownloadWorker).to_not receive(:perform_in)
+      expect(PackageManager::NPM).to receive(:update).with("a-package", sync_version: "1.2.3", force_sync_dependencies: false)
+      expect(Rails.logger).to receive(:info).with(a_string_matching("Package update"))
+      expect(Rails.logger).to receive(:info).with("[Version Update Failure] platform=npm name=a-package version=1.2.3")
+
+      expect { subject.perform("npm", "a-package", "1.2.3", nil, 16) }.to raise_exception(PackageManagerDownloadWorker::VersionUpdateFailure)
+    end
   end
 
   it "should not raise an error if version didn't get created after 15 attempts and is golang" do


### PR DESCRIPTION
NPM is currently unreliable in its update publishing: https://github.com/npm/feedback/discussions/937 The updates are coming in out of order, which is throwing off single version updates.

In order to increase its reliability, we are disabling per-version updates for NPM until the update issues affecting the CouchDB feed are resolved.

It looks like the main entrypoint to this is the PackageManagerDownloadWorker, so I'll monitor that when this change goes out. If there's any other places to watch, let me know and I can keep an eye out. 