### PR TITLE
Fix up error when cargo is pointing ot a bogus version

### DIFF
--- a/app/models/package_manager/cargo.rb
+++ b/app/models/package_manager/cargo.rb
@@ -42,6 +42,13 @@ module PackageManager
       version = raw_project.dig("crate", "newest_version")
       url = download_url(db_project, version)
       body = get_raw(url)
+      if body.empty? # if we can't fetch it, we can't say if it is deprecated or not but default false
+        return {
+          is_deprecated: false,
+          message: nil,
+        }
+      end
+
       tar_extract = Gem::Package::TarReader.new(Zlib::GzipReader.new(StringIO.new(body)))
       tar_extract.rewind
       toml = tar_extract.find { |entry| entry.full_name.end_with?("/Cargo.toml") }.read


### PR DESCRIPTION
If the version doesn't actually exist, we get no body and it's throwing an error. Just assume the best case

(accidentally pushed straight to main but let's go ahead and review before deploying)