### PR TITLE
More Consistent Maintenance Stat Collection

### DIFF
--- a/app/models/maintenance_stats/queries/github/commit_count_query.rb
+++ b/app/models/maintenance_stats/queries/github/commit_count_query.rb
@@ -57,7 +57,10 @@ module MaintenanceStats
           # merge params for query
           date_params.merge!(params.slice(:owner, :repo_name))
 
-          @client.query(COMMIT_COUNTS_QUERY, variables: date_params)
+          results = @client.query(COMMIT_COUNTS_QUERY, variables: date_params)
+          QueryUtils.check_for_graphql_errors(results)
+
+          results
         end
       end
 

--- a/app/models/maintenance_stats/queries/github/issues_query.rb
+++ b/app/models/maintenance_stats/queries/github/issues_query.rb
@@ -38,7 +38,10 @@ module MaintenanceStats
           params[:open_pr_query] = "repo:#{params[:owner]}/#{params[:repo_name]} is:pr is:open created:>#{params[:one_year].to_date}"
           params[:closed_pr_query] = "repo:#{params[:owner]}/#{params[:repo_name]} is:pr is:closed created:>#{params[:one_year].to_date}"
 
-          @client.query(ISSUES_QUERY, variables: params)
+          results = @client.query(ISSUES_QUERY, variables: params)
+          QueryUtils.check_for_graphql_errors(results)
+
+          results
         end
       end
     end

--- a/app/models/maintenance_stats/queries/github/repo_releases_query.rb
+++ b/app/models/maintenance_stats/queries/github/repo_releases_query.rb
@@ -44,8 +44,7 @@ module MaintenanceStats
             params[:cursor] = cursor if cursor.present?
             result = @client.query(RELEASES_QUERY, variables: params)
 
-            # send back the releases we have so far if we encounter an error
-            return releases if check_for_errors(result)
+            QueryUtils.check_for_graphql_errors(result)
 
             has_next_page = result.data.repository.releases.page_info.has_next_page
             cursor = result.data.repository.releases.page_info.end_cursor
@@ -65,12 +64,6 @@ module MaintenanceStats
           end
 
           releases
-        end
-
-        private
-
-        def check_for_errors(result)
-          result.data.nil? || result.errors.any? || result.data.errors.any?
         end
       end
     end

--- a/app/models/maintenance_stats/queries/query_utils.rb
+++ b/app/models/maintenance_stats/queries/query_utils.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module MaintenanceStats
+  module Queries
+    class QueryError < StandardError; end
+
+    class QueryUtils
+      def self.check_for_graphql_errors(result)
+        if result.data.nil?
+          raise QueryError, "No data found in result"
+        end
+
+        if result.errors.any?
+          error_messages = result.errors.values.flatten
+          raise QueryError, "Error exists in query: #{error_messages}"
+        end
+
+        if result.data.errors.any?
+          error_messages = result.data.errors.values.flatten
+          raise QueryError, "Error exists in result: #{error_messages}"
+        end
+      end
+    end
+  end
+end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -4,50 +4,51 @@
 #
 # Table name: repositories
 #
-#  id                         :integer          not null, primary key
-#  contributions_count        :integer          default(0), not null
-#  default_branch             :string
-#  description                :string
-#  fork                       :boolean
-#  fork_policy                :string
-#  forks_count                :integer
-#  full_name                  :string
-#  has_audit                  :string
-#  has_changelog              :string
-#  has_coc                    :string
-#  has_contributing           :string
-#  has_issues                 :boolean
-#  has_license                :string
-#  has_pages                  :boolean
-#  has_readme                 :string
-#  has_threat_model           :string
-#  has_wiki                   :boolean
-#  homepage                   :string
-#  host_domain                :string
-#  host_type                  :string
-#  keywords                   :string           default([]), is an Array
-#  language                   :string
-#  last_synced_at             :datetime
-#  license                    :string
-#  logo_url                   :string
-#  mirror_url                 :string
-#  name                       :string
-#  open_issues_count          :integer
-#  private                    :boolean
-#  pull_requests_enabled      :string
-#  pushed_at                  :datetime
-#  rank                       :integer
-#  scm                        :string
-#  size                       :integer
-#  source_name                :string
-#  stargazers_count           :integer
-#  status                     :string
-#  subscribers_count          :integer
-#  uuid                       :string
-#  created_at                 :datetime         not null
-#  updated_at                 :datetime         not null
-#  repository_organisation_id :integer
-#  repository_user_id         :integer
+#  id                             :integer          not null, primary key
+#  contributions_count            :integer          default(0), not null
+#  default_branch                 :string
+#  description                    :string
+#  fork                           :boolean
+#  fork_policy                    :string
+#  forks_count                    :integer
+#  full_name                      :string
+#  has_audit                      :string
+#  has_changelog                  :string
+#  has_coc                        :string
+#  has_contributing               :string
+#  has_issues                     :boolean
+#  has_license                    :string
+#  has_pages                      :boolean
+#  has_readme                     :string
+#  has_threat_model               :string
+#  has_wiki                       :boolean
+#  homepage                       :string
+#  host_domain                    :string
+#  host_type                      :string
+#  keywords                       :string           default([]), is an Array
+#  language                       :string
+#  last_synced_at                 :datetime
+#  license                        :string
+#  logo_url                       :string
+#  maintenance_stats_refreshed_at :datetime
+#  mirror_url                     :string
+#  name                           :string
+#  open_issues_count              :integer
+#  private                        :boolean
+#  pull_requests_enabled          :string
+#  pushed_at                      :datetime
+#  rank                           :integer
+#  scm                            :string
+#  size                           :integer
+#  source_name                    :string
+#  stargazers_count               :integer
+#  status                         :string
+#  subscribers_count              :integer
+#  uuid                           :string
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#  repository_organisation_id     :integer
+#  repository_user_id             :integer
 #
 # Indexes
 #
@@ -55,6 +56,7 @@
 #  index_repositories_on_fork                              (fork)
 #  index_repositories_on_host_type_and_uuid                (host_type,uuid) UNIQUE
 #  index_repositories_on_lower_host_type_lower_full_name   (lower((host_type)::text), lower((full_name)::text)) UNIQUE
+#  index_repositories_on_maintenance_stats_refreshed_at    (maintenance_stats_refreshed_at)
 #  index_repositories_on_private                           (private)
 #  index_repositories_on_rank_and_stargazers_count_and_id  (rank,stargazers_count,id)
 #  index_repositories_on_repository_organisation_id        (repository_organisation_id)

--- a/app/models/repository_host/github.rb
+++ b/app/models/repository_host/github.rb
@@ -232,17 +232,13 @@ module RepositoryHost
       metrics << MaintenanceStats::Stats::Github::ReleaseStats.new(result).fetch_stats
 
       result = MaintenanceStats::Queries::Github::CommitCountQuery.new(v4_client).query(params: { owner: repository.owner_name, repo_name: repository.project_name, start_date: now })
-      metrics << MaintenanceStats::Stats::Github::CommitsStat.new(result).fetch_stats unless check_for_v4_error_response(result)
+      metrics << MaintenanceStats::Stats::Github::CommitsStat.new(result).fetch_stats
 
-      begin
-        result = MaintenanceStats::Queries::Github::RepositoryContributorStatsQuery.new(v3_client).query(params: { full_name: repository.full_name })
-        metrics << MaintenanceStats::Stats::Github::V3ContributorCountStats.new(result).fetch_stats
-      rescue Octokit::Error => e
-        Rails.logger.warn(e.message)
-      end
+      result = MaintenanceStats::Queries::Github::RepositoryContributorStatsQuery.new(v3_client).query(params: { full_name: repository.full_name })
+      metrics << MaintenanceStats::Stats::Github::V3ContributorCountStats.new(result).fetch_stats
 
       result = MaintenanceStats::Queries::Github::IssuesQuery.new(v4_client).query(params: { owner: repository.owner_name, repo_name: repository.project_name, start_date: now })
-      metrics << MaintenanceStats::Stats::Github::IssueStats.new(result).fetch_stats unless check_for_v4_error_response(result)
+      metrics << MaintenanceStats::Stats::Github::IssueStats.new(result).fetch_stats
 
       add_metrics_to_repo(metrics)
 
@@ -253,14 +249,6 @@ module RepositoryHost
 
     def api_client(token = nil)
       AuthToken.fallback_client(token)
-    end
-
-    def check_for_v4_error_response(response)
-      # errors can be stored in the response from Github or can be stored in the response object from HTTP errors
-      response.errors.messages.each(&Rails.logger.method(:warn)) if response.errors.present?
-      response.data.errors.messages.each(&Rails.logger.method(:warn)) if response.data&.errors.present?
-      # if we have either type of error or there is no data return true
-      response.data.nil? || response.errors.any? || response.data.errors.any?
     end
   end
 end

--- a/app/models/repository_host/github.rb
+++ b/app/models/repository_host/github.rb
@@ -226,6 +226,11 @@ module RepositoryHost
       v3_client = AuthToken.client({ auto_paginate: false })
       now = DateTime.current
 
+      # We have a valid token to run the queries so
+      # set refreshed_at time so we don't try and refresh
+      # this repository again if the information is bad
+      repository.update!(maintenance_stats_refreshed_at: now)
+
       metrics = []
 
       result = MaintenanceStats::Queries::Github::RepoReleasesQuery.new(v4_client).query(params: { owner: repository.owner_name, repo_name: repository.project_name, end_date: now - 1.year })

--- a/db/migrate/20240104185219_add_maintenance_stats_refreshed_at_to_repository.rb
+++ b/db/migrate/20240104185219_add_maintenance_stats_refreshed_at_to_repository.rb
@@ -1,0 +1,8 @@
+class AddMaintenanceStatsRefreshedAtToRepository < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_column :repositories, :maintenance_stats_refreshed_at, :datetime, if_not_exists: true
+    add_index :repositories, :maintenance_stats_refreshed_at, algorithm: :concurrently, if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_13_145217) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_04_185219) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -257,9 +257,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_13_145217) do
     t.integer "repository_user_id"
     t.string "keywords", default: [], array: true
     t.index "lower((host_type)::text), lower((full_name)::text)", name: "index_repositories_on_lower_host_type_lower_full_name", unique: true
+    t.datetime "maintenance_stats_refreshed_at"
     t.index "lower((language)::text)", name: "github_repositories_lower_language"
     t.index ["fork"], name: "index_repositories_on_fork"
     t.index ["host_type", "uuid"], name: "index_repositories_on_host_type_and_uuid", unique: true
+    t.index ["maintenance_stats_refreshed_at"], name: "index_repositories_on_maintenance_stats_refreshed_at"
     t.index ["private"], name: "index_repositories_on_private"
     t.index ["rank", "stargazers_count", "id"], name: "index_repositories_on_rank_and_stargazers_count_and_id"
     t.index ["repository_organisation_id"], name: "index_repositories_on_repository_organisation_id"

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -252,9 +252,9 @@ describe Repository, type: :model do
     context "with invalid repository" do
       let(:repository) { create(:repository, full_name: "bad/example-for-testing") }
 
-      it "should save metrics for repository" do
+      it "should not save metrics for repository" do
         VCR.use_cassette("github/bad_repository", match_requests_on: %i[method uri body query]) do
-          repository.gather_maintenance_stats
+          expect { repository.gather_maintenance_stats }.to raise_error(MaintenanceStats::Queries::QueryError)
         end
 
         maintenance_stats = repository.repository_maintenance_stats

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -227,6 +227,7 @@ describe Repository, type: :model do
 
       it "should save metrics for repository" do
         maintenance_stats = repository.repository_maintenance_stats
+        expect(repository.maintenance_stats_refreshed_at).to_not be_nil
         expect(maintenance_stats.count).to be > 0
 
         maintenance_stats.each do |stat|
@@ -259,6 +260,8 @@ describe Repository, type: :model do
 
         maintenance_stats = repository.repository_maintenance_stats
         expect(maintenance_stats.count).to be 0
+        # we should update the refreshed_at time even with a query error
+        expect(repository.maintenance_stats_refreshed_at).not_to be_nil
       end
     end
 
@@ -294,6 +297,7 @@ describe Repository, type: :model do
 
         maintenance_stats = repository.repository_maintenance_stats
         expect(maintenance_stats.count).to be 0
+        expect(repository.maintenance_stats_refreshed_at).to be_nil
       end
     end
   end

--- a/spec/requests/api/repositories_spec.rb
+++ b/spec/requests/api/repositories_spec.rb
@@ -16,7 +16,7 @@ describe "Api::RepositoriesController" do
       get "/api/github/#{repository.full_name}/dependencies"
       expect(response).to have_http_status(:success)
       expect(response.content_type).to start_with("application/json")
-      expect(json.to_json).to be_json_eql repository.as_json({ except: %i[id repository_organisation_id repository_user_id], methods: %i[github_contributions_count github_id] }).merge(dependencies: []).to_json
+      expect(json.to_json).to be_json_eql repository.as_json({ except: %i[id maintenance_stats_refreshed_at repository_organisation_id repository_user_id], methods: %i[github_contributions_count github_id] }).merge(dependencies: []).to_json
     end
   end
 
@@ -36,7 +36,7 @@ describe "Api::RepositoriesController" do
       expect(response.content_type).to start_with("application/json")
       expect(json.to_json).to be_json_eql(
         repository.to_json({
-                             except: %i[id repository_organisation_id repository_user_id],
+                             except: %i[id maintenance_stats_refreshed_at repository_organisation_id repository_user_id],
                              methods: %i[github_contributions_count github_id],
                            })
       ).excluding("maintenance_stats") # exclude maintenance stats since those are not included in the serializer

--- a/spec/requests/api/repository_users_spec.rb
+++ b/spec/requests/api/repository_users_spec.rb
@@ -22,7 +22,7 @@ describe "Api::RepositoryUsersController" do
       get "/api/github/#{@user.login}/repositories"
       expect(response).to have_http_status(:success)
       expect(response.content_type).to start_with("application/json")
-      expect(response.body).to be_json_eql [repo.as_json({ except: %i[id repository_organisation_id repository_user_id], methods: %i[github_contributions_count github_id] })].to_json
+      expect(response.body).to be_json_eql [repo.as_json({ except: %i[id maintenance_stats_refreshed_at repository_organisation_id repository_user_id], methods: %i[github_contributions_count github_id] })].to_json
     end
   end
 


### PR DESCRIPTION
This PR does a few things:

* Raises an error when errors occur during stat collection instead of catching the errors and just ignoring those stats. This should make the stats more consistent and avoid the issue where one stat was collected while others are still their old data. This should also help notify us about issues gathering stats.

* Creates a `maintenance_stats_refreshed_at` column to track when we last attempted to do a refresh. This should help us avoid querying for the same repositories over and over if we cannot get stats for them. This still needs a follow up PR to use that column for queuing work. I will also likely need to manually run the database migration which is why it has `if_not_exists: true` on the add_column and add_index commands.

* One off rake task to get the dates set for repositories that have existing stats. I will need to run this manually for the 120k repositories that have stats now.