### PR TITLE
Use Repository Refresh Date for Scheduling Stat Refresh

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -123,8 +123,10 @@ class Project < ApplicationRecord
   has_many :repository_maintenance_stats, through: :repository
 
   scope :updated_within, ->(start, stop) { where("updated_at >= ? and updated_at <= ? ", start, stop).order(updated_at: :asc) }
-  scope :least_recently_updated_stats, -> { joins(repository: :repository_maintenance_stats).where(repositories: { host_type: "GitHub" }).group("projects.id").order(Arel.sql("max(repository_maintenance_stats.updated_at) ASC")) }
-  scope :no_existing_stats, -> { where.missing(:repository_maintenance_stats).where(repositories: { host_type: "GitHub" }) }
+  # restrict to only GitHub repositories where we have attempted to refresh the stats previously
+  scope :least_recently_updated_stats, -> { joins(:repository).where(repositories: { host_type: "GitHub" }).where.not(repositories: { maintenance_stats_refreshed_at: nil }).merge(Repository.order(maintenance_stats_refreshed_at: :asc)) }
+  # restrict to only GitHub repositories that have no existing stats and have never attempted to be refreshed
+  scope :no_existing_stats, -> { where.missing(:repository_maintenance_stats).where(repositories: { host_type: "GitHub", maintenance_stats_refreshed_at: nil }) }
 
   scope :platform, ->(platforms) { where(platform: Array.wrap(platforms).map { |platform| PackageManager::Base.format_name(platform) }) }
   scope :lower_platform, ->(platform) { where("lower(projects.platform) = ?", platform.try(:downcase)) }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -132,37 +132,47 @@ describe Project, type: :model do
         results = Project.no_existing_stats.where(id: project.id)
         expect(results.count).to eql 1
       end
+
+      context "with refreshed at date" do
+        let!(:repository) { create(:repository, maintenance_stats_refreshed_at: Time.current) }
+
+        it "should not be included in no_existing_stats query" do
+          # if the repository has a refreshed_at date but no stats that means
+          # there was a problem getting stats and should not be considered for
+          # the no_existing_stats query
+          results = Project.no_existing_stats.where(id: project.id)
+          expect(results.count).to eql 0
+        end
+      end
     end
 
     context "with stats" do
       let!(:stat1) { create(:repository_maintenance_stat, repository: repository) }
 
+      context "with refreshed at date" do
+        let!(:repository) { create(:repository, maintenance_stats_refreshed_at: Time.current) }
+
+        it "should show up in least_recently_updated_stats query" do
+          results = Project.least_recently_updated_stats.where(id: project.id)
+
+          expect(results.count).to eql 1
+        end
+      end
+
       it "should not be in no_existing_stats query" do
         results = Project.no_existing_stats.where(id: project.id)
         expect(results.count).to eql 0
       end
-
-      it "should show up in least_recently_updated_stats query" do
-        results = Project.least_recently_updated_stats.where(id: project.id)
-        # count will return a hash
-        # the key is the grouped column which is the project id
-        # the value is the count for that project id
-        expect(results.count.key?(project.id)).to be true
-        expect(results.count[project.id]).to eql 1
-      end
     end
 
     context "two projects with stats" do
+      let!(:repository) { create(:repository, maintenance_stats_refreshed_at: 1.day.ago) }
       let!(:stat1) { create(:repository_maintenance_stat, repository: repository) }
-      let!(:repository2) { create(:repository, full_name: "octokit/octokit") }
+      let!(:repository2) { create(:repository, full_name: "octokit/octokit", maintenance_stats_refreshed_at: 1.year.ago) }
       let!(:project2) { create(:project, repository: repository2) }
       let!(:stat2) { create(:repository_maintenance_stat, repository: repository2) }
 
-      before do
-        stat2.update_column(:updated_at, Date.today - 1.month)
-      end
-
-      it "should return project with oldest stats first" do
+      it "should return project with oldest refreshed at date first" do
         results = Project.least_recently_updated_stats
         expect(results.first.id).to eql project2.id
       end


### PR DESCRIPTION
Updated the Project scopes to find Projects with the oldest stats that should be refreshed. This value is updated during the stat refresh so we can avoid always selecting repositories that no longer exist on GitHub every time.