### PR TITLE
Fix Go's check_status_url and only mark "Removed" if it's pre-existing.

### DIFF
--- a/app/models/package_manager/go.rb
+++ b/app/models/package_manager/go.rb
@@ -31,7 +31,7 @@ module PackageManager
     end
 
     def self.check_status_url(db_project)
-      "#{PROXY_BASE_URL}/#{encode_for_proxy(db_project.name)}/@v/list"
+      "#{DISCOVER_URL}/#{db_project.name}"
     end
 
     def self.package_link(db_project, version = nil)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -633,6 +633,10 @@ class Project < ApplicationRecord
     response = Typhoeus.get(url)
     if platform.downcase == "packagist" && [302, 404].include?(response.response_code)
       update_attribute(:status, "Removed")
+    elsif platform.downcase == "go" && [404].include?(response.response_code)
+      # pkg.go.dev can be 404 on first-hit for a new package (or alias for the package), so ensure that the package existed in the past
+      # by ensuring its age is old enough to not be just uncached by pkg.go.dev yet.
+      update_attribute(:status, "Removed") if created_at < 1.week.ago
     elsif platform.downcase != "packagist" && [400, 404, 410].include?(response.response_code)
       update_attribute(:status, "Removed")
     elsif can_have_entire_package_deprecated?


### PR DESCRIPTION
currently a pre-existing Go Project that was removed will not be marked as "Removed" because we're checking the Go index API, which returns a 200 but wouldn't return any versions. Since [we've already decided to only store Go Modules that are on pkg.go.dev](https://github.com/librariesio/libraries.io/blob/134010e61aefb0a91df8f525d0f3e07efca4de13/app/models/package_manager/go.rb#L124-L125), this changes the status url from the API to pkg.go.dev, which returns 404 for non-existent Go Modules.