### PR TITLE
Support 400 for missing Go packages too.

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -633,7 +633,7 @@ class Project < ApplicationRecord
     response = Typhoeus.get(url)
     if platform.downcase == "packagist" && [302, 404].include?(response.response_code)
       update_attribute(:status, "Removed")
-    elsif platform.downcase == "go" && response.response_code == 404
+    elsif platform.downcase == "go" && [400, 404].include?(response.response_code)
       # pkg.go.dev can be 404 on first-hit for a new package (or alias for the package), so ensure that the package existed in the past
       # by ensuring its age is old enough to not be just uncached by pkg.go.dev yet.
       update_attribute(:status, "Removed") if created_at < 1.week.ago


### PR DESCRIPTION
Sometimes missing packages on pkg.go.dev return 400 and others return 404, so this adds support for both (I think the 400s might be from invalid Go Modules, eg Godeps packages):

```
curl -I https://pkg.go.dev/launchpad.net/gocheck 
HTTP/2 400 

curl -I https://pkg.go.dev/github.com/some-nonexistent-fake/pkg
HTTP/2 404 

 curl -I https://pkg.go.dev/launchpad.net/gozk/zookeeperd
HTTP/2 404 
```

🤷🏻 