### PR TITLE
Remove SUPPORTS_SINGLE_VERSION_UPDATE constant

### DIFF
--- a/app/models/package_manager/conda.rb
+++ b/app/models/package_manager/conda.rb
@@ -6,7 +6,6 @@ module PackageManager
     HAS_DEPENDENCIES = true
     REPOSITORY_SOURCE_NAME = "Main"
     BIBLIOTHECARY_SUPPORT = true
-    SUPPORTS_SINGLE_VERSION_UPDATE = true
     URL = "https://anaconda.org"
     API_URL = "https://conda.libraries.io"
 

--- a/app/models/package_manager/go.rb
+++ b/app/models/package_manager/go.rb
@@ -5,7 +5,6 @@ module PackageManager
     HAS_VERSIONS = true
     HAS_DEPENDENCIES = true
     BIBLIOTHECARY_SUPPORT = true
-    SUPPORTS_SINGLE_VERSION_UPDATE = true
     COLOR = "#375eab"
     KNOWN_HOSTS = [
       "bitbucket.org",

--- a/app/models/package_manager/maven/google.rb
+++ b/app/models/package_manager/maven/google.rb
@@ -2,7 +2,6 @@
 
 class PackageManager::Maven::Google < PackageManager::Maven::Common
   REPOSITORY_SOURCE_NAME = "Google"
-  SUPPORTS_SINGLE_VERSION_UPDATE = true
   HIDDEN = true
 
   def self.repository_base

--- a/app/models/package_manager/maven/maven_central.rb
+++ b/app/models/package_manager/maven/maven_central.rb
@@ -2,7 +2,6 @@
 
 class PackageManager::Maven::MavenCentral < PackageManager::Maven::Common
   REPOSITORY_SOURCE_NAME = "Maven"
-  SUPPORTS_SINGLE_VERSION_UPDATE = true
   HIDDEN = true
 
   def self.repository_base

--- a/app/models/package_manager/npm.rb
+++ b/app/models/package_manager/npm.rb
@@ -9,7 +9,6 @@ module PackageManager
     URL = "https://www.npmjs.com"
     COLOR = "#f1e05a"
     ENTIRE_PACKAGE_CAN_BE_DEPRECATED = true
-    SUPPORTS_SINGLE_VERSION_UPDATE = false
 
     def self.missing_version_remover
       PackageManager::Base::MissingVersionRemover
@@ -109,6 +108,13 @@ module PackageManager
           original_license: license,
         }
       end
+    end
+
+    # NPM is currently unreliable in its update publishing.
+    # The updates are coming in out of order, which is throwing off single version updates.
+    # See https://github.com/librariesio/libraries.io/pull/3278 for more details.
+    def self.supports_single_version_update?
+      false
     end
 
     def self.one_version(raw_project, version_string)

--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -9,7 +9,6 @@ module PackageManager
     URL = "https://pypi.org/"
     COLOR = "#3572A5"
     ENTIRE_PACKAGE_CAN_BE_DEPRECATED = true
-    SUPPORTS_SINGLE_VERSION_UPDATE = true
     # Adapted from https://peps.python.org/pep-0508/#names to include extras
     PEP_508_NAME_REGEX = /[A-Z0-9][A-Z0-9._-]*[A-Z0-9]|[A-Z0-9]/i.freeze
     PEP_508_NAME_WITH_EXTRAS_REGEX = /(^#{PEP_508_NAME_REGEX}\s*(?:\[#{PEP_508_NAME_REGEX}(?:,\s*#{PEP_508_NAME_REGEX})*\])?)/i.freeze

--- a/app/workers/package_manager_download_worker.rb
+++ b/app/workers/package_manager_download_worker.rb
@@ -68,7 +68,7 @@ class PackageManagerDownloadWorker
     key, platform = get_platform(platform_name)
     name = name.to_s.strip
     version = version.to_s.strip
-    sync_version = (platform::SUPPORTS_SINGLE_VERSION_UPDATE && version.presence) || :all
+    sync_version = (platform.supports_single_version_update? && version.presence) || :all
 
     if platform::SYNC_ACTIVE != true
       Rails.logger.info("Skipping Package update for inactive platform=#{key} name=#{name} version=#{version} source=#{source}")

--- a/spec/workers/package_manager_download_worker_spec.rb
+++ b/spec/workers/package_manager_download_worker_spec.rb
@@ -36,18 +36,13 @@ describe PackageManagerDownloadWorker do
   end
 
   context "when the package manager supports single versions updates" do
-    # remove the stub once the NPM::SUPPORTS_SINGLE_VERSION_UPDATE gets sets back to true
-    before do
-      stub_const("PackageManager::NPM::SUPPORTS_SINGLE_VERSION_UPDATE", true)
-    end
-
     it "should raise an error if version didn't get created after 15 attempts" do
       expect(PackageManagerDownloadWorker).to_not receive(:perform_in)
-      expect(PackageManager::NPM).to receive(:update).with("a-package", sync_version: "1.2.3", force_sync_dependencies: false)
+      expect(PackageManager::Pypi).to receive(:update).with("a-package", sync_version: "1.2.3", force_sync_dependencies: false)
       expect(Rails.logger).to receive(:info).with(a_string_matching("Package update"))
-      expect(Rails.logger).to receive(:info).with("[Version Update Failure] platform=npm name=a-package version=1.2.3")
+      expect(Rails.logger).to receive(:info).with("[Version Update Failure] platform=pypi name=a-package version=1.2.3")
 
-      expect { subject.perform("npm", "a-package", "1.2.3", nil, 16) }.to raise_exception(PackageManagerDownloadWorker::VersionUpdateFailure)
+      expect { subject.perform("pypi", "a-package", "1.2.3", nil, 16) }.to raise_exception(PackageManagerDownloadWorker::VersionUpdateFailure)
     end
   end
 


### PR DESCRIPTION
In order for a package manager to support single version updates, in the current code you need to do two things:

* Add a one_version method to the subclass
* Add a SUPPORTS_SINGLE_VERSION_UPDATE constant set to true

It's not clear that you have to do both of these things, and the existence of the one_version method on the subclass can indicate the same thing as the constant. Removing the constant simplifies the interface for package managers.

In the rare case where a package manager that supports single version updates needs to be disabled, the class method that checks for the one_version method's existence can be overridden.

This also fixes a bug where the Google Maven package manager incorrectly indicated it supported single version updates but did not implement one_version.
