### PR TITLE
Update bugsnag 6.26.0 ~> 6.26.1 and remove interrim breadcrumb redaction fix.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
     brpoplpush-redis_script (0.1.3)
       concurrent-ruby (~> 1.0, >= 1.0.5)
       redis (>= 1.0, < 6)
-    bugsnag (6.26.0)
+    bugsnag (6.26.1)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)

--- a/config/initializers/bugsnag.rb
+++ b/config/initializers/bugsnag.rb
@@ -13,16 +13,5 @@ if Rails.env.production?
     elsif ENV["REVISION_ID"]
       config.app_version = ENV["REVISION_ID"]
     end
-    config.add_on_breadcrumb(proc do |breadcrumb|
-      if breadcrumb.metadata[:path].present?
-        cleaned_path = begin
-          Bugsnag.cleaner.clean_url(breadcrumb.metadata[:path])
-        rescue StandardError => e
-          Rails.logger.info "[BUGSNAG FILTERING] error='#{e.class}' message='#{e.message}'"
-          nil
-        end
-        breadcrumb.metadata[:path] = cleaned_path if cleaned_path
-      end
-    end)
   end
 end


### PR DESCRIPTION
(followup to https://github.com/librariesio/libraries.io/pull/3185)

the newest version of the `bugsnag` gem includes a fix for redacting paths in the breadcrumbs, so we can remove our patch and upgrade the gem.
