### PR TITLE
Set a Default Unique Job Lock TTL and set some Specific Options on Maintenance Stat Worker

### DIFF
--- a/app/workers/repository_maintenance_stat_worker.rb
+++ b/app/workers/repository_maintenance_stat_worker.rb
@@ -2,7 +2,7 @@
 
 class RepositoryMaintenanceStatWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :repo_maintenance_stat, retry: 3, lock: :until_executed
+  sidekiq_options queue: :repo_maintenance_stat, retry: 3, lock: :until_executed, lock_ttl: 1.hours.to_i, lock_prefix: "maintstatjobs"
 
   def perform(repo_id)
     Repository.find(repo_id).gather_maintenance_stats

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -61,6 +61,7 @@ Sidekiq.default_job_options = {
 SidekiqUniqueJobs.configure do |config|
   config.enabled = !Rails.env.test?
   config.lock_info = true
+  config.lock_ttl = 1.day.to_i
 end
 
 Marginalia::SidekiqInstrumentation.enable!


### PR DESCRIPTION
The big change here is setting a default TTL on Sidekiq Unique Job locks. The default is `nil` which means a lock will live _f o r e v e r_ and if the lock fails to clear for some reason then the job is locked until redis crashes or somebody comes along and manually clears them. This sets the default to 1 day which seems mostly reasonable and can be overridden in specific workers if needed.

The other piece of the PR is setting a TTL and a custom prefix so I can try and hunt down locks for maintenance stats specifically in the future.