### PR TITLE
Find Last Commit Date Out of Most Recent Batch of Commits

### DIFF
--- a/app/models/maintenance_stats/queries/github/commit_count_query.rb
+++ b/app/models/maintenance_stats/queries/github/commit_count_query.rb
@@ -10,7 +10,7 @@ module MaintenanceStats
               defaultBranchRef {
                 target {
                   ... on Commit {
-                    latestCommit: history(first: 1){
+                    latestCommit: history(first: 10){
                       nodes {
                         committedDate
                       }

--- a/app/models/maintenance_stats/stats/github/commits_stat.rb
+++ b/app/models/maintenance_stats/stats/github/commits_stat.rb
@@ -22,7 +22,10 @@ module MaintenanceStats
 
         def pull_out_latest_commit(dataset)
           nodes = dataset.dig_data("repository", "defaultBranchRef", "target", "latestCommit", "nodes")
-          Date.parse(nodes.first["committedDate"]) if nodes.present?
+          if nodes.present?
+            dates = nodes.map { |node| Date.parse(node["committedDate"]) }
+            dates.compact.max
+          end
         end
       end
 

--- a/spec/fixtures/vcr_cassettes/github/empty_repository.yml
+++ b/spec/fixtures/vcr_cassettes/github/empty_repository.yml
@@ -78,7 +78,6 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":82582762,"node_id":"MDEwOlJlcG9zaXRvcnk4MjU4Mjc2Mg==","name":"heidigoodchild","full_name":"buddhamagnet/heidigoodchild","private":false,"owner":{"login":"buddhamagnet","id":35007,"node_id":"MDQ6VXNlcjM1MDA3","avatar_url":"https://avatars3.githubusercontent.com/u/35007?v=4","gravatar_id":"","url":"https://api.github.com/users/buddhamagnet","html_url":"https://github.com/buddhamagnet","followers_url":"https://api.github.com/users/buddhamagnet/followers","following_url":"https://api.github.com/users/buddhamagnet/following{/other_user}","gists_url":"https://api.github.com/users/buddhamagnet/gists{/gist_id}","starred_url":"https://api.github.com/users/buddhamagnet/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/buddhamagnet/subscriptions","organizations_url":"https://api.github.com/users/buddhamagnet/orgs","repos_url":"https://api.github.com/users/buddhamagnet/repos","events_url":"https://api.github.com/users/buddhamagnet/events{/privacy}","received_events_url":"https://api.github.com/users/buddhamagnet/received_events","type":"User","site_admin":false},"html_url":"https://github.com/buddhamagnet/heidigoodchild","description":null,"fork":false,"url":"https://api.github.com/repos/buddhamagnet/heidigoodchild","forks_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/forks","keys_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/keys{/key_id}","collaborators_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/teams","hooks_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/hooks","issue_events_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/issues/events{/number}","events_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/events","assignees_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/assignees{/user}","branches_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/branches{/branch}","tags_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/tags","blobs_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/git/refs{/sha}","trees_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/git/trees{/sha}","statuses_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/statuses/{sha}","languages_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/languages","stargazers_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/stargazers","contributors_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/contributors","subscribers_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/subscribers","subscription_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/subscription","commits_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/commits{/sha}","git_commits_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/git/commits{/sha}","comments_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/comments{/number}","issue_comment_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/issues/comments{/number}","contents_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/contents/{+path}","compare_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/compare/{base}...{head}","merges_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/merges","archive_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/downloads","issues_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/issues{/number}","pulls_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/pulls{/number}","milestones_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/milestones{/number}","notifications_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/labels{/name}","releases_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/releases{/id}","deployments_url":"https://api.github.com/repos/buddhamagnet/heidigoodchild/deployments","created_at":"2017-02-20T17:13:25Z","updated_at":"2017-02-20T17:13:25Z","pushed_at":"2017-02-20T17:13:26Z","git_url":"git://github.com/buddhamagnet/heidigoodchild.git","ssh_url":"git@github.com:buddhamagnet/heidigoodchild.git","clone_url":"https://github.com/buddhamagnet/heidigoodchild.git","svn_url":"https://github.com/buddhamagnet/heidigoodchild","homepage":null,"size":0,"stargazers_count":0,"watchers_count":0,"language":null,"has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":0,"license":null,"topics":[],"forks":0,"open_issues":0,"watchers":0,"default_branch":"master","permissions":{"admin":false,"push":false,"pull":true},"network_count":0,"subscribers_count":1}'
-    http_version: 
   recorded_at: Mon, 18 Nov 2019 20:48:52 GMT
 - request:
     method: get
@@ -152,7 +151,6 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"resources":{"core":{"limit":5000,"remaining":4997,"reset":1574113732},"search":{"limit":30,"remaining":30,"reset":1574110192},"graphql":{"limit":5000,"remaining":4984,"reset":1574113732},"integration_manifest":{"limit":5000,"remaining":5000,"reset":1574113732}},"rate":{"limit":5000,"remaining":4997,"reset":1574113732}}'
-    http_version: 
   recorded_at: Mon, 18 Nov 2019 20:48:52 GMT
 - request:
     method: get
@@ -226,7 +224,6 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"total_count":0,"incomplete_results":false,"items":[]}'
-    http_version: 
   recorded_at: Mon, 18 Nov 2019 20:48:52 GMT
 - request:
     method: get
@@ -300,7 +297,6 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"resources":{"core":{"limit":5000,"remaining":4997,"reset":1574113732},"search":{"limit":30,"remaining":29,"reset":1574110192},"graphql":{"limit":5000,"remaining":4984,"reset":1574113732},"integration_manifest":{"limit":5000,"remaining":5000,"reset":1574113732}},"rate":{"limit":5000,"remaining":4997,"reset":1574113732}}'
-    http_version: 
   recorded_at: Mon, 18 Nov 2019 20:48:53 GMT
 - request:
     method: get
@@ -374,7 +370,6 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"total_count":0,"incomplete_results":false,"items":[]}'
-    http_version: 
   recorded_at: Mon, 18 Nov 2019 20:48:53 GMT
 - request:
     method: get
@@ -448,7 +443,6 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"resources":{"core":{"limit":5000,"remaining":4997,"reset":1574113732},"search":{"limit":30,"remaining":28,"reset":1574110192},"graphql":{"limit":5000,"remaining":4983,"reset":1574113732},"integration_manifest":{"limit":5000,"remaining":5000,"reset":1574113732}},"rate":{"limit":5000,"remaining":4997,"reset":1574113732}}'
-    http_version: 
   recorded_at: Mon, 18 Nov 2019 20:48:54 GMT
 - request:
     method: post
@@ -532,7 +526,6 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"data":{"openPullRequests":{"issueCount":0},"closedPullRequests":{"issueCount":0},"repository":{"openIssues":{"totalCount":0},"closedIssues":{"totalCount":0}}}}'
-    http_version: 
   recorded_at: Wed, 05 May 2021 15:38:19 GMT
 - request:
     method: get
@@ -621,7 +614,6 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"all":[],"owner":[]}'
-    http_version: 
   recorded_at: Mon, 06 Feb 2023 19:08:46 GMT
 - request:
     method: post
@@ -698,7 +690,6 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"data":{"viewer":{"login":"johnbintz-tidelift"},"rateLimit":{"remaining":4975}}}'
-    http_version: 
   recorded_at: Mon, 06 Feb 2023 19:10:32 GMT
 - request:
     method: get
@@ -784,7 +775,6 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"resources":{"core":{"limit":5000,"used":16,"remaining":4984,"reset":1675712125},"search":{"limit":30,"used":0,"remaining":30,"reset":1675710693},"graphql":{"limit":5000,"used":25,"remaining":4975,"reset":1675713756},"integration_manifest":{"limit":5000,"used":0,"remaining":5000,"reset":1675714233},"source_import":{"limit":100,"used":0,"remaining":100,"reset":1675710693},"code_scanning_upload":{"limit":1000,"used":0,"remaining":1000,"reset":1675714233},"actions_runner_registration":{"limit":10000,"used":0,"remaining":10000,"reset":1675714233},"scim":{"limit":15000,"used":0,"remaining":15000,"reset":1675714233},"dependency_snapshots":{"limit":100,"used":0,"remaining":100,"reset":1675710693}},"rate":{"limit":5000,"used":16,"remaining":4984,"reset":1675712125}}'
-    http_version: 
   recorded_at: Mon, 06 Feb 2023 19:10:33 GMT
 - request:
     method: post
@@ -864,92 +854,6 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"data":{"repository":{"releases":{"nodes":[],"totalCount":0,"pageInfo":{"hasPreviousPage":false,"hasNextPage":false,"endCursor":null,"startCursor":null}}}}}'
-    http_version: 
-  recorded_at: Mon, 06 Feb 2023 19:10:33 GMT
-- request:
-    method: post
-    uri: https://api.github.com/graphql
-    body:
-      encoding: UTF-8
-      string: '{"query":"query MaintenanceStats__Queries__Github__CommitCountQuery__COMMIT_COUNTS_QUERY($owner:
-        String!, $repo_name: String!, $one_week: GitTimestamp!, $one_month: GitTimestamp!,
-        $two_months: GitTimestamp!, $one_year: GitTimestamp!) {\n  repository(owner:
-        $owner, name: $repo_name) {\n    defaultBranchRef {\n      target {\n        __typename\n        ...
-        on Commit {\n          latestCommit: history(first: 1) {\n            nodes
-        {\n              committedDate\n            }\n          }\n          lastWeek:
-        history(since: $one_week) {\n            totalCount\n          }\n          lastMonth:
-        history(since: $one_month) {\n            totalCount\n          }\n          lastTwoMonths:
-        history(since: $two_months) {\n            totalCount\n          }\n          lastYear:
-        history(since: $one_year) {\n            totalCount\n          }\n        }\n      }\n      name\n    }\n  }\n}","variables":{"one_week":"2018-12-07T17:49:49+00:00","one_month":"2018-11-14T17:49:49+00:00","two_months":"2018-10-14T17:49:49+00:00","one_year":"2017-12-14T17:49:49+00:00","owner":"buddhamagnet","repo_name":"heidigoodchild"},"operationName":"MaintenanceStats__Queries__Github__CommitCountQuery__COMMIT_COUNTS_QUERY"}'
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - application/json
-      User-Agent:
-      - Ruby
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer test_token
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - GitHub.com
-      Date:
-      - Mon, 06 Feb 2023 19:10:33 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      X-Oauth-Scopes:
-      - public_repo
-      X-Accepted-Oauth-Scopes:
-      - repo
-      Github-Authentication-Token-Expiration:
-      - 2023-02-13 19:01:57 UTC
-      X-Github-Media-Type:
-      - github.v4
-      X-Ratelimit-Limit:
-      - '5000'
-      X-Ratelimit-Remaining:
-      - '4973'
-      X-Ratelimit-Reset:
-      - '1675713756'
-      X-Ratelimit-Used:
-      - '27'
-      X-Ratelimit-Resource:
-      - graphql
-      Access-Control-Expose-Headers:
-      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
-        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
-        X-GitHub-Request-Id, Deprecation, Sunset
-      Access-Control-Allow-Origin:
-      - "*"
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      X-Frame-Options:
-      - deny
-      X-Content-Type-Options:
-      - nosniff
-      X-Xss-Protection:
-      - '0'
-      Referrer-Policy:
-      - origin-when-cross-origin, strict-origin-when-cross-origin
-      Content-Security-Policy:
-      - default-src 'none'
-      Vary:
-      - Accept-Encoding, Accept, X-Requested-With
-      X-Github-Request-Id:
-      - 9E5E:2E16:5D4893:BEC3A8:63E150A9
-    body:
-      encoding: ASCII-8BIT
-      string: '{"data":{"repository":{"defaultBranchRef":null}}}'
-    http_version: 
   recorded_at: Mon, 06 Feb 2023 19:10:33 GMT
 - request:
     method: get
@@ -1023,7 +927,6 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: ''
-    http_version: 
   recorded_at: Mon, 06 Feb 2023 19:10:33 GMT
 - request:
     method: post
@@ -1107,6 +1010,89 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"data":{"openPullRequests":{"issueCount":0},"closedPullRequests":{"issueCount":0},"repository":{"openIssues":{"totalCount":0},"closedIssues":{"totalCount":0}}}}'
-    http_version: 
   recorded_at: Mon, 06 Feb 2023 19:10:33 GMT
-recorded_with: VCR 4.0.0
+- request:
+    method: post
+    uri: https://api.github.com/graphql
+    body:
+      encoding: UTF-8
+      string: '{"query":"query MaintenanceStats__Queries__Github__CommitCountQuery__COMMIT_COUNTS_QUERY($owner:
+        String!, $repo_name: String!, $one_week: GitTimestamp!, $one_month: GitTimestamp!,
+        $two_months: GitTimestamp!, $one_year: GitTimestamp!) {\n  repository(owner:
+        $owner, name: $repo_name) {\n    defaultBranchRef {\n      target {\n        __typename\n        ...
+        on Commit {\n          latestCommit: history(first: 10) {\n            nodes
+        {\n              committedDate\n            }\n          }\n          lastWeek:
+        history(since: $one_week) {\n            totalCount\n          }\n          lastMonth:
+        history(since: $one_month) {\n            totalCount\n          }\n          lastTwoMonths:
+        history(since: $two_months) {\n            totalCount\n          }\n          lastYear:
+        history(since: $one_year) {\n            totalCount\n          }\n        }\n      }\n      name\n    }\n  }\n}","variables":{"one_week":"2018-12-07T17:49:49+00:00","one_month":"2018-11-14T17:49:49+00:00","two_months":"2018-10-14T17:49:49+00:00","one_year":"2017-12-14T17:49:49+00:00","owner":"buddhamagnet","repo_name":"heidigoodchild"},"operationName":"MaintenanceStats__Queries__Github__CommitCountQuery__COMMIT_COUNTS_QUERY"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer test_token
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Mon, 22 Jan 2024 15:04:27 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Oauth-Scopes:
+      - public_repo
+      X-Accepted-Oauth-Scopes:
+      - repo
+      Github-Authentication-Token-Expiration:
+      - 2024-12-31 05:00:00 UTC
+      X-Github-Media-Type:
+      - github.v4
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4998'
+      X-Ratelimit-Reset:
+      - '1705939466'
+      X-Ratelimit-Used:
+      - '2'
+      X-Ratelimit-Resource:
+      - graphql
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '0'
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Github-Request-Id:
+      - D4B1:20A2:6ABB2BF:DDD2273:65AE83FA
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":{"repository":{"defaultBranchRef":null}}}'
+  recorded_at: Mon, 22 Jan 2024 15:04:27 GMT
+recorded_with: VCR 6.2.0

--- a/spec/models/maintenance_stats/github/commit_count_stats_spec.rb
+++ b/spec/models/maintenance_stats/github/commit_count_stats_spec.rb
@@ -28,7 +28,7 @@ describe MaintenanceStats::Stats::Github::CommitsStat do
 
       # check values against the VCR cassette data
 
-      expect(results[:last_year_commits]).to eql 131
+      expect(results[:last_year_commits]).to eql 139
     end
 
     it "should get the latest commit date" do
@@ -39,7 +39,7 @@ describe MaintenanceStats::Stats::Github::CommitsStat do
       expect(results.keys).to eql expected_keys
 
       # check values against the VCR cassette data
-      expect(results[:latest_commit]).to eql Date.new(2022, 12, 8)
+      expect(results[:latest_commit]).to eql Date.new(2024, 1, 19)
     end
   end
 


### PR DESCRIPTION
The GitHub GraphQL API does not seem to be consistent on which commit is the first returned. The order should be similar to what `git log` would return for the repository and there are some edge cases where a commit's data could have changed in a way where an older date commit is the first returned. This PR changes the query to look at the first 10 commits returned and find the latest date out of those. 10 is an arbitrary number but I didn't want the batch to be too big that it consumes more rate limit and the cases where I have found this to be a problem generally have the latest commit as the 2nd in the list returned from the query.

An example from https://github.com/dkubb/axiom-types/commits/master/

Query returns:
```
{
  "data": {
    "repository": {
      "defaultBranchRef": {
        "target": {
          "history": {
            "nodes": [
              {
                "committedDate": "2015-02-26T18:10:35Z"
              },
              {
                "committedDate": "2015-06-14T07:21:36Z"
              },
              {
                "committedDate": "2015-06-14T05:23:12Z"
              },
              {
                "committedDate": "2014-03-27T06:31:00Z"
              },
              {
                "committedDate": "2014-03-27T06:29:06Z"
              },
              {
                "committedDate": "2014-03-27T06:03:39Z"
              },
              {
                "committedDate": "2014-03-27T06:02:24Z"
              },
              {
                "committedDate": "2014-03-27T05:31:02Z"
              },
              {
                "committedDate": "2014-03-27T05:29:17Z"
              },
              {
                "committedDate": "2014-03-27T05:29:08Z"
              }
            ]
          }
        }
      }
    }
  }
}
```