### PR TITLE
Slow Down Stats Collection

### DIFF
--- a/lib/tasks/maintenance_stats.rake
+++ b/lib/tasks/maintenance_stats.rake
@@ -52,18 +52,18 @@ namespace :maintenance_stats do
     Update maintenance stats for repositories
 
       number_to_sync [Integer]: How many Repositories to update. (default: 2000)
-      before [String] Only update stats older than this date. String should be parseable by Date.parse().
+      before_date [String] Only update stats older than this date. String should be parseable by Date.parse().
         This date is inclusive and will include Repositories last updated on this date. (default: 1 week ago)
 
     Usage:
       rake maintenance_stats:update_maintenance_stats[100,01-31-2024]
       rake maintenance_stats:update_maintenance_stats defaults to 2000 repos last updated more than 1 week ago
   DESC
-  task :update_maintenance_stats, %i[number_to_sync before] => :environment do |_task, args|
+  task :update_maintenance_stats, %i[number_to_sync before_date] => :environment do |_task, args|
     exit if ENV["READ_ONLY"].present?
     number_to_sync = args.number_to_sync || 2000
     # set to end of day to include anything updated on the target date
-    not_updated_since = (Date.parse(args.before) || 1.week.ago).at_end_of_day
+    not_updated_since = (Date.parse(args.before_date) || 1.week.ago).at_end_of_day
 
     Repository
       .least_recently_updated_stats

--- a/lib/tasks/maintenance_stats.rake
+++ b/lib/tasks/maintenance_stats.rake
@@ -69,7 +69,6 @@ namespace :maintenance_stats do
                           Date.parse(args.before_date)
                         end
 
-
     Repository
       .least_recently_updated_stats
       .where(host_type: "GitHub")

--- a/lib/tasks/maintenance_stats.rake
+++ b/lib/tasks/maintenance_stats.rake
@@ -51,11 +51,13 @@ namespace :maintenance_stats do
   desc <<~DESC
     Update maintenance stats for repositories
 
-      number_to_sync [Integer, nil]: How many Repositories to update (default: 2000)
-      before [String, nil] Only update stats older than this date. Date is inclusive and will include Repositories last updated on this date (default: 1 week ago)
+      number_to_sync [Integer]: How many Repositories to update. (default: 2000)
+      before [String] Only update stats older than this date. String should be parseable by Date.parse().
+        This date is inclusive and will include Repositories last updated on this date. (default: 1 week ago)
 
     Usage:
       rake maintenance_stats:update_maintenance_stats[100,01-31-2024]
+      rake maintenance_stats:update_maintenance_stats defaults to 2000 repos last updated more than 1 week ago
   DESC
   task :update_maintenance_stats, %i[number_to_sync before] => :environment do |_task, args|
     exit if ENV["READ_ONLY"].present?


### PR DESCRIPTION
Now that we have fixed a few issues with the stat collection, we are collecting stats more often than we really need. This PR would update the task to only collect stats for repositories that are more than a week out of date rather than doing 2000 every hour as it is now.