### PR TITLE
Downgrade URL Parser

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -320,7 +320,7 @@ GEM
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     librariesio-gem-parser (1.0.0)
-    librariesio-url-parser (1.0.8)
+    librariesio-url-parser (1.0.3)
     license-compatibility (3.1.0)
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)


### PR DESCRIPTION
There is an error introduced in version 1.0.7 of the URL parser gem that needs to be fixed when resolving user URLs. This rolls back to the version before I bumped up to 1.0.8.