### PR TITLE
Queue PackageManagerDownloadWorker if it previously failed

### DIFF
--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -152,6 +152,11 @@ class Api::ProjectsController < Api::ApplicationController
       version.update_column(:dependencies_count, deps.size)
     end
 
+    if version.dependencies_count.nil? && deps.empty? && version.updated_at < 1.day.ago
+      version.touch
+      PackageManagerDownloadWorker.perform_async(platform, name, version.number)
+    end
+
     # nil means that we haven't fetched the deps yet, so check back later.
     project_json[:dependencies] = version.dependencies_count.nil? ? nil : map_dependencies(deps)
 


### PR DESCRIPTION
If the caller is interested in dependencies for a version which has never successfully updated these, queue an update. But only if it's been at least 1 day since the last retry.