### PR TITLE
fix: [sc-39770] Make Google Maven act like other managers for updates/versions

### DIFF
--- a/app/models/package_manager/maven/maven_central.rb
+++ b/app/models/package_manager/maven/maven_central.rb
@@ -12,10 +12,6 @@ class PackageManager::Maven::MavenCentral < PackageManager::Maven::Common
     get("https://maven.libraries.io/mavenCentral/recent")
   end
 
-  def self.one_version(raw_project, version_string)
-    retrieve_versions([version_string], raw_project[:name])&.first
-  end
-
   def self.missing_version_remover
     PackageManager::Base::MissingVersionRemover
   end

--- a/spec/models/package_manager/maven_spec.rb
+++ b/spec/models/package_manager/maven_spec.rb
@@ -83,17 +83,6 @@ describe PackageManager::Maven do
     end
   end
 
-  describe ".one_version" do
-    it "retrieves a single version" do
-      allow(described_class)
-        .to receive(:download_pom)
-        .and_raise(PackageManager::Maven::POMNotFound.new("https://a-maven-central-url"))
-      raw_project = { name: "org.foo:bar" }
-
-      expect(PackageManager::Maven::MavenCentral.one_version(raw_project, "1.0.0")).to eq(nil)
-    end
-  end
-
   describe ".versions" do
     it "returns the expected version data" do
       allow(described_class)


### PR DESCRIPTION
Part of the problem with tracking down an issue with Google Maven was
that its behavior was too different from other package managers when it
didn't need to be. This gets Google Maven using more of the existing
infrastructure rather than inventing its own. It also cleans up some
additional API cruft, making method usages more consistent (even if
their parameters coming in are a little odd).