### PR TITLE
Remove setting custom similarity threshold

### DIFF
--- a/config/initializers/pg_search.rb
+++ b/config/initializers/pg_search.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-# TODO: Better place to put this?
-ActiveRecord::Base.connection.execute("SET pg_trgm.similarity_threshold = 0.6;")


### PR DESCRIPTION
I put this initializer in but: it is breaking the build, likely there's a better way to have that setting set, and we might not need it anyway
