### PR TITLE
Return Early if Github Manifest Content API Response is an Array

### DIFF
--- a/app/models/repository_host/github.rb
+++ b/app/models/repository_host/github.rb
@@ -77,6 +77,14 @@ module RepositoryHost
 
     def get_file_contents(path, token = nil)
       file = api_client(token).contents(repository.full_name, path: path)
+
+      # Sometimes the Github API will return an array of contents instead of a single file
+      # if the path does not direct to a single manifest file as expected.
+      # There are some scenarios where the path we sent in will end up with a response like this
+      # for unknown reasons.
+      # In the case where we get an array of objects we can't read the contents, so just return nil and move on.
+      return nil if file.is_a?(Array)
+
       {
         sha: file.sha,
         content: file.content.present? ? Base64.decode64(file.content) : file.content,


### PR DESCRIPTION
I'm not entirely sure what is causing this issue. [The API endpoint](https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content) will return either a single file or an array of files depending on if the path sent in is a single file or a directory. We are calling this endpoint to read the content of manifest files in a repository, but some paths are being interpreted as directories instead. We see a lot of errors pop up where we are trying to read the content of an array, so this PR would just skip those files since we can't get the content from it and we were assuming it was going to return a single file.