### PR TITLE
PackageManager::Go.find_project_names: skip certain hosts

### DIFF
--- a/app/models/package_manager/go.rb
+++ b/app/models/package_manager/go.rb
@@ -12,6 +12,9 @@ module PackageManager
       "launchpad.net",
       "hub.jazz.net",
     ].freeze
+    SKIP_HOSTS = [
+      "jfrog.com"
+    ]
     KNOWN_VCS = [
       ".bzr",
       ".fossil",
@@ -229,6 +232,7 @@ module PackageManager
     # https://golang.org/cmd/go/#hdr-Import_path_syntax
     def self.project_find_names(name)
       return [name] if name.start_with?(*KNOWN_HOSTS)
+      return [name] if name.start_with?(*SKIP_HOSTS)
       return [name] if KNOWN_VCS.any?(&name.method(:include?))
 
       host = name.split("/").first

--- a/app/models/package_manager/go.rb
+++ b/app/models/package_manager/go.rb
@@ -13,8 +13,8 @@ module PackageManager
       "hub.jazz.net",
     ].freeze
     SKIP_HOSTS = [
-      "jfrog.com"
-    ]
+      "jfrog.com",
+    ].freeze
     KNOWN_VCS = [
       ".bzr",
       ".fossil",
@@ -249,7 +249,18 @@ module PackageManager
           &.last
           &.sub(/https?:\/\//, "")
 
-        go_import&.start_with?(*KNOWN_HOSTS) ? [go_import] : [name]
+        chosen_name = go_import&.start_with?(*KNOWN_HOSTS) ? [go_import] : [name]
+        # Collect info on what data we're mapping here, to ensure it's doing the right thing.
+        StructuredLog.capture(
+          "GO_MODULES_PROJECT_FIND_NAMES",
+          {
+            name: name,
+            found_name: go_import,
+            chosen_name: chosen_name,
+          }
+        )
+
+        chosen_name
       rescue Faraday::ConnectionFailed => e
         # We can get here from go modules that don't exist anymore, or having server troubles:
         # Fallback to the given name, cache the host as "bad" for a day,
@@ -258,7 +269,8 @@ module PackageManager
         Rails.cache.write("unreachable-go-hosts:#{host}", true, ex: 1.day)
         Bugsnag.notify(e)
         [name]
-      rescue StandardError
+      rescue StandardError => e
+        Bugsnag.notify(e)
         [name]
       end
     end

--- a/spec/models/package_manager/go_spec.rb
+++ b/spec/models/package_manager/go_spec.rb
@@ -324,17 +324,33 @@ describe PackageManager::Go do
   end
 
   describe ".project_find_names(name)" do
-    context "for names from a a known host" do
-      it "returns the name" do
-        expect(described_class.project_find_names("github.com/user/project"))
-          .to eq(["github.com/user/project"])
+    context "for names from a known host" do
+      it "returns the name without calling the host" do
+        name = "github.com/user/project"
+        allow(described_class).to receive(:get_html)
+
+        expect(described_class.project_find_names(name)).to eq([name])
+        expect(described_class).to_not have_received(:get_html)
+      end
+    end
+
+    context "for names from a host we ignore" do
+      it "returns the name without calling the host" do
+        name = "jfrog.com/some/git/repo"
+        allow(described_class).to receive(:get_html)
+
+        expect(described_class.project_find_names(name)).to eq([name])
+        expect(described_class).to_not have_received(:get_html)
       end
     end
 
     context "for names with a known vcs" do
       it "returns the name" do
-        expect(described_class.project_find_names("example.org/user/foo.hg"))
-          .to eq(["example.org/user/foo.hg"])
+        name = "example.org/user/foo.hg"
+        allow(described_class).to receive(:get_html)
+
+        expect(described_class.project_find_names(name)).to eq([name])
+        expect(described_class).to_not have_received(:get_html)
       end
     end
 


### PR DESCRIPTION
when we lookup Go Module names that we can't find to check for an alternative path to use, there are certain hosts that will be slow to respond. This adds a list of hosts that we want to explicitly skip when looking up Go Modules in `find_project_names` so we don't hold up `/api/checks` requests.