### PR TITLE
Fix status#check keywords

### DIFF
--- a/app/serializers/optimized_project_serializer.rb
+++ b/app/serializers/optimized_project_serializer.rb
@@ -9,7 +9,6 @@ class OptimizedProjectSerializer
     deprecation_reason
     description
     homepage
-    keywords
     language
     latest_release_number
     latest_release_published_at
@@ -46,6 +45,7 @@ class OptimizedProjectSerializer
         .attributes
         .slice(*PROJECT_ATTRIBUTES)
         .merge!(
+          keywords: project.keywords, # the method, not the db field
           canonical_name: project.name,
           name: @requested_name_map[[project.platform, project.name]],
           download_url: project.download_url,

--- a/spec/requests/api/status_spec.rb
+++ b/spec/requests/api/status_spec.rb
@@ -10,7 +10,7 @@ describe "API::StatusController" do
   let!(:repository) { create(:repository) }
   let!(:maintenance_stat) { create(:repository_maintenance_stat, repository: repository) }
   let!(:project) { create(:project, repository: repository) }
-  let!(:project_django) { create(:project, name: "Django", platform: "Pypi") }
+  let!(:project_django) { create(:project, name: "Django", platform: "Pypi", keywords: "old kewords", keywords_array: ["new keywords"]) }
 
   before do
     internal_user.current_api_key.update_attribute(:is_internal, true)
@@ -104,6 +104,22 @@ describe "API::StatusController" do
       expected_fields.each do |field|
         expect(project).to have_key(field)
       end
+    end
+
+    it "correctly serves the keywords array" do
+      post(
+        url,
+        params: {
+          api_key: internal_user.api_key,
+          projects: [
+            { name: project_django.name, platform: project_django.platform },
+          ],
+          score: true,
+        }
+      )
+
+      expect(response).to have_http_status(:success)
+      expect(JSON.parse(response.body).dig(0, "keywords")).to eq(["new keywords"])
     end
 
     it "correctly serves the original name" do


### PR DESCRIPTION
`project[:keywords]` (the database field) seems to be an old field that is no longer written to. Return `project.keywords` (the method) instead.

The db field should probably be removed, but I don't have a local environment fully set up enough to take on that type of project at this time.