### PR TITLE
Clean up Project Provider Map system

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,6 +117,7 @@ group :test do
   gem "capybara"
   gem "database_cleaner", "~> 1.99.0"
   gem "database_cleaner-active_record"
+  gem "db-query-matchers"
   gem "factory_bot_rails", "~> 6.2.0"
   gem "faker"
   gem "json_spec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,9 @@ GEM
     datadog-ci (0.3.0)
       msgpack
     date (3.3.3)
+    db-query-matchers (0.11.0)
+      activesupport (>= 4.0, < 7.1)
+      rspec (>= 3.0)
     ddtrace (1.16.2)
       datadog-ci (~> 0.3.0)
       debase-ruby_core_source (= 3.2.2)
@@ -689,6 +692,7 @@ DEPENDENCIES
   dalli
   database_cleaner (~> 1.99.0)
   database_cleaner-active_record
+  db-query-matchers
   ddtrace (~> 1.16.2)
   dotenv-rails
   elasticsearch (~> 2)

--- a/app/models/package_manager/conda.rb
+++ b/app/models/package_manager/conda.rb
@@ -9,11 +9,11 @@ module PackageManager
     URL = "https://anaconda.org"
     API_URL = "https://conda.libraries.io"
 
-    PROVIDER_MAP = ProviderMap.new(
+    PROVIDER_MAP = ProviderMap.new(prioritized_provider_infos: [
       ProviderInfo.new(identifier: "Main", default: true, provider_class: Main),
       ProviderInfo.new(identifier: "CondaMain", provider_class: Main),
-      ProviderInfo.new(identifier: "CondaForge", provider_class: Forge)
-    )
+      ProviderInfo.new(identifier: "CondaForge", provider_class: Forge),
+    ])
 
     def self.formatted_name
       "conda"

--- a/app/models/package_manager/conda.rb
+++ b/app/models/package_manager/conda.rb
@@ -54,33 +54,18 @@ module PackageManager
       end
     end
 
-    def self.package_link(project, _version = nil)
-      db_version = project.versions.last
-      repository_source = db_version&.repository_sources&.first.presence || "default"
-      PROVIDER_MAP[repository_source].package_link(project)
-    end
-
     def self.install_instructions(db_project, _version = nil)
-      db_version = db_project.versions.last
-      repository_source = db_version&.repository_sources&.first.presence || "default"
-      PROVIDER_MAP[repository_source].install_instructions(db_project)
+      self::PROVIDER_MAP
+        .best_repository_source(project: db_project)
+        .provider_class
+        .install_instructions(db_project)
     end
 
-    PROVIDER_MAP = {
-      "CondaForge" => Forge,
-      "default" => Main,
-      "Main" => Main,
-      "CondaMain" => Main,
-    }.freeze
-
-    def self.providers(project)
-      project
-        .versions
-        .flat_map(&:repository_sources)
-        .compact
-        .uniq
-        .map { |source| PROVIDER_MAP[source] } || [PROVIDER_MAP["default"]]
-    end
+    PROVIDER_MAP = ProviderMap.new(
+      ProviderInfo.new(identifier: "Main", default: true, provider_class: Main),
+      ProviderInfo.new(identifier: "CondaMain", provider_class: Main),
+      ProviderInfo.new(identifier: "CondaForge", provider_class: Forge)
+    )
 
     def self.check_status_url(db_project)
       "#{API_URL}/package/#{db_project.name}"

--- a/app/models/package_manager/conda.rb
+++ b/app/models/package_manager/conda.rb
@@ -62,7 +62,7 @@ module PackageManager
 
     def self.install_instructions(db_project, _version = nil)
       self::PROVIDER_MAP
-        .best_repository_source(project: db_project)
+        .preferred_provider_for_project(project: db_project)
         .provider_class
         .install_instructions(db_project)
     end

--- a/app/models/package_manager/conda.rb
+++ b/app/models/package_manager/conda.rb
@@ -9,6 +9,12 @@ module PackageManager
     URL = "https://anaconda.org"
     API_URL = "https://conda.libraries.io"
 
+    PROVIDER_MAP = ProviderMap.new(
+      ProviderInfo.new(identifier: "Main", default: true, provider_class: Main),
+      ProviderInfo.new(identifier: "CondaMain", provider_class: Main),
+      ProviderInfo.new(identifier: "CondaForge", provider_class: Forge)
+    )
+
     def self.formatted_name
       "conda"
     end
@@ -60,12 +66,6 @@ module PackageManager
         .provider_class
         .install_instructions(db_project)
     end
-
-    PROVIDER_MAP = ProviderMap.new(
-      ProviderInfo.new(identifier: "Main", default: true, provider_class: Main),
-      ProviderInfo.new(identifier: "CondaMain", provider_class: Main),
-      ProviderInfo.new(identifier: "CondaForge", provider_class: Forge)
-    )
 
     def self.check_status_url(db_project)
       "#{API_URL}/package/#{db_project.name}"

--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -18,16 +18,15 @@ module PackageManager
     }.freeze
     NAME_DELIMITER = ":"
 
-    PROVIDER_MAP = {
-      "Atlassian" => Atlassian,
-      "default" => MavenCentral,
-      "Hortonworks" => Hortonworks,
-      "Maven" => MavenCentral,
-      "SpringLibs" => SpringLibs,
-      "Jboss" => Jboss,
-      "JbossEa" => JbossEa,
-      "Google" => Google,
-    }.freeze
+    PROVIDER_MAP = ProviderMap.new(
+      ProviderInfo.new(identifier: "Maven", default: true, provider_class: MavenCentral),
+      ProviderInfo.new(identifier: "Google", provider_class: Google),
+      ProviderInfo.new(identifier: "Atlassian", provider_class: Atlassian),
+      ProviderInfo.new(identifier: "Hortonworks", provider_class: Hortonworks),
+      ProviderInfo.new(identifier: "SpringLibs", provider_class: SpringLibs),
+      ProviderInfo.new(identifier: "Jboss", provider_class: Jboss),
+      ProviderInfo.new(identifier: "JbossEa", provider_class: JbossEa)
+    )
 
     class POMNotFound < StandardError
       attr_reader :url
@@ -39,7 +38,7 @@ module PackageManager
     end
 
     def self.repository_base
-      PROVIDER_MAP["default"].repository_base
+      PROVIDER_MAP.default_provider.provider_class.repository_base
     end
 
     def self.project_names

--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -18,15 +18,15 @@ module PackageManager
     }.freeze
     NAME_DELIMITER = ":"
 
-    PROVIDER_MAP = ProviderMap.new(
+    PROVIDER_MAP = ProviderMap.new(prioritized_provider_infos: [
       ProviderInfo.new(identifier: "Maven", default: true, provider_class: MavenCentral),
       ProviderInfo.new(identifier: "Google", provider_class: Google),
       ProviderInfo.new(identifier: "Atlassian", provider_class: Atlassian),
       ProviderInfo.new(identifier: "Hortonworks", provider_class: Hortonworks),
       ProviderInfo.new(identifier: "SpringLibs", provider_class: SpringLibs),
       ProviderInfo.new(identifier: "Jboss", provider_class: Jboss),
-      ProviderInfo.new(identifier: "JbossEa", provider_class: JbossEa)
-    )
+      ProviderInfo.new(identifier: "JbossEa", provider_class: JbossEa),
+    ])
 
     class POMNotFound < StandardError
       attr_reader :url

--- a/app/models/package_manager/multiple_sources_base.rb
+++ b/app/models/package_manager/multiple_sources_base.rb
@@ -12,21 +12,21 @@ module PackageManager
 
     def self.package_link(db_project, version = nil)
       self::PROVIDER_MAP
-        .best_repository_source(project: db_project, version: version)
+        .preferred_provider_for_project(project: db_project, version: version)
         .provider_class
         .package_link(db_project, version)
     end
 
     def self.download_url(db_project, version = nil)
       self::PROVIDER_MAP
-        .best_repository_source(project: db_project, version: version)
+        .preferred_provider_for_project(project: db_project, version: version)
         .provider_class
         .download_url(db_project, version)
     end
 
     def self.check_status_url(db_project)
       self::PROVIDER_MAP
-        .best_repository_source(project: db_project)
+        .preferred_provider_for_project(project: db_project)
         .provider_class
         .check_status_url(db_project)
     end

--- a/app/models/package_manager/multiple_sources_base.rb
+++ b/app/models/package_manager/multiple_sources_base.rb
@@ -6,47 +6,37 @@ module PackageManager
     HAS_VERSIONS = false
     HAS_DEPENDENCIES = false
 
-    def self.providers(project)
-      project
-        .versions
-        .flat_map(&:repository_sources)
-        .compact
-        .uniq
-        .map { |source| self::PROVIDER_MAP[source] }.presence || [self::PROVIDER_MAP["default"]]
+    def self.providers(db_project)
+      self::PROVIDER_MAP.providers_for(project: db_project).map(&:provider_class)
     end
 
     def self.package_link(db_project, version = nil)
-      repository_source = get_repository_source(db_project, version)
-      self::PROVIDER_MAP[repository_source].package_link(db_project, version)
+      self::PROVIDER_MAP
+        .best_repository_source(project: db_project, version: version)
+        .provider_class
+        .package_link(db_project, version)
     end
 
     def self.download_url(db_project, version = nil)
-      repository_source = get_repository_source(db_project, version)
-      self::PROVIDER_MAP[repository_source].download_url(db_project, version)
+      self::PROVIDER_MAP
+        .best_repository_source(project: db_project, version: version)
+        .provider_class
+        .download_url(db_project, version)
     end
 
     def self.check_status_url(db_project)
-      source = db_project.versions.flat_map(&:repository_sources).compact.uniq.first.presence || "default"
-      self::PROVIDER_MAP[source].check_status_url(db_project)
+      self::PROVIDER_MAP
+        .best_repository_source(project: db_project)
+        .provider_class
+        .check_status_url(db_project)
     end
 
     def self.repository_base
-      self::PROVIDER_MAP["default"].repository_base
+      self::PROVIDER_MAP.default_provider.provider_class.repository_base
     end
 
     def self.recent_names
-      self::PROVIDER_MAP["default"].recent_names
-    end
-
-    private_class_method def self.get_repository_source(db_project, version = nil)
-      db_version = if version.nil?
-                     db_project.versions.first
-                   elsif db_project.association(:versions).loaded? && !db_project.versions.empty?
-                     db_project.versions.find { |v| v.number == version }
-                   else
-                     db_project.versions.find_by(number: version)
-                   end
-      db_version&.repository_sources&.first.presence || "default"
+      self::PROVIDER_MAP.default_provider.provider_class.recent_names
     end
   end
 end

--- a/app/models/package_manager/multiple_sources_base/provider_info.rb
+++ b/app/models/package_manager/multiple_sources_base/provider_info.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module PackageManager
+  class MultipleSourcesBase < Base
+    class ProviderInfo
+      attr_reader :identifier, :provider_class
+
+      def initialize(identifier:, provider_class:, default: false)
+        @identifier = identifier
+        @provider_class = provider_class
+        @default = default
+      end
+
+      def default?
+        !!@default
+      end
+    end
+  end
+end

--- a/app/models/package_manager/multiple_sources_base/provider_map.rb
+++ b/app/models/package_manager/multiple_sources_base/provider_map.rb
@@ -8,7 +8,7 @@ module PackageManager
     class ProviderMap
       # @param prioritized_provider_infos [Array(ProviderInfo)] ProviderInfo classes in
       #        the order in which they should be resolved for matches.
-      def initialize(*prioritized_provider_infos)
+      def initialize(prioritized_provider_infos:)
         @prioritized_provider_infos = prioritized_provider_infos
 
         raise "Need exactly one default provider" unless @prioritized_provider_infos.find_all(&:default?).count == 1

--- a/app/models/package_manager/multiple_sources_base/provider_map.rb
+++ b/app/models/package_manager/multiple_sources_base/provider_map.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module PackageManager
+  class MultipleSourcesBase < Base
+    # Given a set of prioritized ProviderInfo objects, determine the most
+    # likely upstream package repository for a package. This uses the
+    # packages' versions' repository_sources field to
+    class ProviderMap
+      # @param prioritized_provider_infos [Array(ProviderInfo)]
+      def initialize(*prioritized_provider_infos)
+        @prioritized_provider_infos = prioritized_provider_infos
+
+        raise "Need at least one provider marked default" if @prioritized_provider_infos.none?(&:default?)
+      end
+
+      # @param project [Project]
+      def providers_for(project:)
+        found_providers = project
+          .repository_sources
+          .map do |source|
+            @prioritized_provider_infos.find { |provider_info| provider_info.identifier == source }
+          end
+          .compact
+
+        if found_providers.empty?
+          unless project.repository_sources.empty?
+            # If we have removed all possible providers that a version
+            # can have, this means that every pacakge will use the
+            # default provider, which is probably not what we want.
+            # The old providers should be cleaned out of
+            # Version#repository_sources first.
+            StructuredLog.capture(
+              "PROJECT_REPOSITORY_SOURCE_PROVIDERS_MISSING",
+              {
+                project_id: project.id,
+                project_providers: project.repository_sources.join(","),
+              }
+            )
+          end
+
+          [default_provider]
+        else
+          found_providers
+        end
+      end
+
+      def default_provider
+        @prioritized_provider_infos.find(&:default?)
+      end
+
+      def best_repository_source(project:, version: nil)
+        db_version = project.find_version_or_most_recent_version(version: version)
+
+        repository_sources = db_version&.repository_sources
+
+        return default_provider unless repository_sources
+
+        best_match = @prioritized_provider_infos.find do |provider_info|
+          repository_sources.include?(provider_info.identifier)
+        end
+
+        best_match || default_provider
+      end
+    end
+  end
+end

--- a/app/models/package_manager/packagist.rb
+++ b/app/models/package_manager/packagist.rb
@@ -12,12 +12,11 @@ module PackageManager
     ENTIRE_PACKAGE_CAN_BE_DEPRECATED = true
 
     # TODO: rename PackageManager::Packagist -> PackageManager::Composer, and then  PackageManager::Packagist::Main => PackageManager::Composer::Packagist
-    PROVIDER_MAP = {
-      "default" => Main,
-      "Drupal" => Drupal,
-      "Main" => Main,
-      "Packagist" => Main,
-    }.freeze
+    PROVIDER_MAP = ProviderMap.new(
+      ProviderInfo.new(identifier: "Main", default: true, provider_class: Main),
+      ProviderInfo.new(identifier: "Packagist", provider_class: Main),
+      ProviderInfo.new(identifier: "Drupal", provider_class: Drupal)
+    )
 
     def self.formatted_name
       "Packagist"

--- a/app/models/package_manager/packagist.rb
+++ b/app/models/package_manager/packagist.rb
@@ -12,11 +12,11 @@ module PackageManager
     ENTIRE_PACKAGE_CAN_BE_DEPRECATED = true
 
     # TODO: rename PackageManager::Packagist -> PackageManager::Composer, and then  PackageManager::Packagist::Main => PackageManager::Composer::Packagist
-    PROVIDER_MAP = ProviderMap.new(
+    PROVIDER_MAP = ProviderMap.new(prioritized_provider_infos: [
       ProviderInfo.new(identifier: "Main", default: true, provider_class: Main),
       ProviderInfo.new(identifier: "Packagist", provider_class: Main),
-      ProviderInfo.new(identifier: "Drupal", provider_class: Drupal)
-    )
+      ProviderInfo.new(identifier: "Drupal", provider_class: Drupal),
+    ])
 
     def self.formatted_name
       "Packagist"

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -750,6 +750,29 @@ class Project < ApplicationRecord
     subs.reject { |sub| mutes.include?(sub.id) }
   end
 
+  # @return [Array(String)] All possible Version#repository_sources for
+  #                         this package, unordered
+  def repository_sources
+    versions
+      .flat_map(&:repository_sources)
+      .compact
+      .uniq
+  end
+
+  # @return [Version,nil] If version was provided, the specific Version or
+  #                       nil if not found. If not provided, the most
+  #                       recently created Version.
+  def find_version_or_most_recent_version(version: nil)
+    if version.nil?
+      versions.order(created_at: :desc).first
+    # Avoid a database call if we can help it.
+    elsif association(:versions).loaded? && !versions.empty?
+      versions.find { |v| v.number == version }
+    else
+      versions.find_by(number: version)
+    end
+  end
+
   private
 
   def spdx_license

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -759,14 +759,9 @@ class Project < ApplicationRecord
       .uniq
   end
 
-  # @return [Version,nil] If version was provided, the specific Version or
-  #                       nil if not found. If not provided, the most
-  #                       recently created Version.
-  def find_version_or_most_recent_version(version: nil)
-    if version.nil?
-      versions.order(created_at: :desc).first
+  def find_version(version)
     # Avoid a database call if we can help it.
-    elsif association(:versions).loaded? && !versions.empty?
+    if association(:versions).loaded? && !versions.empty?
       versions.find { |v| v.number == version }
     else
       versions.find_by(number: version)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -81,7 +81,7 @@ FactoryBot.define do
 
   factory :version do
     project
-    number { "1.0.0" }
+    sequence(:number) { |n| "#{n}.0.0" }
     published_at { 1.day.ago }
     repository_sources { nil }
   end

--- a/spec/models/package_manager/multiple_sources_base/provider_map_spec.rb
+++ b/spec/models/package_manager/multiple_sources_base/provider_map_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe PackageManager::MultipleSourcesBase::ProviderMap do
-  subject(:provider_map) { described_class.new(provider_info_one, provider_info_two) }
+  subject(:provider_map) { described_class.new(prioritized_provider_infos: [provider_info_one, provider_info_two]) }
 
   let(:provider_info_one) do
     PackageManager::MultipleSourcesBase::ProviderInfo.new(

--- a/spec/models/package_manager/multiple_sources_base/provider_map_spec.rb
+++ b/spec/models/package_manager/multiple_sources_base/provider_map_spec.rb
@@ -66,12 +66,12 @@ RSpec.describe PackageManager::MultipleSourcesBase::ProviderMap do
     end
   end
 
-  describe "#best_repository_source" do
+  describe "#preferred_provider_for_project" do
     let(:search_version) { "2.3.4" }
 
     context "with no version found" do
       it "returns default provider" do
-        expect(provider_map.best_repository_source(project: project, version: search_version)).to eq(provider_info_one)
+        expect(provider_map.preferred_provider_for_project(project: project, version: search_version)).to eq(provider_info_one)
       end
     end
 
@@ -80,7 +80,7 @@ RSpec.describe PackageManager::MultipleSourcesBase::ProviderMap do
 
       context "with no match" do
         it "returns default provider" do
-          expect(provider_map.best_repository_source(project: project, version: search_version)).to eq(provider_info_one)
+          expect(provider_map.preferred_provider_for_project(project: project, version: search_version)).to eq(provider_info_one)
         end
       end
 
@@ -88,7 +88,7 @@ RSpec.describe PackageManager::MultipleSourcesBase::ProviderMap do
         let(:repository_sources) { %w[two] }
 
         it "returns found provider" do
-          expect(provider_map.best_repository_source(project: project, version: search_version)).to eq(provider_info_two)
+          expect(provider_map.preferred_provider_for_project(project: project, version: search_version)).to eq(provider_info_two)
         end
       end
     end

--- a/spec/models/package_manager/multiple_sources_base/provider_map_spec.rb
+++ b/spec/models/package_manager/multiple_sources_base/provider_map_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PackageManager::MultipleSourcesBase::ProviderMap do
+  subject(:provider_map) { described_class.new(provider_info_one, provider_info_two) }
+
+  let(:provider_info_one) do
+    PackageManager::MultipleSourcesBase::ProviderInfo.new(
+      identifier: "one",
+      default: true,
+      provider_class: :one
+    )
+  end
+
+  let(:provider_info_two) do
+    PackageManager::MultipleSourcesBase::ProviderInfo.new(
+      identifier: "two",
+      provider_class: :two
+    )
+  end
+
+  let(:project) { create(:project) }
+  let(:repository_sources) { [] }
+
+  let!(:version) { create(:version, project: project, repository_sources: repository_sources) }
+
+  before do
+    # Unfortunately there's some interaction between Project, Version, and
+    # their hooks that cause the project's versions association to be cached
+    # with no versions. Force-reload the project so the above created
+    # versions can be found.
+    project.reload
+  end
+
+  describe "#providers_for" do
+    context "with no repository sources" do
+      it "returns default provider" do
+        expect(provider_map.providers_for(project: project)).to eq([provider_info_one])
+      end
+    end
+
+    # This is a not-great situation so we need to log it
+    context "with bad repository sources" do
+      let(:repository_sources) { %w[wow cool] }
+
+      before do
+        allow(StructuredLog).to receive(:capture)
+          .with("PROJECT_REPOSITORY_SOURCE_PROVIDERS_MISSING", { project_id: project.id, project_providers: "wow,cool" })
+      end
+
+      it "returns default provider" do
+        expect(provider_map.providers_for(project: project)).to eq([provider_info_one])
+
+        expect(StructuredLog).to have_received(:capture)
+          .with("PROJECT_REPOSITORY_SOURCE_PROVIDERS_MISSING", { project_id: project.id, project_providers: "wow,cool" })
+      end
+    end
+
+    context "with one repository source known, one unknown" do
+      let(:repository_sources) { %w[two three] }
+
+      it "returns found provider" do
+        expect(provider_map.providers_for(project: project)).to eq([provider_info_two])
+      end
+    end
+  end
+
+  describe "#best_repository_source" do
+    let(:search_version) { "2.3.4" }
+
+    context "with no version found" do
+      it "returns default provider" do
+        expect(provider_map.best_repository_source(project: project, version: search_version)).to eq(provider_info_one)
+      end
+    end
+
+    context "with version found" do
+      let(:search_version) { version.number }
+
+      context "with no match" do
+        it "returns default provider" do
+          expect(provider_map.best_repository_source(project: project, version: search_version)).to eq(provider_info_one)
+        end
+      end
+
+      context "with match" do
+        let(:repository_sources) { %w[two] }
+
+        it "returns found provider" do
+          expect(provider_map.best_repository_source(project: project, version: search_version)).to eq(provider_info_two)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -483,7 +483,7 @@ describe Project, type: :model do
     end
   end
 
-  describe "#find_version_or_most_recent_version" do
+  describe "#find_version" do
     subject(:project) { create(:project) }
 
     let(:version) { nil }
@@ -491,7 +491,7 @@ describe Project, type: :model do
     context "without associated versions" do
       context "with nil version" do
         it "returns nil" do
-          expect(project.find_version_or_most_recent_version(version: version)).to be(nil)
+          expect(project.find_version(version)).to be(nil)
         end
       end
 
@@ -499,7 +499,7 @@ describe Project, type: :model do
         let(:version) { "1.2.3" }
 
         it "returns nil" do
-          expect(project.find_version_or_most_recent_version(version: "1.2.3")).to be(nil)
+          expect(project.find_version("1.2.3")).to be(nil)
         end
       end
     end
@@ -512,8 +512,8 @@ describe Project, type: :model do
 
       context "without association loaded" do
         context "with nil version" do
-          it "returns the most recently created version" do
-            expect(project.find_version_or_most_recent_version(version: version)).to eq(version_two)
+          it "returns nil" do
+            expect(project.find_version(version)).to be(nil)
           end
         end
 
@@ -522,7 +522,7 @@ describe Project, type: :model do
 
           it "returns the found version" do
             result = nil
-            expect { result = project.find_version_or_most_recent_version(version: version) }.to make_database_queries(count: 1)
+            expect { result = project.find_version(version) }.to make_database_queries(count: 1)
 
             expect(result).to eq(version_one)
           end
@@ -540,7 +540,7 @@ describe Project, type: :model do
 
         it "returns the found version" do
           result = nil
-          expect { result = project.find_version_or_most_recent_version(version: version) }.not_to make_database_queries
+          expect { result = project.find_version(version) }.not_to make_database_queries
 
           expect(result).to eq(version_one)
         end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -20,7 +20,7 @@ describe Project, type: :model do
   it { should validate_presence_of(:name) }
   it { should validate_presence_of(:platform) }
 
-  describe "license normalization" do
+  describe "#normalize_licenses" do
     let(:project) { create(:project, name: "foo", platform: PackageManager::Rubygems) }
 
     it "handles a single license" do
@@ -123,7 +123,7 @@ describe Project, type: :model do
     end
   end
 
-  describe "reformat_urls" do
+  describe "#reformat_repository_url" do
     let!(:project) { create(:project) }
 
     it "should save the updated format URL" do
@@ -135,7 +135,7 @@ describe Project, type: :model do
     end
   end
 
-  describe ".find_best!(platform, name, includes=[])" do
+  describe ".find_best!" do
     context "with an exact match" do
       it "returns the record" do
         project = create(:project, name: "Django")
@@ -160,7 +160,7 @@ describe Project, type: :model do
     end
   end
 
-  describe ".find_best(platform, name, includes=[])" do
+  describe ".find_best" do
     context "with a match" do
       it "returns the record" do
         project = create(:project, name: "Django")
@@ -325,7 +325,8 @@ describe Project, type: :model do
       expect(DeletedProject.count).to eq(0)
     end
   end
-  context "project_mailing_list" do
+
+  describe "#mailing_list" do
     let(:repository) { create(:repository) }
     let(:project) { create(:project, repository: repository) }
 
@@ -361,7 +362,7 @@ describe Project, type: :model do
     end
   end
 
-  describe "latest_release" do
+  describe "#latest_release" do
     let!(:project) { create(:project) }
     let!(:newer_release) { create(:version, project: project, number: "2.0.0", published_at: 1.month.ago, id: 1000, created_at: 1.year.ago) }
     let!(:older_release) { create(:version, project: project, number: "1.0.0", published_at: 1.year.ago, id: 2000, created_at: 1.month.ago) }
@@ -403,7 +404,7 @@ describe Project, type: :model do
     end
   end
 
-  describe "manual_sync" do
+  describe "#manual_sync" do
     let!(:project) { create(:project, platform: "Rubygems", name: "my_gem") }
 
     before { allow(PackageManagerDownloadWorker).to receive(:perform_async) }
@@ -422,7 +423,7 @@ describe Project, type: :model do
     end
   end
 
-  describe "::platform" do
+  describe ".platform" do
     subject(:scoped_collection) { described_class.platform(given_platforms) }
 
     let!(:ruby1) { create(:project, :rubygems) }
@@ -458,6 +459,91 @@ describe Project, type: :model do
 
       it "can match any" do
         expect(scoped_collection).to match_array([ruby1, ruby2, npm1])
+      end
+    end
+  end
+
+  describe "#repository_sources" do
+    subject(:project) { create(:project) }
+
+    let!(:version_one) { create(:version, project: project, repository_sources: %w[a b]) }
+    let!(:version_two) { create(:version, project: project, repository_sources: %w[b c]) }
+    let!(:version_three) { create(:version, project: project, repository_sources: [nil, "d"]) }
+
+    before do
+      # Unfortunately there's some interaction between Project, Version, and
+      # their hooks that cause the project's versions association to be cached
+      # with no versions. Force-reload the project so the above created
+      # versions can be found.
+      project.reload
+    end
+
+    it "returns repository sources" do
+      expect(project.repository_sources).to contain_exactly("a", "b", "c", "d")
+    end
+  end
+
+  describe "#find_version_or_most_recent_version" do
+    subject(:project) { create(:project) }
+
+    let(:version) { nil }
+
+    context "without associated versions" do
+      context "with nil version" do
+        it "returns nil" do
+          expect(project.find_version_or_most_recent_version(version: version)).to be(nil)
+        end
+      end
+
+      context "with specified missing version" do
+        let(:version) { "1.2.3" }
+
+        it "returns nil" do
+          expect(project.find_version_or_most_recent_version(version: "1.2.3")).to be(nil)
+        end
+      end
+    end
+
+    context "with associated versions" do
+      let(:target_found_version) { "1.0.0" }
+
+      let!(:version_one) { create(:version, number: target_found_version, project: project, created_at: 1.day.ago) }
+      let!(:version_two) { create(:version, number: "2.0.0", project: project, created_at: 1.hour.ago) }
+
+      context "without association loaded" do
+        context "with nil version" do
+          it "returns the most recently created version" do
+            expect(project.find_version_or_most_recent_version(version: version)).to eq(version_two)
+          end
+        end
+
+        context "with specific version" do
+          let(:version) { target_found_version }
+
+          it "returns the found version" do
+            result = nil
+            expect { result = project.find_version_or_most_recent_version(version: version) }.to make_database_queries(count: 1)
+
+            expect(result).to eq(version_one)
+          end
+        end
+      end
+
+      context "with association loaded and specific version" do
+        let(:version) { target_found_version }
+
+        before do
+          # Clear out the old association data, then cache the new data
+          project.reload
+          ActiveRecord::Associations::Preloader.new(records: [project], associations: :versions).call
+        end
+
+        it "returns the found version" do
+          result = nil
+          expect { result = project.find_version_or_most_recent_version(version: version) }.not_to make_database_queries
+
+          expect(result).to eq(version_one)
+        end
       end
     end
   end


### PR DESCRIPTION
The Provider Maps are used to match Version#repository_sources to PackageManager classes for packages in ecosystems where multiple package providers exist. The original system was very lax in selecting the most appropriate provider, especially when multiple were involved.

Theoretically, a package should only be found at one provider, but in the case of Maven packages, this turned out to not be the case -- providers like Hortonworks and Atlassian provided their own versions of packages that also existed in Maven Central. We stopped examining Maven repos others than Google Maven and Maven Central, but unfortunately, some packages still present as belonging to these other less-supported repos.

The true fix for this is to remove any references to the old Maven repo in repository_sources, but that still left in place a Provider Map system that would break again in the case where a provider was added, then removed. This would cause events like a package being marked as removed happening because an old provider was checked and the URL 404'd.s This new code:

* structures the Provider Map system in a more structured, prioritized way
* adds checks to ensure if the data or Provider Map get into bad states, we are notified of it sooner
* centralizes more logic related to building package related URLs
