### PR TITLE
Better error for POM file parsing error

### DIFF
--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -215,7 +215,7 @@ module PackageManager
       raise POMNotFound, url if pom_request.status == 404
 
       xml = Ox.parse(pom_request.body)
-      raise POMParseError, url unless xml
+      raise POMParseError, url if xml.nil?
 
       published_at = pom_request.headers["Last-Modified"]
       pat = Ox::Element.new("publishedAt")

--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -37,6 +37,15 @@ module PackageManager
       end
     end
 
+    class POMParseError < StandardError
+      attr_reader :url
+
+      def initialize(url)
+        @url = url
+        super("Unable to parse POM: #{@url}")
+      end
+    end
+
     def self.repository_base
       PROVIDER_MAP.default_provider.provider_class.repository_base
     end
@@ -206,6 +215,8 @@ module PackageManager
       raise POMNotFound, url if pom_request.status == 404
 
       xml = Ox.parse(pom_request.body)
+      raise POMParseError, url unless xml
+
       published_at = pom_request.headers["Last-Modified"]
       pat = Ox::Element.new("publishedAt")
       pat << published_at

--- a/spec/models/package_manager/maven_spec.rb
+++ b/spec/models/package_manager/maven_spec.rb
@@ -258,6 +258,23 @@ describe PackageManager::Maven do
     end
   end
 
+  describe ".download_pom" do
+    context "with an empty body" do
+      before do
+        stub_request(
+          :get,
+          "https://repo1.maven.org/maven2/group_id/artifact_id/version/artifact_id-version.pom"
+        ).to_return(body: nil, headers: { "Last-Modified" => Time.now })
+      end
+
+      it "raises POMParseError" do
+        expect do
+          described_class.download_pom("group_id", "artifact_id", "version")
+        end.to raise_error(described_class::POMParseError)
+      end
+    end
+  end
+
   describe ".licenses(xml)" do
     context "with licences in the XML" do
       it "returns those licenses" do


### PR DESCRIPTION
It's possible for Ox.parse to return nil when parsing. If that happens, raise a better error than `nil doesn't respond to <<`.