### PR TITLE
Ensure that Go hostnames are even valid when Libraries looks them up.

### DIFF
--- a/app/models/package_manager/go.rb
+++ b/app/models/package_manager/go.rb
@@ -6,6 +6,7 @@ module PackageManager
     HAS_DEPENDENCIES = true
     BIBLIOTHECARY_SUPPORT = true
     COLOR = "#375eab"
+    VALID_HOST = /\./.freeze
     KNOWN_HOSTS = [
       "bitbucket.org",
       "github.com",
@@ -231,6 +232,7 @@ module PackageManager
 
     # https://golang.org/cmd/go/#hdr-Import_path_syntax
     def self.project_find_names(name)
+      return [name] unless name.match?(VALID_HOST)
       return [name] if name.start_with?(*KNOWN_HOSTS)
       return [name] if name.start_with?(*SKIP_HOSTS)
       return [name] if KNOWN_VCS.any?(&name.method(:include?))

--- a/spec/models/package_manager/go_spec.rb
+++ b/spec/models/package_manager/go_spec.rb
@@ -344,6 +344,16 @@ describe PackageManager::Go do
       end
     end
 
+    context "for invalid hostnames" do
+      it "returns the name without calling the host" do
+        name = "not-even-a-legit-hostname"
+        allow(described_class).to receive(:get_html)
+
+        expect(described_class.project_find_names(name)).to eq([name])
+        expect(described_class).to_not have_received(:get_html)
+      end
+    end
+
     context "for names with a known vcs" do
       it "returns the name" do
         name = "example.org/user/foo.hg"


### PR DESCRIPTION
* `PackageManager::Go.project_find_names()`: avoid the case of an invalid Go Module from even being looked up 