### PR TITLE
Update bibliothecary to get new go.mod "replace" directive parsing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby "2.7.8"
 gem "active_model_serializers"
 gem "api-pagination"
 gem "asciidoctor"
-gem "bibliothecary", ">= 8.6.2"
+gem "bibliothecary", ">= 8.7.6"
 gem "bitbucket_rest_api", git: "https://github.com/librariesio/bitbucket"
 gem "bootsnap", require: false
 gem "bootstrap-sass"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
     autoprefixer-rails (9.5.1.1)
       execjs
     base64 (0.1.1)
-    bibliothecary (8.6.5)
+    bibliothecary (8.7.6)
       commander
       deb_control
       librariesio-gem-parser
@@ -638,14 +638,14 @@ GEM
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
-    typhoeus (1.4.0)
+    typhoeus (1.4.1)
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (2.4.2)
+    unicode-display_width (2.5.0)
     unicode_utils (1.4.0)
     vcr (6.2.0)
     version_gem (1.1.3)
@@ -672,7 +672,7 @@ DEPENDENCIES
   annotate
   api-pagination
   asciidoctor
-  bibliothecary (>= 8.6.2)
+  bibliothecary (>= 8.7.6)
   bitbucket_rest_api!
   bootsnap
   bootstrap-sass

--- a/app/models/package_manager/go/go_mod.rb
+++ b/app/models/package_manager/go/go_mod.rb
@@ -7,6 +7,7 @@ class PackageManager::Go
     RETRACT_WITH_PARENS = /^\s*retract\s\((.*?)\)/m.freeze
     RETRACT_WITHOUT_PARENS = /retract\s(.+)/.freeze
     MODULE_REGEX = /module\s+(.+)/.freeze
+    LOCAL_FILEPATH_REGEXP = /\.?\.\//.freeze
 
     def initialize(mod_contents)
       @mod_contents = mod_contents
@@ -51,6 +52,7 @@ class PackageManager::Go
 
     def dependencies
       Bibliothecary::Parsers::Go.parse_go_mod(mod_contents)
+        .reject { |dep| dep[:name].match?(LOCAL_FILEPATH_REGEXP) }
         .map do |dep|
           {
             # Note that Go "replace" directives would result in :original_requirement and :original_name keys being included

--- a/app/models/package_manager/go/go_mod.rb
+++ b/app/models/package_manager/go/go_mod.rb
@@ -53,6 +53,8 @@ class PackageManager::Go
       Bibliothecary::Parsers::Go.parse_go_mod(mod_contents)
         .map do |dep|
           {
+            # Note that Go "replace" directives would result in :original_requirement and :original_name keys being included
+            # here too, but Libraries does not need those (yet?)
             project_name: dep[:name],
             requirements: dep[:requirement],
             kind: dep[:type],

--- a/spec/models/package_manager/go/go_mod_spec.rb
+++ b/spec/models/package_manager/go/go_mod_spec.rb
@@ -6,6 +6,22 @@ RSpec.describe PackageManager::Go::GoMod do
   subject(:go_mod) { described_class.new(mod_contents) }
   let(:mod_contents) { "" }
 
+  describe "replaced versions" do
+    let(:mod_contents) do
+      <<~MODFILE
+        require github.com/go-check/check v1.0.0
+        replace github.com/go-check/check v1.0.0 => github.com/go-check/check v4.0.0
+      MODFILE
+    end
+
+    it "detects replaced version" do
+      # Note that this happens in bibliothecary
+      expect(go_mod.dependencies).to eq([
+        { kind: "runtime", platform: "Go", project_name: "github.com/go-check/check", requirements: "v4.0.0" },
+      ])
+    end
+  end
+
   describe "#retracted_version_ranges" do
     context "when empty" do
       it "has no retracted versions" do

--- a/spec/models/package_manager/go/go_mod_spec.rb
+++ b/spec/models/package_manager/go/go_mod_spec.rb
@@ -6,19 +6,37 @@ RSpec.describe PackageManager::Go::GoMod do
   subject(:go_mod) { described_class.new(mod_contents) }
   let(:mod_contents) { "" }
 
-  describe "replaced versions" do
-    let(:mod_contents) do
-      <<~MODFILE
-        require github.com/go-check/check v1.0.0
-        replace github.com/go-check/check v1.0.0 => github.com/go-check/check v4.0.0
-      MODFILE
+  describe "#dependencies" do
+    context "with replaced versions" do
+      let(:mod_contents) do
+        <<~MODFILE
+          require github.com/go-check/check v1.0.0
+          replace github.com/go-check/check v1.0.0 => github.com/go-check/check v4.0.0
+        MODFILE
+      end
+
+      it "detects replaced version" do
+        # Note that this happens in bibliothecary
+        expect(go_mod.dependencies).to eq([
+          { kind: "runtime", platform: "Go", project_name: "github.com/go-check/check", requirements: "v4.0.0" },
+        ])
+      end
     end
 
-    it "detects replaced version" do
-      # Note that this happens in bibliothecary
-      expect(go_mod.dependencies).to eq([
-        { kind: "runtime", platform: "Go", project_name: "github.com/go-check/check", requirements: "v4.0.0" },
-      ])
+    context "with local package names" do
+      let(:mod_contents) do
+        <<~MODFILE
+          require some.legit/package v1.0.0
+          require ./some-absolute-local/package v1.0.0
+          require ../some-relative-local/package v1.0.0
+        MODFILE
+      end
+
+      it "omits any absolute or relative local package names" do
+        expect(go_mod.dependencies).to eq([
+          { kind: "runtime", platform: "Go", project_name: "some.legit/package", requirements: "v1.0.0" },
+        ])
+      end
     end
   end
 


### PR DESCRIPTION
* update `bibliothecary` to the newest version to get parsing support for the `replace` directive in go.mod (https://github.com/librariesio/bibliothecary/pull/585)
* adds a regression test for `replace` directive
* also, don't return local filepaths from `PackageManager::Go::GoMod#dependencies` bc Libraries has no need for them

this should prevent Libraries from seeing something like [this go.mod](https://github.com/netleapio/zappy-framework/blob/37b2a6ca97823b348a4a6ba7a365f811c891b384/go.mod) and trying to fetch `https://tinygo.org/x/tinyfont =>?go-get=1` as a url in `PackageManager::Go.package_find_names()`