### PR TITLE
Stop Removing Go Pseudo Versions

### DIFF
--- a/app/models/package_manager/go.rb
+++ b/app/models/package_manager/go.rb
@@ -35,7 +35,7 @@ module PackageManager
     end
 
     def self.missing_version_remover
-      PackageManager::Base::MissingVersionRemover
+      PackageManager::Go::GoMissingVersionRemover
     end
 
     def self.check_status_url(db_project)

--- a/app/models/package_manager/go/go_missing_version_remover.rb
+++ b/app/models/package_manager/go/go_missing_version_remover.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module PackageManager
+  class Go
+    class GoMissingVersionRemover
+      # should match the same regex that Golang uses to identify pseudo version numbers
+      # https://github.com/golang/mod/blob/master/module/pseudo.go#L47C39-L47C135
+      PSEUDO_VERSION_REGEX = /^v[0-9]+\.(0\.0-|\d+\.\d+-([^+]*\.)?0\.)\d{14}-[A-Za-z0-9]+(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$/.freeze
+
+      def initialize(
+        project:,
+        version_numbers_to_keep:,
+        target_status:,
+        removal_time:
+      )
+        @project = project
+        @version_numbers_to_keep = version_numbers_to_keep
+        @target_status = target_status
+        @removal_time = removal_time
+      end
+
+      def remove_missing_versions_of_project!
+        version_numbers = @project.versions.map(&:number)
+
+        # Do not consider pseudo version numbers for removal.
+        # Our upstream data sources are not consistent with what pseudo versions are returned.
+        # If we have seen a pseudo version for a Go module then it was valid at some point and
+        # should still be valid going forward.
+        # More information on pseudo versions: https://go.dev/ref/mod#pseudo-versions
+        non_pseudo_version_numbers = version_numbers.grep_v(PSEUDO_VERSION_REGEX)
+
+        versions_to_remove = non_pseudo_version_numbers - @version_numbers_to_keep
+
+        @project
+          .versions
+          .where(number: versions_to_remove)
+          .where("status != ? or status is null", @target_status)
+          .update_all(status: @target_status, updated_at: @removal_time)
+      end
+    end
+  end
+end

--- a/spec/models/package_manager/go/go_missing_version_remover_spec.rb
+++ b/spec/models/package_manager/go/go_missing_version_remover_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe PackageManager::Go::GoMissingVersionRemover do
+  describe "#remove_missing_versions_of_project!" do
+    let(:db_project) { Project.create(platform: "Go", name: project_name) }
+    let(:project_name) { "name" }
+
+    let(:version_to_keep_status) { nil }
+    let!(:version_to_keep) { db_project.versions.create(number: "1.0.0", status: version_to_keep_status, updated_at: original_time) }
+
+    let(:version_to_remove_status) { nil }
+    let!(:version_to_remove) { db_project.versions.create(number: "2.0.0", status: version_to_remove_status, updated_at: original_time) }
+
+    let(:version_already_removed_status) { "Removed" }
+    let!(:version_already_removed) { db_project.versions.create(number: "3.0.0", status: version_already_removed_status, updated_at: original_time) }
+
+    let(:version_in_another_state_status) { "Deprecated" }
+    let!(:version_in_another_state) { db_project.versions.create(number: "4.0.0", status: version_in_another_state_status, updated_at: original_time) }
+
+    let(:pseudo_version_status) { nil }
+    let!(:pseudo_version) { db_project.versions.create(number: "v0.0.0-20221208032759-85de2813cf6b", status: pseudo_version_status, updated_at: original_time) }
+
+    let(:original_time) { Time.zone.parse("2010-01-01 10:00:00") }
+    let(:removal_time) { Time.zone.parse("2020-01-01 10:00:00") }
+
+    let(:versions_to_keep) { ["1.0.0"] }
+
+    let(:remover) do
+      described_class.new(
+        project: db_project,
+        version_numbers_to_keep: versions_to_keep,
+        target_status: "Removed",
+        removal_time: removal_time
+      )
+    end
+
+    it "changes the missing releases to the indicated statuses" do
+      remover.remove_missing_versions_of_project!
+
+      version_to_keep.reload
+      version_to_remove.reload
+      version_already_removed.reload
+      version_in_another_state.reload
+
+      expect(version_to_keep.status).to eq(nil)
+      expect(version_to_keep.updated_at).to eq(original_time)
+
+      expect(version_to_remove.status).to eq("Removed")
+      expect(version_to_remove.updated_at).to eq(removal_time)
+
+      expect(version_already_removed.status).to eq("Removed")
+      expect(version_already_removed.updated_at).to eq(original_time)
+
+      expect(version_in_another_state.status).to eq("Removed")
+      expect(version_in_another_state.updated_at).to eq(removal_time)
+
+      expect(pseudo_version.status).to be_nil
+      expect(pseudo_version.updated_at).to eq(original_time)
+    end
+
+    context "with no versions to remove" do
+      let(:versions_to_keep) { ["1.0.0", "2.0.0", "3.0.0", "4.0.0"] }
+
+      it "changes nothing" do
+        remover.remove_missing_versions_of_project!
+
+        version_to_keep.reload
+        version_to_remove.reload
+        version_already_removed.reload
+        version_in_another_state.reload
+
+        expect(version_to_keep.status).to eq(nil)
+        expect(version_to_keep.updated_at).to eq(original_time)
+
+        expect(version_to_remove.status).to eq(nil)
+        expect(version_to_remove.updated_at).to eq(original_time)
+
+        expect(version_already_removed.status).to eq("Removed")
+        expect(version_already_removed.updated_at).to eq(original_time)
+
+        expect(version_in_another_state.status).to eq("Deprecated")
+        expect(version_in_another_state.updated_at).to eq(original_time)
+
+        expect(pseudo_version.status).to be_nil
+        expect(pseudo_version.updated_at).to eq(original_time)
+      end
+    end
+
+    context "with all versions in target state" do
+      let(:version_to_keep_status) { "Removed" }
+      let(:version_to_remove_status) { "Removed" }
+      let(:version_in_another_state_status) { "Removed" }
+
+      it "changes nothing" do
+        remover.remove_missing_versions_of_project!
+
+        version_to_keep.reload
+        version_to_remove.reload
+        version_already_removed.reload
+        version_in_another_state.reload
+        pseudo_version.reload
+
+        expect(version_to_keep.status).to eq("Removed")
+        expect(version_to_keep.updated_at).to eq(original_time)
+
+        expect(version_to_remove.status).to eq("Removed")
+        expect(version_to_remove.updated_at).to eq(original_time)
+
+        expect(version_already_removed.status).to eq("Removed")
+        expect(version_already_removed.updated_at).to eq(original_time)
+
+        expect(version_in_another_state.status).to eq("Removed")
+        expect(version_in_another_state.updated_at).to eq(original_time)
+
+        expect(pseudo_version.status).to be_nil
+        expect(pseudo_version.updated_at).to eq(original_time)
+      end
+    end
+  end
+end

--- a/spec/models/package_manager/go_spec.rb
+++ b/spec/models/package_manager/go_spec.rb
@@ -412,10 +412,12 @@ describe PackageManager::Go do
     let(:version_number_to_remove) { "1.0.1" }
     let(:old_updated_at) { 5.years.ago.round }
     let(:version_to_remove_status) { nil }
+    let!(:version_to_not_remove) { create(:version, project: project, number: version_number_to_not_remove, updated_at: old_updated_at) }
     let!(:version_to_remove) { create(:version, project: project, number: version_number_to_remove, updated_at: old_updated_at, status: version_to_remove_status) }
 
     before do
-      project.versions.create!(number: version_number_to_not_remove, updated_at: old_updated_at)
+      # doesn't seem like the project has any version info unless it is reloaded explicitly
+      project.versions.reload
     end
 
     it "should mark missing versions as Removed" do


### PR DESCRIPTION
This changes the version remove logic for Go to not mark not found pseudo versions as removed. My rationale is that the upstream Go data sources are not very consistent with storing pseudo version information, but if we have seen a pseudo version previously then it should be considered valid since it is a combination of the module version, git commit date, and git commit hash that existed at some point. More info at https://go.dev/ref/mod#pseudo-versions. I think in order for a version like this to be removed and unreachable then the git history of the project would need to have been rewritten, but feel free to correct me on these assumptions. There will need to be follow up PRs/work to restore pseudo versions which have been marked as removed.

For testing I have added some data to the specs to check that the status is not touched for pseudo versions and have tested with a few packages locally by running a `PackageManager::Go.update()` on them with extra pseudo versions in my database.