### PR TITLE
NPM: change deprecation logic to only require latest non-prerelease to be deprecated

### DIFF
--- a/spec/models/package_manager/npm_spec.rb
+++ b/spec/models/package_manager/npm_spec.rb
@@ -41,12 +41,40 @@ describe PackageManager::NPM do
       expect(PackageManager::NPM).to receive(:project).with("foo").and_return({ "versions" => version_data })
     end
 
-    context "any version isn't deprecated" do
+    context "latest version isn't deprecated" do
       let(:version_data) do
         {
-          "0.0.1" => { "deprecated" => "This package is deprecated" },
-          "0.0.2" => { "deprecated" => "This package is deprecated" },
-          "0.0.3" => {},
+          "0.0.1" => { "version" => "0.0.1", "deprecated" => "This package is deprecated" },
+          "0.0.2" => { "version" => "0.0.2", "deprecated" => "This package is deprecated" },
+          "0.0.3" => { "version" => "0.0.3" },
+        }
+      end
+
+      it "project not considered deprecated" do
+        expect(deprecation_info).to eq({ is_deprecated: false, message: nil })
+      end
+    end
+
+    context "latest version is deprecated" do
+      let(:version_data) do
+        {
+          "0.0.1" => { "version" => "0.0.1", "deprecated" => "This package is deprecated" },
+          "0.0.2" => { "version" => "0.0.2", "deprecated" => "This package is deprecated" },
+          "0.0.3" => { "version" => "0.0.3" },
+        }
+      end
+
+      it "project not considered deprecated" do
+        expect(deprecation_info).to eq({ is_deprecated: false, message: nil })
+      end
+    end
+
+    context "latest version is a prerelease and deprecated" do
+      let(:version_data) do
+        {
+          "0.0.1" => { "version" => "0.0.1" },
+          "0.0.2" => { "version" => "0.0.2" },
+          "0.0.3" => { "version" => "0.0.3-canary-release-01234", "deprecated" => "This release is a canary release" },
         }
       end
 
@@ -58,9 +86,9 @@ describe PackageManager::NPM do
     context "all versions deprecated" do
       let(:version_data) do
         {
-          "0.0.1" => { "deprecated" => "This package is deprecated" },
-          "0.0.2" => { "deprecated" => "This package is deprecated" },
-          "0.0.3" => { "deprecated" => "This package is deprecated" },
+          "0.0.1" => { "version" => "0.0.1", "deprecated" => "This package is deprecated" },
+          "0.0.2" => { "version" => "0.0.2", "deprecated" => "This package is deprecated" },
+          "0.0.3" => { "version" => "0.0.3", "deprecated" => "This package is deprecated" },
         }
       end
 


### PR DESCRIPTION
These changes tweak the behavior of NPM deprecation detection again:

### Background

####  pre-March 2023

we marked an NPM package as "Deprecated" if the latest-release had a "deprecation" message in the API.

#### March 2023

we [changed the logic](https://github.com/librariesio/libraries.io/pull/3053) to require *all releases* to have a "deprecation" message for the package to be marked as "Deprecated". This was for two reasons:
  * we were marking packages like [graphql](https://www.npmjs.com/package/graphql?activeTab=versions) as "Deprecated" because they publish frequent canary builds that are marked with a "deprecation" message. Whenever the latest release was a deprecated canary build and Libraries marked it "Deprecated", this gave the illusion that the package was deprecated even though it was very active.  
  * and also the `npm deprecate "This package is deprecated..."` command will deprecate all the releases for a package, implying that NPM's philosophy is that "all releases deprecated == the package is deprecated"

#### Mar 2024 

in this PR, we go back to the latest-release only for detection, but we ignore any version that's a prerelease, to handle the case of "graphql" where the latest version may be a deprecated prerelease. 

### Why?

despite the aforementioned `npm deprecate` logic, there's conflicting behavior on npmjs.com where a package page will be display as deprecated if the latest non-prerelease release is deprecated, even if the older releases aren't deprecated. For example, `@types/faker`:

https://www.npmjs.com/package/@types/faker
<img width="1422" alt="Screenshot 2024-03-19 at 5 39 49 PM" src="https://github.com/librariesio/libraries.io/assets/5054/228fa281-2519-475a-83f3-18e83b520fb2">
<img width="870" alt="Screenshot 2024-03-19 at 5 39 57 PM" src="https://github.com/librariesio/libraries.io/assets/5054/c8c38a97-dfb1-44e0-85e6-cbbbffc67923">

since there's not a first-class "deprecation" for packages in NPM, we have to pick a side, and users who visit NPM will think that this example means that the package is deprecated. If Libraries doesn't mark the package as deprecated, this will lead to more confusion.