### PR TITLE
Add Repository Status Logic to Create Function

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -325,6 +325,7 @@ class Repository < ApplicationRecord
       g.license = repo_hash[:license][:key] if repo_hash[:license]
       g.source_name = (repo_hash[:parent][:full_name] if repo_hash[:fork] && repo_hash[:parent])
 
+      g.status = g.correct_status_from_upstream(archived_upstream: repo_hash[:archived])
       g.assign_attributes repo_hash.slice(*Repository::API_FIELDS)
 
       if g.changed?


### PR DESCRIPTION
Project updates call the create function instead of update so Repository statuses were not being set correctly on Project updates and a full update would only run if any Repository details changed. This PR adds the Repository status method call into the create function so statuses would be set correctly on a Project update.