### PR TITLE
Re-add rate-limit headers back to non-rate-limited responses.

### DIFF
--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -5,10 +5,12 @@ class Api::ApplicationController < ApplicationController
   before_action :check_api_key
   before_action :add_rate_limit_headers
 
+  RACK_ATTACK_THROTTLE_KEY = "rack.attack.throttle_data"
+
   private
 
   def add_rate_limit_headers
-    throttle_data = request.env["rack.attack.throttle_data"]
+    throttle_data = request.env[RACK_ATTACK_THROTTLE_KEY]
       &.values
       &.min_by { |t| t[:limit] - t[:count] }
     return unless throttle_data

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -17,11 +17,11 @@ class Api::ApplicationController < ApplicationController
 
     now = throttle_data[:epoch_time]
 
-    headers["X-RateLimit-Limit"]     = throttle_data[:limit].to_s
+    headers["X-RateLimit-Limit"] = throttle_data[:limit].to_s
     headers["X-RateLimit-Remaining"] = (throttle_data[:limit] - throttle_data[:count]).to_s
     # "A response that includes the RateLimit-Limit header field MUST also include the RateLimit-Reset."
     # (from the IETF draft https://www.ietf.org/archive/id/draft-ietf-httpapi-ratelimit-headers-07.html#section-4)
-    headers["X-RateLimit-Reset"]     = (throttle_data[:period] - (now % throttle_data[:period])).to_s
+    headers["X-RateLimit-Reset"] = (throttle_data[:period] - (now % throttle_data[:period])).to_s
   end
 
   def disabled_in_read_only

--- a/lib/subscribers/rack_attack.rb
+++ b/lib/subscribers/rack_attack.rb
@@ -14,7 +14,7 @@ ActiveSupport::Notifications.subscribe(/rack_attack/) do |_name, _start, _finish
 
   Rails.logger.info "[RACK_ATTACK] " \
                     "method=#{req.request_method} " \
-                    "path=#{req.fullpath} " \
+                    "path=#{req.path} " \
                     "match_type=#{match_type} " \
                     "match=#{match} " \
                     "match_discriminator=#{match_discriminator} " \

--- a/spec/requests/api/application_spec.rb
+++ b/spec/requests/api/application_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Api::ApplicationController", type: :request do
+  describe "an arbitrary API request" do
+    let!(:user) { create(:user, :internal) }
+
+    context "when not rate-limited" do
+      before { ApiKey.first.update(rate_limit: 12345) }
+
+      # These are set in Api::ApplicationController
+      it "includes rate limit headers" do
+        get "/api/versions", params: { since: 1.day.ago, api_key: user.api_key }
+
+        expect(response).to have_http_status(:success)
+        expect(response.headers["X-RateLimit-Limit"]).to eq("12345")
+        expect(response.headers["X-RateLimit-Remaining"]).to eq("12344")
+        expect(response.headers["X-RateLimit-Reset"]).to match(/\d+/)
+      end
+    end
+
+    context "when rate-limited" do
+      before { ApiKey.first.update(rate_limit: 0) }
+
+      # These are set in Rack::Attack's throttled_responder
+      it "includes rate limit headers" do
+        get "/api/versions", params: { since: 1.day.ago, api_key: user.api_key }
+
+        expect(response).to have_http_status(:too_many_requests)
+        expect(response.headers["X-RateLimit-Limit"]).to eq("0")
+        expect(response.headers["X-RateLimit-Remaining"]).to eq("0")
+        expect(response.headers["X-RateLimit-Reset"]).to match(/\d+/)
+        expect(response.headers["Retry-After"]).to eq(response.headers["X-RateLimit-Reset"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
before https://github.com/librariesio/libraries.io/pull/3277 , we served `X-RateLimit-Limit` and `X-RateLimit-Remaining` headers in non-rate-limited responses to transmit info about rate-limiting to clients.

after https://github.com/librariesio/libraries.io/pull/3277 , those successful response headers were removed, and we added `RateLimit-Limit`, `RateLimit-Remaining`, and `RateLimit-Reset` headers to non-rate-limited responses, so unfortunately clients could no longer track their usage in successful responses.

these changes bring back the former non-rate-limited headers, and also prefix the rate-limited headers with `X-` since those headers are not quite a standard yet, at time of writing: https://www.ietf.org/archive/id/draft-ietf-httpapi-ratelimit-headers-07.html .
 
### Example:

```
# Non-rate-limited API response
HTTP/1.1 200 OK
...
X-RateLimit-Limit: 60
X-RateLimit-Remaining: 3
X-RateLimit-Reset: 57
...

# Rate-limited API response
HTTP/1.1 429 Too Many Requests
...
X-RateLimit-Limit: 60
X-RateLimit-Remaining: 0
X-RateLimit-Reset: 54
Retry-After: 54
...
```

NOTE: I've only added the non-rate-limited headers to API responses. Do we want to include them for Web responses too?

closes https://github.com/librariesio/libraries.io/issues/3283