### PR TITLE
Search: allow opting out of versions

### DIFF
--- a/app/controllers/api/search_controller.rb
+++ b/app/controllers/api/search_controller.rb
@@ -4,14 +4,19 @@ class Api::SearchController < Api::ApplicationController
   before_action :require_api_key
 
   def index
+    include_versions = params.fetch(:include_versions, "true") == "true"
+
     if use_pg_search?
-      @projects = pg_search_projects(params[:q]).includes(:repository, :versions).paginate(page: params[:page])
+      @projects = pg_search_projects(params[:q]).strict_loading.includes(:repository)
+      @projects = @projects.includes(:versions) if include_versions
+      @projects = @projects.paginate(page: params[:page])
     else
       search = paginate search_projects(params[:q])
-      @projects = search.records.includes(:repository, :versions)
+      @projects = search.records.includes(:repository)
+      @projects = @projects.includes(:versions) if include_versions
     end
 
-    render json: @projects
+    render json: @projects, each_serializer: ProjectSerializer, include_versions: include_versions
   end
 
   private

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -30,9 +30,13 @@ class ProjectSerializer < ActiveModel::Serializer
     status
   ]
 
-  has_many :versions
+  has_many :versions, if: :include_versions?
 
   attribute :updated_at, if: :show_updated_at?
+
+  def include_versions?
+    instance_options.fetch(:include_versions, true)
+  end
 
   def show_updated_at?
     instance_options[:show_updated_at]

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -15,10 +15,6 @@ FactoryBot.define do
     "andrew#{n}"
   end
 
-  sequence :repository_url do |n|
-    "https://github.com/rails/rails#{n}"
-  end
-
   trait :removed do
     status { "Removed" }
   end
@@ -31,7 +27,7 @@ FactoryBot.define do
     language        { "Ruby" }
     licenses        { "MIT" }
     keywords_array  { ["web"] }
-    repository_url
+    repository_url  { "https://github.com/rails/#{name}" }
     dependent_repos_count { 0 }
     repository { nil }
 

--- a/spec/requests/api/search_spec.rb
+++ b/spec/requests/api/search_spec.rb
@@ -5,6 +5,9 @@ require "rails_helper"
 describe "API::SearchController", elasticsearch: true do
   describe "GET /api/search", type: :request do
     let!(:user) { create(:user) }
+    let!(:project) { create :project, name: "charisma-generator" }
+    let!(:other_project) { create :project, name: "wisdom-generator" }
+    let!(:version) { create(:version, project: project, number: "1.0.0") }
 
     context "with missing api key" do
       it "returns forbidden" do
@@ -24,18 +27,26 @@ describe "API::SearchController", elasticsearch: true do
 
     context "with valid api key" do
       it "renders successfully" do
-        get "/api/search?api_key=#{user.api_key}"
+        get "/api/search", params: { api_key: user.api_key, q: "charisma" }
 
         expect(response).to have_http_status(:success)
         expect(response.content_type).to start_with("application/json")
-        expect(response.body).to be_json_eql []
+        response_hash = JSON.parse(response.body)
+        expect(response_hash.size).to eq(1)
+        expect(response_hash.first.keys).to include("versions")
+      end
+
+      it "renders successfully with include_versions=false" do
+        get "/api/search", params: { api_key: user.api_key, q: "charisma", include_versions: false }
+
+        expect(response.content_type).to start_with("application/json")
+        response_hash = JSON.parse(response.body)
+        expect(response_hash.size).to eq(1)
+        expect(response_hash.first.keys).not_to include("versions")
       end
     end
 
     context "with pg_search_projects enabled" do
-      let!(:project) { create :project, name: "charisma-generator" }
-      let!(:other_project) { create :project, name: "wisdom-generator" }
-
       before do
         expect_any_instance_of(ApplicationController).to receive(:use_pg_search?).and_return(true)
         allow_any_instance_of(ApplicationController).to receive(:es_query).and_raise
@@ -43,8 +54,59 @@ describe "API::SearchController", elasticsearch: true do
 
       it "renders successfully" do
         get "/api/search", params: { api_key: user.api_key, q: "charisma" }
+
         expect(response.content_type).to start_with("application/json")
-        expect(response.body).to match [ProjectSerializer.new(project)].to_json
+        response_hash = JSON.parse(response.body)
+        expect(response_hash.size).to eq(1)
+        expect(response_hash.first).to match(
+          {
+            "contributions_count" => 0,
+            "dependent_repos_count" => 0,
+            "dependents_count" => 0,
+            "deprecation_reason" => nil,
+            "description" => "Ruby on Rails is a full-stack web framework optimized for programmer happiness and sustainable productivity. It encourages beautiful code by favoring convention over configuration.",
+            "forks" => 0,
+            "homepage" => "http://rubyonrails.org/",
+            "keywords" => ["web"],
+            "language" => "Ruby",
+            "latest_download_url" => "https://rubygems.org/downloads/charisma-generator-1.0.0.gem",
+            "latest_release_number" => "1.0.0",
+            "latest_release_published_at" => anything,
+            "latest_stable_release_number" => nil,
+            "latest_stable_release_published_at" => nil,
+            "license_normalized" => false,
+            "licenses" => "MIT",
+            "name" => "charisma-generator",
+            "normalized_licenses" => ["MIT"],
+            "package_manager_url" => "https://rubygems.org/gems/charisma-generator",
+            "platform" => "Rubygems",
+            "rank" => 0,
+            "repository_license" => nil,
+            "repository_status" => nil,
+            "repository_url" => "https://github.com/rails/charisma-generator",
+            "stars" => 0,
+            "status" => nil,
+            "versions" => [
+              {
+                "number" => "1.0.0",
+                "published_at" => anything,
+                "spdx_expression" => nil,
+                "original_license" => nil,
+                "researched_at" => nil,
+                "repository_sources" => ["Rubygems"],
+              },
+            ],
+          }
+        )
+      end
+
+      it "renders successfully with include_versions=false" do
+        get "/api/search", params: { api_key: user.api_key, q: "charisma", include_versions: false }
+
+        expect(response.content_type).to start_with("application/json")
+        response_hash = JSON.parse(response.body)
+        expect(response_hash.size).to eq(1)
+        expect(response_hash.first.keys).not_to include("versions")
       end
     end
   end

--- a/spec/requests/api/search_spec.rb
+++ b/spec/requests/api/search_spec.rb
@@ -26,6 +26,10 @@ describe "API::SearchController", elasticsearch: true do
     end
 
     context "with valid api key" do
+      before do
+        Project.__elasticsearch__.refresh_index!
+      end
+
       it "renders successfully" do
         get "/api/search", params: { api_key: user.api_key, q: "charisma" }
 


### PR DESCRIPTION
For performance gains / payload reduction, allow the querystring param `?include_versions=false`. Defaults to `true`