### PR TITLE
Migration: adds Project#latest_version_id

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -35,6 +35,7 @@
 #  versions_count                     :integer          default(0), not null
 #  created_at                         :datetime         not null
 #  updated_at                         :datetime         not null
+#  latest_version_id                  :integer
 #  pm_id                              :integer
 #  repository_id                      :integer
 #

--- a/db/migrate/20240409222313_add_latest_version_id_to_projects.rb
+++ b/db/migrate/20240409222313_add_latest_version_id_to_projects.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLatestVersionIdToProjects < ActiveRecord::Migration[7.0]
+  def change
+    add_column :projects, :latest_version_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_09_215450) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_09_222313) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -171,6 +171,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_09_215450) do
     t.text "deprecation_reason"
     t.datetime "status_checked_at", precision: nil
     t.boolean "lifted", default: false
+    t.integer "latest_version_id"
     t.index "(COALESCE((name)::text, ''::text)) gist_trgm_ops", name: "index_projects_search_on_name", using: :gist
     t.index "lower((language)::text)", name: "index_projects_on_lower_language"
     t.index "lower((platform)::text), lower((name)::text)", name: "index_projects_on_platform_and_name_lower"


### PR DESCRIPTION
this new column can cache the most recently published `Project#versions` so we can do `includes()` and `joins()` against it. We currently do a query everytime we fetch `latest_version`: https://github.com/librariesio/libraries.io/blob/8cad44493718ea89347074a08db925dd5ca48b80/app/models/concerns/releases.rb#L40-L42

in a followup PR, we'll backfill this value, change it to a real association, and keep it updated in the same place that we keep `latest_release_published_at` + `latest_release_number` updated: https://github.com/librariesio/libraries.io/blob/main/app/models/project.rb#L268-L270

(NB: "latest release" means "either latest version or latest tag", but "latest version" will simply be the latest Version only)