### PR TITLE
Add Project#latest_version assocation, keep it up-to-date on save, and backfill it.

### DIFF
--- a/app/models/concerns/releases.rb
+++ b/app/models/concerns/releases.rb
@@ -37,11 +37,6 @@ module Releases
     latest_stable_version || latest_stable_tag
   end
 
-  # Deprecated: will be removed once :latest_version association is added.
-  def latest_version
-    versions.order("published_at DESC NULLS LAST", created_at: :desc).first
-  end
-
   def latest_tag
     return nil if repository.nil?
 

--- a/app/models/concerns/releases.rb
+++ b/app/models/concerns/releases.rb
@@ -37,6 +37,7 @@ module Releases
     latest_stable_version || latest_stable_tag
   end
 
+  # Deprecated: will be removed once :latest_version association is added.
   def latest_version
     versions.order("published_at DESC NULLS LAST", created_at: :desc).first
   end
@@ -75,6 +76,10 @@ module Releases
 
   def set_latest_release_number
     self.latest_release_number = latest_release.try(:number)
+  end
+
+  def set_latest_version
+    self.latest_version_id = versions.select(:id).order("published_at DESC NULLS LAST", created_at: :desc).first&.id
   end
 
   def set_latest_stable_release_info

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -269,6 +269,7 @@ class Project < ApplicationRecord
     set_latest_release_published_at
     set_latest_release_number
     set_latest_stable_release_info
+    set_latest_version
     set_runtime_dependencies_count
     set_language
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -107,6 +107,7 @@ class Project < ApplicationRecord
 
   belongs_to :repository
   has_many :versions, dependent: :destroy
+  belongs_to :latest_version, class_name: "Version"
   has_many :dependencies, -> { group "project_name" }, through: :versions
   has_many :contributions, through: :repository
   has_many :contributors, through: :contributions, source: :repository_user

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -267,10 +267,10 @@ class Project < ApplicationRecord
 
   def update_details
     normalize_licenses
+    set_latest_version
     set_latest_release_published_at
     set_latest_release_number
     set_latest_stable_release_info
-    set_latest_version
     set_runtime_dependencies_count
     set_language
   end

--- a/db/migrate/20240409222653_backfill_projects_latest_version_id.rb
+++ b/db/migrate/20240409222653_backfill_projects_latest_version_id.rb
@@ -1,0 +1,36 @@
+class BackfillProjectsLatestVersionId < ActiveRecord::Migration[7.0]
+  def up
+    # This migration has already been run manually in production.
+    return if Rails.env.production?
+
+    Project
+      .in_batches(of: 10_000) do |projects|
+        sql = <<~SQL
+          WITH rows_to_update AS (
+            SELECT p.id as project_id, latest_version.id as latest_version_id
+            FROM projects p
+            LEFT JOIN LATERAL (
+              SELECT versions.*
+              FROM versions 
+              WHERE versions.project_id = p.id 
+              ORDER BY published_at DESC NULLS LAST, versions.created_at DESC 
+              LIMIT 1
+            ) as latest_version ON true
+            WHERE p.id IN (#{projects.map(&:id).join(",")})
+          )
+          UPDATE projects
+          SET latest_version_id = rows_to_update.latest_version_id
+          FROM rows_to_update
+          WHERE projects.id = rows_to_update.project_id
+        SQL
+      
+        ActiveRecord::Base.connection.execute(sql)
+        print "."
+      end
+    end
+  end
+
+  def down
+    # No-op
+  end
+end

--- a/db/migrate/20240409222653_backfill_projects_latest_version_id.rb
+++ b/db/migrate/20240409222653_backfill_projects_latest_version_id.rb
@@ -27,7 +27,6 @@ class BackfillProjectsLatestVersionId < ActiveRecord::Migration[7.0]
         ActiveRecord::Base.connection.execute(sql)
         print "."
       end
-    end
   end
 
   def down

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_09_222313) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_09_222653) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -401,16 +401,9 @@ describe Project, type: :model do
   describe "#update_details" do
     let!(:project) { create(:project) }
     let!(:older_release) { create(:version, project: project, number: "1.0.0", published_at: 1.year.ago, id: 2000, created_at: 1.month.ago) }
-
-    xit "should normalize licenses"
-    xit "should set latest_release_published_at"
-    xit "should set latest_release_number"
-    xit "should set latest_stable_release_info"
-    xit "should set runtime_dependencies_count"
-    xit "should set language"
+    let!(:newer_release) { create(:version, project: project, number: "2.0.0", published_at: 1.month.ago, id: 1000, created_at: 1.year.ago, skip_save_project: true) }
 
     it "should update latest_version_id" do
-      newer_release = create(:version, project: project, number: "2.0.0", published_at: 1.month.ago, id: 1000, created_at: 1.year.ago, skip_save_project: true)
       expect { project.update_details }.to change { project.latest_version_id }.from(older_release.id).to(newer_release.id)
     end
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -398,6 +398,23 @@ describe Project, type: :model do
     end
   end
 
+  describe "#update_details" do
+    let!(:project) { create(:project) }
+    let!(:older_release) { create(:version, project: project, number: "1.0.0", published_at: 1.year.ago, id: 2000, created_at: 1.month.ago) }
+
+    xit "should normalize licenses"
+    xit "should set latest_release_published_at"
+    xit "should set latest_release_number"
+    xit "should set latest_stable_release_info"
+    xit "should set runtime_dependencies_count"
+    xit "should set language"
+
+    it "should update latest_version_id" do
+      newer_release = create(:version, project: project, number: "2.0.0", published_at: 1.month.ago, id: 1000, created_at: 1.year.ago, skip_save_project: true)
+      expect { project.update_details }.to change { project.latest_version_id }.from(older_release.id).to(newer_release.id)
+    end
+  end
+
   describe "#latest_release" do
     let!(:project) { create(:project) }
     let!(:newer_release) { create(:version, project: project, number: "2.0.0", published_at: 1.month.ago, id: 1000, created_at: 1.year.ago) }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -428,6 +428,7 @@ describe Project, type: :model do
       before do
         newer_release.update!(published_at: nil)
         older_release.update!(published_at: nil)
+        project.set_latest_version
       end
 
       it "returns the latest created release" do
@@ -449,6 +450,7 @@ describe Project, type: :model do
       before do
         older_release.update!(published_at: nil)
         newer_release.update!(published_at: nil)
+        project.set_latest_version
       end
 
       it "returns the latest created release" do


### PR DESCRIPTION
(followup to https://github.com/librariesio/libraries.io/pull/3356)

* a backfill migration to populate `Projects#latest_version_id` (this has already been run on production)
* replace `Project#latest_version` method with a new `:latest_version` belongs_to association
* add a `set_latest_version` method that updates that column after a `Project` is saved