### PR TITLE
Treat Redirected Go Packages as Removed

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -645,7 +645,7 @@ class Project < ApplicationRecord
     response = Typhoeus.get(url)
     if platform.downcase == "packagist" && [302, 404].include?(response.response_code)
       update_attribute(:status, "Removed")
-    elsif platform.downcase == "go" && [400, 404].include?(response.response_code)
+    elsif platform.downcase == "go" && [302, 400, 404].include?(response.response_code)
       # pkg.go.dev can be 404 on first-hit for a new package (or alias for the package), so ensure that the package existed in the past
       # by ensuring its age is old enough to not be just uncached by pkg.go.dev yet.
       update_attribute(:status, "Removed") if created_at < 1.week.ago

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -213,7 +213,7 @@ describe Project, type: :model do
       context "recently created" do
         let!(:project) { create(:project, platform: "Go", name: "github.com/some-nonexistent-fake/pkg", status: nil, created_at: 1.hour.ago) }
 
-        it "should not mark it as Removed" do
+        it "should not mark it as Removed for a 404" do
           VCR.use_cassette("project/check_status/go") do
             project.check_status
             project.reload
@@ -221,18 +221,36 @@ describe Project, type: :model do
             expect(project.status_checked_at).to eq(DateTime.current)
           end
         end
+
+        it "should not mark it as Removed for a 302" do
+          url = "https://pkg.go.dev/#{project.name}"
+          WebMock.stub_request(:get, url).to_return(status: 302)
+          project.check_status
+          project.reload
+          expect(project.status).to eq(nil)
+          expect(project.status_checked_at).to eq(DateTime.current)
+        end
       end
 
       context "not recently created" do
         let!(:project) { create(:project, platform: "Go", name: "github.com/some-nonexistent-fake/pkg", status: nil, created_at: 1.month.ago) }
 
-        it "should mark it as Removed" do
+        it "should mark it as Removed for a 404" do
           VCR.use_cassette("project/check_status/go") do
             project.check_status
             project.reload
             expect(project.status).to eq("Removed")
             expect(project.status_checked_at).to eq(DateTime.current)
           end
+        end
+
+        it "should mark it as Removed for a 302" do
+          url = "https://pkg.go.dev/#{project.name}"
+          WebMock.stub_request(:get, url).to_return(status: 302)
+          project.check_status
+          project.reload
+          expect(project.status).to eq("Removed")
+          expect(project.status_checked_at).to eq(DateTime.current)
         end
       end
     end


### PR DESCRIPTION
This PR updates the `check_status` logic for Go packages to treat a redirect from pkg.go.dev as a "Removed" package. The reasons for this change are to help capture when packages are renamed or recased and mark the now incorrect one appropriately. This is just an idea, so feel free to disagree with this approach. 

One example is:
https://libraries.io/go/github.com%2FAzure%2Fazure-pipeline-go vs https://libraries.io/go/github.com%2Fazure%2FAzure-pipeline-go which both reference `github.com/Azure/azure-pipeline-go`. This PR would mark `github.com/azure/Azure-pipeline-go` as removed.

```shell
> url = "https://pkg.go.dev/github.com/azure/Azure-pipeline-go"
> response = Typhoeus.get(url)
> response.response_code
=> 302
> response.body
=> "<a href=\"/github.com/Azure/azure-pipeline-go\">Found</a>.\n\n"
```