### PR TITLE
Replace queries against RepositoryDependency with Dependency 

### DIFF
--- a/app/controllers/api/docs_controller.rb
+++ b/app/controllers/api/docs_controller.rb
@@ -19,7 +19,7 @@ class Api::DocsController < ApplicationController
 
     @repo_dependencies = @repository.as_json
 
-    @repo_dependencies[:dependencies] = map_dependencies(@repository.repository_dependencies.includes(:project) || [])
+    @repo_dependencies[:dependencies] = map_dependencies(@repository.projects_dependencies || [])
 
     @search = Project.search("grunt", api: true).records
 

--- a/app/controllers/api/repositories_controller.rb
+++ b/app/controllers/api/repositories_controller.rb
@@ -17,7 +17,7 @@ class Api::RepositoriesController < Api::ApplicationController
     cache_key = "repository_dependencies:#{@repository.id}"
     json_hash = Rails.cache.fetch(cache_key, expires_in: 1.day) do
       result = RepositorySerializer.new(@repository).as_json
-      result[:dependencies] = map_dependencies(@repository.projects_dependencies(includes: []) || []).map(&:as_json)
+      result[:dependencies] = map_dependencies(@repository.projects_dependencies || []).map(&:as_json)
       result
     end
     render json: json_hash

--- a/app/controllers/api/repositories_controller.rb
+++ b/app/controllers/api/repositories_controller.rb
@@ -17,7 +17,7 @@ class Api::RepositoriesController < Api::ApplicationController
     cache_key = "repository_dependencies:#{@repository.id}"
     json_hash = Rails.cache.fetch(cache_key, expires_in: 1.day) do
       result = RepositorySerializer.new(@repository).as_json
-      result[:dependencies] = map_dependencies(@repository.repository_dependencies.includes(:project, :manifest) || []).map(&:as_json)
+      result[:dependencies] = map_dependencies(@repository.projects_dependencies(includes: [])|| []).map(&:as_json)
       result
     end
     render json: json_hash

--- a/app/controllers/project_usage_controller.rb
+++ b/app/controllers/project_usage_controller.rb
@@ -3,16 +3,23 @@
 class ProjectUsageController < ApplicationController
   before_action :find_project
   def show
-    # looking at repository dependencies is inefficient, let's not DoS ourself
-    if @project.dependent_repos_count > 10000
+    # TODO: can remove this early return if it never gets logged or is not slow anymore
+    if @project.dependents_count > 10000
+      StructuredLog.capture(
+        "PROJECT_USAGE_TOO_MANY_DEPENDENTS", {
+          name: @project.name,
+          platform: @project.platform,
+          dependents_count: @project.dependents_count,
+        }
+      )
       @too_big = true
-      @total = @project.dependent_repos_count
+      @total = @project.dependents_count
       return
     end
-    @all_counts = @project.repository_dependencies.group("repository_dependencies.requirements").count.select { |k, _v| k.present? }
+    @all_counts = @project.dependents.group("dependencies.requirements").count.select { |k, _v| k.present? }
     @total = @all_counts.sum { |_k, v| v }
     if @all_counts.any?
-      @kinds = @project.repository_dependencies.group("repository_dependencies.kind").count
+      @kinds = @project.dependents.group("dependencies.kind").count
       @counts = sort_by_semver_range(@all_counts.length > 18 ? 17 : 18)
       @highest_percentage = @counts.map { |_k, v| v.to_f / @total * 100 }.max
     end

--- a/app/controllers/project_usage_controller.rb
+++ b/app/controllers/project_usage_controller.rb
@@ -3,19 +3,6 @@
 class ProjectUsageController < ApplicationController
   before_action :find_project
   def show
-    # TODO: can remove this early return if it never gets logged or is not slow anymore
-    if @project.dependents_count > 10000
-      StructuredLog.capture(
-        "PROJECT_USAGE_TOO_MANY_DEPENDENTS", {
-          name: @project.name,
-          platform: @project.platform,
-          dependents_count: @project.dependents_count,
-        }
-      )
-      @too_big = true
-      @total = @project.dependents_count
-      return
-    end
     @all_counts = @project.dependents.group("dependencies.requirements").count.select { |k, _v| k.present? }
     @total = @all_counts.sum { |_k, v| v }
     if @all_counts.any?

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -37,7 +37,7 @@ class RepositoriesController < ApplicationController
 
   def dependencies
     load_repo
-    @manifests = @repository.manifests.latest.limit(10).includes(repository_dependencies: { project: :versions })
+    @dependencies = @repository.projects.map(&:latest_version).compact.flat_map(&:dependencies)
     render layout: false
   end
 

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -37,7 +37,7 @@ class RepositoriesController < ApplicationController
 
   def dependencies
     load_repo
-    @dependencies = @repository.projects.map(&:latest_version).compact.flat_map(&:dependencies)
+    @dependencies = @repository.projects_dependencies
     render layout: false
   end
 

--- a/app/models/package_manager/carthage.rb
+++ b/app/models/package_manager/carthage.rb
@@ -9,7 +9,7 @@ module PackageManager
     COLOR = "#ffac45"
 
     def self.project_names
-      Manifest.platform("Carthage").includes(:repository_dependencies).map { |m| m.repository_dependencies.map(&:project_name).compact.map(&:downcase) }.flatten.uniq
+      Project.platform("Carthage").map { |m| m.projects_dependencies.map(&:project_name).compact.map(&:downcase) }.flatten.uniq
     end
 
     def self.project(name)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -271,6 +271,7 @@ class Project < ApplicationRecord
     set_latest_release_published_at
     set_latest_release_number
     set_latest_stable_release_info
+    set_latest_version
     set_runtime_dependencies_count
     set_language
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -668,21 +668,13 @@ class Project < ApplicationRecord
     end
   end
 
-  def unique_repo_requirement_ranges
-    repository_dependencies.select("repository_dependencies.requirements").distinct.pluck(:requirements)
-  end
-
   def unique_project_requirement_ranges
     dependents.select("dependencies.requirements").distinct.pluck(:requirements)
   end
 
-  def unique_requirement_ranges
-    (unique_repo_requirement_ranges + unique_project_requirement_ranges).uniq
-  end
-
   def potentially_outdated?
     current_version = SemanticRange.clean(latest_release_number)
-    unique_requirement_ranges.compact.sort.any? do |range|
+    unique_project_requirement_ranges.compact.sort.any? do |range|
       !(SemanticRange.gtr(current_version, range, false, platform) ||
       SemanticRange.satisfies(current_version, range, false, platform))
     rescue StandardError

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -271,7 +271,6 @@ class Project < ApplicationRecord
     set_latest_release_published_at
     set_latest_release_number
     set_latest_stable_release_info
-    set_latest_version
     set_runtime_dependencies_count
     set_language
   end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -262,6 +262,11 @@ class Repository < ApplicationRecord
     RepositoryTreeResolver.new(self, date).load_dependencies_tree
   end
 
+  # TODO: this could probably be refactored into an association 
+  def projects_dependencies
+    projects.map(&:latest_version).compact.flat_map(&:dependencies)
+  end
+
   def id_or_name
     if host_type == "GitHub"
       uuid || full_name

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -263,8 +263,12 @@ class Repository < ApplicationRecord
   end
 
   # TODO: this could probably be refactored into an association 
-  def projects_dependencies
-    projects.map(&:latest_version).compact.flat_map(&:dependencies)
+  def projects_dependencies(includes: {})
+    projects
+      .map(&:latest_version)
+      .compact
+      .flat_map { |v| v.dependencies.includes(includes) }
+      .uniq { |d| [d.project_id, d.requirements] }
   end
 
   def id_or_name

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -263,8 +263,8 @@ class Repository < ApplicationRecord
   end
 
   # TODO: this could probably be refactored into an association
-  def projects_dependencies(includes: nil)
-    projects
+  def projects_dependencies(includes: nil, only_visible: false)
+    (only_visible ? projects.visible : projects)
       .map(&:latest_version)
       .compact
       .flat_map { |v| v.dependencies.includes(includes) }

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -262,8 +262,8 @@ class Repository < ApplicationRecord
     RepositoryTreeResolver.new(self, date).load_dependencies_tree
   end
 
-  # TODO: this could probably be refactored into an association 
-  def projects_dependencies(includes: {})
+  # TODO: this could probably be refactored into an association
+  def projects_dependencies(includes: nil)
     projects
       .map(&:latest_version)
       .compact

--- a/app/models/repository_subscription.rb
+++ b/app/models/repository_subscription.rb
@@ -25,7 +25,7 @@ class RepositorySubscription < ApplicationRecord
 
   def update_subscriptions
     projects = []
-    repository.repository_dependencies.each do |dep|
+    repository.projects_dependencies(includes: [:project]).each do |dep|
       if dep.project.present?
         project = dep.project.try(:id)
       elsif dep.project_name.present?

--- a/app/models/repository_tree_resolver.rb
+++ b/app/models/repository_tree_resolver.rb
@@ -58,7 +58,7 @@ class RepositoryTreeResolver
 
       dependencies = []
       manifests.each do |manifest|
-        manifest.repository_dependencies.each do |repository_dependency|
+        manifest.projects_dependencies(includes: [:project]).each do |repository_dependency|
           dependencies << repository_dependency
         end
       end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -50,7 +50,7 @@ class Tag < ApplicationRecord
     repository.projects.without_versions.each do |project|
       repos = project.subscriptions.map(&:repository).compact.uniq
       repos.each do |repo|
-        requirements = repo.repository_dependencies.select { |rd| rd.project == project }.map(&:requirements)
+        requirements = repo.projects_dependencies(includes: [:project]).select { |rd| rd.project == project }.map(&:requirements)
         repo.web_hooks.each do |web_hook|
           web_hook.send_new_version(project, project.platform, self, requirements)
         end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -93,13 +93,13 @@ class User < ApplicationRecord
   def watched_dependent_projects
     repository_subscriptions
       .map(&:repository)
-      .map { |r| r.projects_dependencies(includes: [:project]).map(&:project) }
+      .map { |r| r.projects_dependencies(includes: [:project], only_visible: true).map(&:project) }
       .flatten
       .uniq
   end
 
   def all_subscribed_project_ids
-    (subscribed_projects.visible.pluck(:id) + watched_dependent_projects.visible.pluck(:id)).uniq
+    (subscribed_projects.visible.pluck(:id) + watched_dependent_projects.pluck(:id)).uniq
   end
 
   def all_subscribed_versions

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -91,8 +91,11 @@ class User < ApplicationRecord
   end
 
   def watched_dependent_projects
-    repo_subs = repository_subscriptions.pluck(:repository_id)
-    Project.where(id: RepositoryDependency.where(repository_id: repo_subs).pluck(:project_id).uniq)
+    repository_subscriptions
+      .map(&:repository)
+      .map { |r| r.projects_dependencies(includes: [:project]).map(&:project) }
+      .flatten
+      .uniq
   end
 
   def all_subscribed_project_ids

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -102,7 +102,7 @@ class Version < ApplicationRecord
   def notify_web_hooks
     repos = project.subscriptions.map(&:repository).compact.uniq
     repos.each do |repo|
-      requirements = repo.repository_dependencies.select { |rd| rd.project == project }.map(&:requirements)
+      requirements = repo.projects_dependencies(includes: [:project]).select { |rd| rd.project == project }.map(&:requirements)
       repo.web_hooks.each do |web_hook|
         web_hook.send_new_version(project, project.platform, self, requirements)
       end

--- a/app/models/web_hook.rb
+++ b/app/models/web_hook.rb
@@ -92,6 +92,6 @@ class WebHook < ApplicationRecord
   def send_payload(data, ignore_errors: false)
     response = request(data).run
     update(last_sent_at: Time.now.utc, last_response: response.response_code)
-    raise StandardError, "webhook #{id} failed; timed_out=#{response.timed_out?} code=#{response.code}" unless response.success? || ignore_errors
+    raise StandardError, "webhook failed webhook_id=#{id} timed_out=#{response.timed_out?} code=#{response.code}" unless response.success? || ignore_errors
   end
 end

--- a/app/serializers/dependency_serializer.rb
+++ b/app/serializers/dependency_serializer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class DependencySerializer < ActiveModel::Serializer
+  # NB: filepath is deprecated as we're only pulling deps from projects instead of repos now.
   attributes :project_name, :name, :platform, :requirements, :latest_stable, :latest,
              :deprecated, :outdated, :filepath, :kind, :optional, :normalized_licenses
 

--- a/app/views/admin/stats/index.html.erb
+++ b/app/views/admin/stats/index.html.erb
@@ -45,7 +45,7 @@
         <small>
           <%= timeago_tag(sub.created_at) %>
           <% if sub.repository %>
-            - <%= link_to pluralize(sub.repository.repository_dependencies.count, 'dependencies'), repository_path(sub.repository.to_param.merge(anchor: 'dependencies')) %>
+            - <%= link_to pluralize(sub.repository.projects_dependencies.count, 'dependencies'), repository_path(sub.repository.to_param.merge(anchor: 'dependencies')) %>
           <% end %>
         </small>
       </div>

--- a/app/views/admin/stats/overview.html.erb
+++ b/app/views/admin/stats/overview.html.erb
@@ -29,10 +29,6 @@
     <h2>
       <%= number_to_human Manifest.fast_total %> Manifests
     </h2>
-
-    <h2>
-      <%= number_to_human RepositoryDependency.fast_total %> Repository Dependencies
-    </h2>
   </div>
 
   <div class="col-md-6">

--- a/app/views/api/docs/index.html.erb
+++ b/app/views/api/docs/index.html.erb
@@ -225,7 +225,7 @@
     <h3 id='repository-dependencies'>Repository Dependencies</h3>
 
     <p>
-      Get a list of dependencies for a repositories. Currently only works for open source repositories.
+      Get a list of dependencies for all of a repository's projects. Currently only works for open source repositories.
     </p>
     <p>
       <code>GET https://libraries.io/api/github/:owner/:name/dependencies?api_key=<%= @api_key %></code>

--- a/app/views/dashboard/_github_repository.html.erb
+++ b/app/views/dashboard/_github_repository.html.erb
@@ -9,7 +9,7 @@
       <%= button_to 'Watch', watch_path(repository.id), method: :post, class: 'btn btn-primary' %>
     <% end %>
     <small>
-      <%= link_to pluralize(repository.repository_dependencies.count, 'dependencies'), repository_path(repository.to_param.merge(anchor: 'dependencies')) %>
+      <%= link_to pluralize(repository.projects_dependencies.count, 'dependencies'), repository_path(repository.to_param.merge(anchor: 'dependencies')) %>
     </small>
   </div>
 </div>

--- a/app/views/repositories/_stats.html.erb
+++ b/app/views/repositories/_stats.html.erb
@@ -62,7 +62,7 @@
       Dependencies
     </td>
     <td>
-      <strong><%= number_with_delimiter repo.repository_dependencies.count %></strong>
+      <strong><%= number_with_delimiter repo.projects_dependencies.count %></strong>
     </td>
   </tr>
   <% if repo.contributions_count > 0 %>

--- a/app/views/repositories/dependencies.html.erb
+++ b/app/views/repositories/dependencies.html.erb
@@ -1,68 +1,61 @@
-<% if @manifests.length > 0 %>
+
+<% if @dependencies.length > 0 %>
   <hr>
   <div id="dependencies" class="table-responsive">
     <h4>Dependencies</h4>
-    <% @manifests.each do |manifest| %>
-        <% deps = manifest.repository_dependencies %>
-        <% if deps.length > 0 %>
-          <table class='table table-hover table-condensed'>
-            <thead>
-              <th>
-                <div class="pictogram tip pictogram-<%= manifest.platform.try(:downcase) %>" title='<%= manifest.platform %>'></div>
-                <%= link_to manifest.filepath, manifest.repository_link %>
-              </th>
-              <th>Kind</th>
-              <th>
-                Requirements
-              </th>
-              <th>
-                Latest Stable
-              </th>
-              <th>
-                Latest Release
-              </th>
-              <th>
-                Licenses
-              </th>
-              <th>
-
-              </th>
-            </thead>
-            <% deps.first(200).reject{|dep| dep.project_name.blank? }.sort_by(&:project_name).each do |dependency| %>
-              <tr>
-                <td>
-                  <% if dependency.platform.present? %>
-                    <%= link_to  truncate_with_tip(dependency.project_name, 30), project_path(name: dependency.project_name, platform: dependency.platform.try(:downcase)) %>
-                  <% else %>
-                    <%= truncate_with_tip(dependency.project_name, 30) %>
-                  <% end %>
-                </td>
-                <td>
-                  <%= truncate_with_tip(dependency.kind, 15) %>
-                </td>
-                <td>
-                  <%= truncate_with_tip(dependency.requirements, 15) %>
-                </td>
-                <td>
-                  <%= dependency.try(:project).try(:latest_stable_release_number) %>
-                </td>
-                <td>
-                  <%= dependency.try(:project).try(:latest_release_number) %>
-                </td>
-                <td>
-                  <% if dependency.project %>
-                    <%= linked_licenses dependency.project.normalized_licenses %>
-                  <% end %>
-                </td>
-                <td>
-                  <% if dependency.project %>
-                    <%= render 'dependencies/flags', dependency: dependency %>
-                  <% end %>
-                </td>
-              </tr>
+    <table class='table table-hover table-condensed'>
+      <thead>
+        <th>Kind</th>
+        <th>
+          Requirements
+        </th>
+        <th>
+          Latest Stable
+        </th>
+        <th>
+          Latest Release
+        </th>
+        <th>
+          Licenses
+        </th>
+        <th>
+        </th>
+      </thead>
+      <tbody>
+      <% @dependencies.first(200).reject { |d| d.project_name.blank? }.sort_by(&:project_name).each do |dependency| %>
+        <tr>
+          <td>
+            <% if dependency.platform.present? %>
+              <%= link_to  truncate_with_tip(dependency.project_name, 30), project_path(name: dependency.project_name, platform: dependency.platform.try(:downcase)) %>
+            <% else %>
+              <%= truncate_with_tip(dependency.project_name, 30) %>
             <% end %>
-          </table>
-        <% end %>
-    <% end %>
+          </td>
+          <td>
+            <%= truncate_with_tip(dependency.kind, 15) %>
+          </td>
+          <td>
+            <%= truncate_with_tip(dependency.requirements, 15) %>
+          </td>
+          <td>
+            <%= dependency.try(:project).try(:latest_stable_release_number) %>
+          </td>
+          <td>
+            <%= dependency.try(:project).try(:latest_release_number) %>
+          </td>
+          <td>
+            <% if dependency.project %>
+              <%= linked_licenses dependency.project.normalized_licenses %>
+            <% end %>
+          </td>
+          <td>
+            <% if dependency.project %>
+              <%= render 'dependencies/flags', dependency: dependency %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
   </div>
 <% end %>

--- a/lib/tasks/open_data.rake
+++ b/lib/tasks/open_data.rake
@@ -424,7 +424,7 @@ namespace :open_data do
 
     Repository.open_source.not_removed.includes(manifests: :repository_dependencies).find_each do |repo|
       repo.manifests.each do |manifest|
-        manifest.repository_dependencies.each do |repository_dependency|
+        manifest.projects_dependencies.each do |repository_dependency|
           csv_file << [
             repository_dependency.id,
             repo.host_type,

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -401,9 +401,9 @@ describe Project, type: :model do
   describe "#update_details" do
     let!(:project) { create(:project) }
     let!(:older_release) { create(:version, project: project, number: "1.0.0", published_at: 1.year.ago, id: 2000, created_at: 1.month.ago) }
-    let!(:newer_release) { create(:version, project: project, number: "2.0.0", published_at: 1.month.ago, id: 1000, created_at: 1.year.ago, skip_save_project: true) }
 
     it "should update latest_version_id" do
+      newer_release = create(:version, project: project, number: "2.0.0", published_at: 1.month.ago, id: 1000, created_at: 1.year.ago, skip_save_project: true)
       expect { project.update_details }.to change { project.latest_version_id }.from(older_release.id).to(newer_release.id)
     end
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -401,10 +401,14 @@ describe Project, type: :model do
   describe "#update_details" do
     let!(:project) { create(:project) }
     let!(:older_release) { create(:version, project: project, number: "1.0.0", published_at: 1.year.ago, id: 2000, created_at: 1.month.ago) }
+    let!(:newer_release) { create(:version, project: project, number: "2.0.0", published_at: 1.month.ago, id: 1000, created_at: 1.year.ago) }
 
-    it "should update latest_version_id" do
-      newer_release = create(:version, project: project, number: "2.0.0", published_at: 1.month.ago, id: 1000, created_at: 1.year.ago, skip_save_project: true)
-      expect { project.update_details }.to change { project.latest_version_id }.from(older_release.id).to(newer_release.id)
+    context "when latest_version_id is out-of-date" do
+      before { project.update_column(:latest_version_id, older_release.id) }
+
+      it "should update latest_version_id" do
+        expect { project.update_details }.to change { project.latest_version_id }.from(older_release.id).to(newer_release.id)
+      end
     end
   end
 

--- a/spec/models/web_hook_spec.rb
+++ b/spec/models/web_hook_spec.rb
@@ -115,7 +115,7 @@ describe WebHook, type: :model do
 
         expect do
           web_hook.send_project_updated(project)
-        end.to raise_error(/webhook #{web_hook.id} failed; timed_out=false code=500/)
+        end.to raise_error(/webhook failed webhook_id=#{web_hook.id} timed_out=false code=500/)
       end
 
       it "raises an error if the receiver times out" do
@@ -124,7 +124,7 @@ describe WebHook, type: :model do
 
         expect do
           web_hook.send_project_updated(project)
-        end.to raise_error(/webhook #{web_hook.id} failed; timed_out=true code=0/)
+        end.to raise_error(/webhook failed webhook_id=#{web_hook.id} timed_out=true code=0/)
       end
     end
   end


### PR DESCRIPTION
this PR adds a `Repository#projects_dependencies` method and adds it to endpoints/codepaths where we want to fetch a repo's deps.

### Flowchart: how fetching deps for a repository is changed by this PR

``` mermaid
flowchart TB
subgraph "AFTER"
    direction TB
    Repository1["Repository"] --> Project
    Project --> Version
    Version --> Dependency1["Dependency 1\n e.g. 'rack 1.0.0'"]
    Version --> Dependency2["Dependency 2\n e.g. 'dalli ~> 2.0.0'"]
    Version --> Dependency3["Dependency 3\n e.g. 'bibliothecary ~ 1.7'"]
end
subgraph "BEFORE"
    direction TB
    Repository2["Repository"] --> RepositoryDependency4["Dependency 1\n e.g. 'rack 1.0.0'"]
    Repository2["Repository"] --> RepositoryDependency5["Dependency 2\n e.g. 'dalli ~> 2.0.0'"]
    Repository2["Repository"] --> RepositoryDependency6["Dependency 3\n e.g. 'bibliothecary ~ 1.7'"]
end

```

## RepositoryDependency vs Dependency: where is the data from?

**RepositoryDependency** is populated by scanning all the manifest files for deps in the repository, e.g. `https://github.com/librariesio/libraries.io`. 

**Dependency**  is populated by scanning the actual package's dependencies from its package repository API.

## Why?

#### Scanning all the manifests in a repository for RepositoryDependency is inaccurate for many many repos

e.g. Libraries currently sees an NPM project and records the deps records for its `package-lock.json` manifest *and* every dep for all the manifests nested inside `node_modules/`. 

additionally, Libraries is also pulling deps from test folders, template folders, build output folders, educational folders, etc.

#### Removed repositories take up space

of the top 100 repositories with the most manifests, 12 of them are Removed.

#### Package deps > repository deps

deps for specific packages are more useful than 100% of the deps found in its repository

#### * Alternatives exist

GitHub (which accounts for 98% of the repos on Libraries) now has an `Insight > Dependency Graph` page that can list the deps found in the entire repo, if people still need that data.

## Which Libraries endpoints will this affect?

* Web: showing a repo's dependencies will now pull the deps from the repo's projects
* Web: showing a project's usage will now pull from project deps instead of repo deps
* Api: pulling repository dependencies will now pull from project deps instead of repo deps
* Api: the docs page will now us project deps in the example for repositorie's dependencies

## Breaking changes?

Other than the source of the dependency data changing, we will start returning `filepath: nil` for all repository dependencies from the API, since we don't have a relative filepath to the repo in most cases.

## Next step

after this is deployed, and if there are no issues with it, we can followup with a PR to stop ingesting RepositoryDependencies and also get rid of the table.
