### PR TITLE
Repository: allow status: "Removed" to be unset

### DIFF
--- a/app/domain/repository/persist_repository_from_upstream.rb
+++ b/app/domain/repository/persist_repository_from_upstream.rb
@@ -111,13 +111,16 @@ class Repository::PersistRepositoryFromUpstream
                             })
       # set to unmaintained if we do not have another status already assigned
       "Unmaintained"
-    elsif !archived_upstream && repository.status == "Unmaintained"
-      StructuredLog.capture("REPOSITORY_REMOVE_UNMAINTAINED_STATUS",
-                            {
-                              repository_host: repository.host_type,
-                              repository_id: repository.id,
-                              full_name: repository.full_name,
-                            })
+    elsif !archived_upstream && %w[Unmaintained Removed].include?(repository.status)
+      if repository.status == "Unmaintained"
+        StructuredLog.capture("REPOSITORY_REMOVE_UNMAINTAINED_STATUS",
+                              {
+                                repository_host: repository.host_type,
+                                repository_id: repository.id,
+                                full_name: repository.full_name,
+                              })
+      end
+
       # set back to nil if we currently have it marked as unmaintained
       nil
     else

--- a/app/domain/repository/persist_repository_from_upstream.rb
+++ b/app/domain/repository/persist_repository_from_upstream.rb
@@ -112,7 +112,7 @@ class Repository::PersistRepositoryFromUpstream
       # set to unmaintained if we do not have another status already assigned
       "Unmaintained"
     elsif !archived_upstream && %w[Unmaintained Removed].include?(repository.status)
-      StructuredLog.capture("REPOSITORY_UNSETTING_REMOVED_STATUS",
+      StructuredLog.capture("REPOSITORY_UNSETTING_STATUS",
                             {
                               repository_host: repository.host_type,
                               repository_id: repository.id,

--- a/app/domain/repository/persist_repository_from_upstream.rb
+++ b/app/domain/repository/persist_repository_from_upstream.rb
@@ -112,14 +112,13 @@ class Repository::PersistRepositoryFromUpstream
       # set to unmaintained if we do not have another status already assigned
       "Unmaintained"
     elsif !archived_upstream && %w[Unmaintained Removed].include?(repository.status)
-      if repository.status == "Unmaintained"
-        StructuredLog.capture("REPOSITORY_REMOVE_UNMAINTAINED_STATUS",
-                              {
-                                repository_host: repository.host_type,
-                                repository_id: repository.id,
-                                full_name: repository.full_name,
-                              })
-      end
+      StructuredLog.capture("REPOSITORY_UNSETTING_REMOVED_STATUS",
+                            {
+                              repository_host: repository.host_type,
+                              repository_id: repository.id,
+                              full_name: repository.full_name,
+                              current_status: repository.status,
+                            })
 
       # set back to nil if we currently have it marked as unmaintained
       nil

--- a/app/models/repository_host/raw_upstream_data_converter.rb
+++ b/app/models/repository_host/raw_upstream_data_converter.rb
@@ -52,7 +52,7 @@ class RepositoryHost::RawUpstreamDataConverter
       is_private: api_project.visibility != "public",
       keywords: api_project.topics,
       language: nil, # separate API endpoint that doesn't seem to be supported by the API gem we use,
-      license: api_project.license.key,
+      license: api_project.license&.key,
       logo_url: api_project.avatar_url,
       mirror_url: nil,
       name: api_project.name,

--- a/spec/domain/repository/persist_repository_from_upstream_spec.rb
+++ b/spec/domain/repository/persist_repository_from_upstream_spec.rb
@@ -181,6 +181,22 @@ RSpec.describe Repository::PersistRepositoryFromUpstream do
       end
     end
 
+    context "with Removed status repository" do
+      let(:status) { "Removed" }
+
+      context "with archived upstream repo" do
+        it "should suggest removed status" do
+          expect(described_class.correct_status_from_upstream(repository, archived_upstream: true)).to eql("Removed")
+        end
+      end
+
+      context "with non archived upstream repo" do
+        it "should suggest nil status" do
+          expect(described_class.correct_status_from_upstream(repository, archived_upstream: false)).to be_nil
+        end
+      end
+    end
+
     context "with hidden status repository" do
       let(:status) { "Hidden" }
 


### PR DESCRIPTION
Presently, if we mark a Repository as with `status: "Removed"`, that is a terminal state which the Repository cannot leave. This PR enables unsetting the Repository's `status`, provided that the repository is reachable, and we get `archived: false` from the RepositoryHost.