### PR TITLE
GoMod#canonical_module_name: handle go module names from go.mod that have double-quotes 

### DIFF
--- a/app/models/package_manager/go/go_mod.rb
+++ b/app/models/package_manager/go/go_mod.rb
@@ -6,7 +6,7 @@ class PackageManager::Go
 
     RETRACT_WITH_PARENS = /^\s*retract\s\((.*?)\)/m
     RETRACT_WITHOUT_PARENS = /retract\s(.+)/
-    MODULE_REGEX = /module\s+(.+)/
+    MODULE_REGEX = /module\s+"?([^"]+)"?/
     LOCAL_FILEPATH_REGEXP = /\.?\.\//
 
     def initialize(mod_contents)

--- a/spec/models/package_manager/go/go_mod_spec.rb
+++ b/spec/models/package_manager/go/go_mod_spec.rb
@@ -146,6 +146,18 @@ RSpec.describe PackageManager::Go::GoMod do
       expect(go_mod.canonical_module_name).to eq("my_cool_package")
     end
 
+    context "when an older vgo go.mod file has quoted name" do
+      let(:mod_contents) do
+        <<~MODFILE
+          module "my_cool_package"
+        MODFILE
+      end
+
+      it "reads module name from go.mod" do
+        expect(go_mod.canonical_module_name).to eq("my_cool_package")
+      end
+    end
+
     context "when malformed" do
       let(:mod_contents) do
         <<~MODFILE


### PR DESCRIPTION
these days `go.mod` files declare their name like `module my.go/module/name` at the top of the file, but it [looks like vgo](https://research.swtch.com/vgo-intro#defining_go_modules), the predecessor to Go Modules, actually quoted the name, e.g. `module "my.go/module/name"`

Go still seems able to parse these older `go.mod` files and will also auto-correct them when it updates the `go.mod` file. But pkg.go.dev [doesn't consider them valid](https://pkg.go.dev/github.com/simonwaldherr/gwv).

this adds support for the quoted names when looking up the canonical name via the Go Proxy's go.mod API, to avoid errors like these when updating the package:

`bad URI(is not URI?): "https://pkg.go.dev/\"github.com/SimonWaldherr/gwv\""`