### PR TITLE
Remove Manifest logic and code

### DIFF
--- a/app/controllers/admin/stats_controller.rb
+++ b/app/controllers/admin/stats_controller.rb
@@ -16,7 +16,6 @@ class Admin::StatsController < Admin::ApplicationController
 
   def repositories
     @new_users          = stats_for(RepositoryUser)
-    @new_manifests      = stats_for(Manifest)
     @new_orgs           = stats_for(RepositoryOrganisation)
   end
 

--- a/app/controllers/api/docs_controller.rb
+++ b/app/controllers/api/docs_controller.rb
@@ -19,7 +19,7 @@ class Api::DocsController < ApplicationController
 
     @repo_dependencies = @repository.as_json
 
-    @repo_dependencies[:dependencies] = map_dependencies(@repository.projects_dependencies || [])
+    @repo_dependencies[:dependencies] = map_dependencies(@repository.projects_dependencies)
 
     @search = Project.search("grunt", api: true).records
 

--- a/app/controllers/api/repositories_controller.rb
+++ b/app/controllers/api/repositories_controller.rb
@@ -17,7 +17,7 @@ class Api::RepositoriesController < Api::ApplicationController
     cache_key = "repository_dependencies:#{@repository.id}"
     json_hash = Rails.cache.fetch(cache_key, expires_in: 1.day) do
       result = RepositorySerializer.new(@repository).as_json
-      result[:dependencies] = map_dependencies(@repository.projects_dependencies || []).map(&:as_json)
+      result[:dependencies] = map_dependencies(@repository.projects_dependencies).map(&:as_json)
       result
     end
     render json: json_hash
@@ -28,7 +28,7 @@ class Api::RepositoriesController < Api::ApplicationController
     cache_key = "shields_dependencies:#{@repository.id}"
     json_hash = Rails.cache.fetch(cache_key, expires_in: 1.day) do
       deps = @repository
-        .projects_dependencies(includes: [:project])
+        .projects_dependencies.includes(:project)
 
       deprecated_count = deps
         .select(&:deprecated?)

--- a/app/models/concerns/repo_metadata.rb
+++ b/app/models/concerns/repo_metadata.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module RepoManifests
+module RepoMetadata
   def download_metadata(token = nil)
     file_list = get_file_list(token)
     return if file_list.blank?

--- a/app/models/manifest.rb
+++ b/app/models/manifest.rb
@@ -20,14 +20,5 @@
 #  index_manifests_on_repository_id  (repository_id)
 #
 class Manifest < ApplicationRecord
-  belongs_to :repository
-  has_many :repository_dependencies, dependent: :delete_all
-
-  scope :latest, -> { order("manifests.filepath, manifests.created_at DESC").select("DISTINCT on (manifests.filepath) *") }
-  scope :platform, ->(platform) { where("lower(manifests.platform) = ?", platform.try(:downcase)) }
-  scope :kind, ->(kind) { where(kind: kind) }
-
-  def repository_link
-    repository.blob_url(branch) + filepath
-  end
+  # TODO: this table will be removed
 end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -66,6 +66,7 @@
 #
 class Repository < ApplicationRecord
   include Status
+  include RepoMetadata
   include RepositorySourceRank
 
   # eager load this module to avoid clashing with Gitlab gem in development

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -356,7 +356,6 @@ class Repository < ApplicationRecord
     repository = Repository.where(host_type: "GitHub").find_by_uuid(uuid)
     user = Identity.where("provider ILIKE ?", "github%").where(uid: sender_id).first.try(:user)
     if user.present? && repository.present?
-      repository.download_metadata(user.token)
       repository.update_all_info_async(user.token)
     end
   end

--- a/app/models/repository_dependency.rb
+++ b/app/models/repository_dependency.rb
@@ -26,7 +26,6 @@
 class RepositoryDependency < ApplicationRecord
   include DependencyChecks
 
-  belongs_to :manifest
   belongs_to :project
   belongs_to :repository
 
@@ -45,7 +44,6 @@ class RepositoryDependency < ApplicationRecord
   alias outdated outdated?
 
   delegate :latest_stable_release_number, :latest_release_number, :deprecated?, to: :project, allow_nil: true
-  delegate :filepath, to: :manifest
 
   def find_project_id
     Project.find_best(platform, project_name&.strip)&.id

--- a/app/models/repository_organisation.rb
+++ b/app/models/repository_organisation.rb
@@ -31,8 +31,8 @@ class RepositoryOrganisation < ApplicationRecord
   has_many :repositories
   has_many :source_repositories, -> { where fork: false }, anonymous_class: Repository
   has_many :open_source_repositories, -> { where fork: false, private: false }, anonymous_class: Repository
-  has_many :dependencies, through: :open_source_repositories
-  has_many :favourite_projects, -> { group("projects.id").order(Arel.sql("COUNT(projects.id) DESC, projects.rank DESC")) }, through: :dependencies, source: :project
+  # TODO: there might be a way to fetch these through repositories#projects_dependencies
+  has_many :favourite_projects, -> { none }, source: :projects
   has_many :all_dependent_repos, -> { group("repositories.id") }, through: :favourite_projects, source: :repository
   has_many :contributors, -> { group("repository_users.id").order(Arel.sql("sum(contributions.count) DESC")) }, through: :open_source_repositories, source: :contributors
   has_many :projects, through: :open_source_repositories

--- a/app/models/repository_organisation.rb
+++ b/app/models/repository_organisation.rb
@@ -31,7 +31,6 @@ class RepositoryOrganisation < ApplicationRecord
   has_many :repositories
   has_many :source_repositories, -> { where fork: false }, anonymous_class: Repository
   has_many :open_source_repositories, -> { where fork: false, private: false }, anonymous_class: Repository
-  has_many :all_dependent_repos, -> { group("repositories.id") }, through: :favourite_projects, source: :repository
   has_many :contributors, -> { group("repository_users.id").order(Arel.sql("sum(contributions.count) DESC")) }, through: :open_source_repositories, source: :contributors
   has_many :projects, through: :open_source_repositories
 

--- a/app/models/repository_organisation.rb
+++ b/app/models/repository_organisation.rb
@@ -57,7 +57,7 @@ class RepositoryOrganisation < ApplicationRecord
   # TODO: can this be an association again if we made projects_dependencies a Repository association again?
   def favourite_projects
     dep_ids = open_source_repositories
-      .flat_map { |r| r.projects_dependencies(only_visible: true).map(&:id) }
+      .flat_map { |r| r.projects_dependencies.merge(Project.visible).map(&:id) }
       .uniq
 
     Project

--- a/app/models/repository_subscription.rb
+++ b/app/models/repository_subscription.rb
@@ -25,7 +25,7 @@ class RepositorySubscription < ApplicationRecord
 
   def update_subscriptions
     projects = []
-    repository.projects_dependencies(includes: [:project]).each do |dep|
+    repository.projects_dependencies.includes(:project).each do |dep|
       if dep.project.present?
         project = dep.project.try(:id)
       elsif dep.project_name.present?

--- a/app/models/repository_user.rb
+++ b/app/models/repository_user.rb
@@ -45,7 +45,7 @@ class RepositoryUser < ApplicationRecord
   # TODO: can this be an association again if we made projects_dependencies a Repository association again?
   def favourite_projects
     dep_ids = open_source_repositories
-      .flat_map { |r| r.projects_dependencies(only_visible: true).map(&:id) }
+      .flat_map { |r| r.projects_dependencies.merge(Project.visible).map(&:id) }
       .uniq
 
     Project

--- a/app/models/repository_user.rb
+++ b/app/models/repository_user.rb
@@ -35,9 +35,7 @@ class RepositoryUser < ApplicationRecord
   has_many :repositories
   has_many :source_repositories, -> { where fork: false }, anonymous_class: Repository
   has_many :open_source_repositories, -> { where fork: false, private: false }, anonymous_class: Repository
-  has_many :dependencies, through: :open_source_repositories
-  has_many :favourite_projects, -> { group("projects.id").order(Arel.sql("COUNT(projects.id) DESC, projects.rank DESC")) }, through: :dependencies, source: :project
-  has_many :all_dependent_repos, -> { group("repositories.id") }, through: :favourite_projects, source: :repository
+  has_many :favourite_projects, -> { group("projects.id").order(Arel.sql("COUNT(projects.id) DESC, projects.rank DESC")) }, through: :repositories, source: :projects
   has_many :contributed_repositories, -> { Repository.source.open_source }, through: :contributions, source: :repository
   has_many :contributed_projects, through: :contributed_repositories, source: :projects
   has_many :contributors, -> { group("repository_users.id").order(Arel.sql("sum(contributions.count) DESC")) }, through: :open_source_repositories, source: :contributors

--- a/app/models/repository_user.rb
+++ b/app/models/repository_user.rb
@@ -35,25 +35,14 @@ class RepositoryUser < ApplicationRecord
   has_many :repositories
   has_many :source_repositories, -> { where fork: false }, anonymous_class: Repository
   has_many :open_source_repositories, -> { where fork: false, private: false }, anonymous_class: Repository
+  has_many :open_source_projects_dependencies, through: :open_source_repositories, source: :projects_dependencies
+  has_many :favourite_projects, -> { group("projects.id").order(Arel.sql("COUNT(projects.id) DESC, projects.rank DESC")) }, through: :open_source_projects_dependencies, source: :project
   has_many :contributed_repositories, -> { Repository.source.open_source }, through: :contributions, source: :repository
   has_many :contributed_projects, through: :contributed_repositories, source: :projects
   has_many :contributors, -> { group("repository_users.id").order(Arel.sql("sum(contributions.count) DESC")) }, through: :open_source_repositories, source: :contributors
   has_many :fellow_contributors, ->(object) { where.not(id: object.id).group("repository_users.id").order(Arel.sql("COUNT(repository_users.id) DESC")) }, through: :contributed_repositories, source: :contributors
   has_many :projects, through: :open_source_repositories
   has_many :identities
-
-  # TODO: can this be an association again if we made projects_dependencies a Repository association again?
-  def favourite_projects
-    dep_ids = open_source_repositories
-      .flat_map { |r| r.projects_dependencies.merge(Project.visible).map(&:id) }
-      .uniq
-
-    Project
-      .joins(:dependents)
-      .where(dependencies: { id: dep_ids })
-      .group("projects.id")
-      .order(Arel.sql("COUNT(projects.id) DESC, projects.rank DESC"))
-  end
 
   # eager load this module to avoid clashing with Gitlab gem in development
   RepositoryOwner::Gitlab # rubocop: disable Lint/Void

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -50,7 +50,7 @@ class Tag < ApplicationRecord
     repository.projects.without_versions.each do |project|
       repos = project.subscriptions.map(&:repository).compact.uniq
       repos.each do |repo|
-        requirements = repo.projects_dependencies(includes: [:project]).select { |rd| rd.project == project }.map(&:requirements)
+        requirements = repo.projects_dependencies.includes(:project).select { |rd| rd.project == project }.map(&:requirements)
         repo.web_hooks.each do |web_hook|
           web_hook.send_new_version(project, project.platform, self, requirements)
         end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,9 +45,8 @@ class User < ApplicationRecord
   has_many :dependencies, through: :source_repositories
   has_many :really_all_dependencies, through: :all_repositories, source: :dependencies
   has_many :all_dependent_projects, -> { group("projects.id") }, through: :really_all_dependencies, source: :project
-  has_many :all_dependent_repos, -> { group("repositories.id") }, through: :all_dependent_projects, source: :repository
 
-  has_many :favourite_projects, -> { group("projects.id").order("COUNT(projects.id) DESC, projects.rank DESC") }, through: :dependencies, source: :project
+  has_many :favourite_projects, -> { group("projects.id").order("COUNT(projects.id) DESC, projects.rank DESC") }, through: :dependencies, source: :projects
 
   has_many :project_mutes, dependent: :delete_all
   has_many :muted_projects, through: :project_mutes, source: :project

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,7 +68,7 @@ class User < ApplicationRecord
   # TODO: can this be an association again if we made projects_dependencies a Repository association again?
   def favourite_projects
     dep_ids = source_repositories
-      .flat_map { |r| r.projects_dependencies(only_visible: true).map(&:id) }
+      .flat_map { |r| r.projects_dependencies.merge(Project.visible).map(&:id) }
       .uniq
 
     Project
@@ -111,7 +111,7 @@ class User < ApplicationRecord
   def watched_dependent_projects
     repository_subscriptions
       .map(&:repository)
-      .map { |r| r.projects_dependencies(includes: [:project], only_visible: true).map(&:project) }
+      .map { |r| r.projects_dependencies.includes(:project).merge(Project.visible).map(&:project) }
       .flatten
       .uniq
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,10 +42,6 @@ class User < ApplicationRecord
 
   has_many :watched_repositories, source: :repository, through: :repository_subscriptions
 
-  has_many :dependencies, through: :source_repositories
-  has_many :really_all_dependencies, through: :all_repositories, source: :dependencies
-  has_many :all_dependent_projects, -> { group("projects.id") }, through: :really_all_dependencies, source: :project
-
   has_many :project_mutes, dependent: :delete_all
   has_many :muted_projects, through: :project_mutes, source: :project
   has_many :project_suggestions
@@ -56,6 +52,18 @@ class User < ApplicationRecord
 
   validates_presence_of :email, on: :update
   validates_format_of :email, with: /\A[^@\s]+@([^@\s]+\.)+[^@\s]+\z/, on: :update
+
+  # TODO: can this be an association again if we made projects_dependencies a Repository association again?
+  def dependencies
+    source_repositories
+      .flat_map(&:projects_dependencies)
+  end
+
+  # TODO: can this be an association again if we made projects_dependencies a Repository association again?
+  def really_all_dependencies
+    all_repositories
+      .flat_map(&:projects_dependencies)
+  end
 
   # TODO: can this be an association again if we made projects_dependencies a Repository association again?
   def favourite_projects

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -102,7 +102,7 @@ class Version < ApplicationRecord
   def notify_web_hooks
     repos = project.subscriptions.map(&:repository).compact.uniq
     repos.each do |repo|
-      requirements = repo.projects_dependencies(includes: [:project]).select { |rd| rd.project == project }.map(&:requirements)
+      requirements = repo.projects_dependencies.includes(:project).select { |rd| rd.project == project }.map(&:requirements)
       repo.web_hooks.each do |web_hook|
         web_hook.send_new_version(project, project.platform, self, requirements)
       end

--- a/app/views/admin/stats/overview.html.erb
+++ b/app/views/admin/stats/overview.html.erb
@@ -25,10 +25,6 @@
     <h2>
       <%= number_to_human RepositorySubscription.fast_total %> Repository Subscriptions
     </h2>
-
-    <h2>
-      <%= number_to_human Manifest.fast_total %> Manifests
-    </h2>
   </div>
 
   <div class="col-md-6">

--- a/app/views/admin/stats/repositories.html.erb
+++ b/app/views/admin/stats/repositories.html.erb
@@ -7,5 +7,4 @@
 <div class="row">
   <%= stats_for('Orgs', @new_orgs) %>
   <%= stats_for('Users', @new_users) %>
-  <%= stats_for('Manifests', @new_manifests) %>
 </div>

--- a/spec/models/manifest_spec.rb
+++ b/spec/models/manifest_spec.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-require "rails_helper"
-
-describe Manifest, type: :model do
-  it { should belong_to(:repository) }
-  it { should have_many(:repository_dependencies) }
-end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe Project, type: :model do
   it { should have_many(:versions) }
+  it { should belong_to(:latest_version) }
   it { should have_many(:dependencies) }
   it { should have_many(:contributions) }
   it { should have_many(:contributors) }

--- a/spec/models/repository_dependency_spec.rb
+++ b/spec/models/repository_dependency_spec.rb
@@ -3,6 +3,5 @@
 require "rails_helper"
 
 describe RepositoryDependency, type: :model do
-  it { should belong_to(:manifest) }
   it { should belong_to(:project) }
 end

--- a/spec/models/repository_organisation_spec.rb
+++ b/spec/models/repository_organisation_spec.rb
@@ -6,8 +6,6 @@ describe RepositoryOrganisation, type: :model do
   it { should have_many(:repositories) }
   it { should have_many(:source_repositories) }
   it { should have_many(:open_source_repositories) }
-  it { should have_many(:dependencies) }
-  it { should have_many(:favourite_projects) }
   it { should have_many(:contributors) }
   it { should have_many(:projects) }
 

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -8,8 +8,6 @@ describe Repository, type: :model do
   it { should have_many(:contributors) }
   it { should have_many(:tags) }
   it { should have_many(:published_tags) }
-  it { should have_many(:manifests) }
-  it { should have_many(:dependencies) }
   it { should have_many(:forked_repositories) }
   it { should have_many(:repository_subscriptions) }
   it { should have_many(:web_hooks) }

--- a/spec/models/repository_user_spec.rb
+++ b/spec/models/repository_user_spec.rb
@@ -7,8 +7,6 @@ describe RepositoryUser, type: :model do
   it { should have_many(:repositories) }
   it { should have_many(:source_repositories) }
   it { should have_many(:open_source_repositories) }
-  it { should have_many(:dependencies) }
-  it { should have_many(:favourite_projects) }
   it { should have_many(:contributors) }
   it { should have_many(:projects) }
   it { should have_many(:contributed_repositories) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,10 +14,6 @@ describe User, type: :model do
   it { should have_many(:adminable_repository_organisations) }
   it { should have_many(:source_repositories) }
   it { should have_many(:watched_repositories) }
-  it { should have_many(:dependencies) }
-  it { should have_many(:really_all_dependencies) }
-  it { should have_many(:all_dependent_projects) }
-  it { should have_many(:favourite_projects) }
   it { should have_many(:project_mutes) }
   it { should have_many(:muted_projects) }
   it { should have_many(:project_suggestions) }


### PR DESCRIPTION
in the quest to [phase out RepositoryDependency](https://github.com/librariesio/libraries.io/pull/3362), this removes any views or logic around Manifests. Manifests aren't used at all outside of RepositoryDependency code.

### Why?

Because data in the Manifest table are disconnected from data in the Projects and Dependency tables, which we want to use instead of RepositoryDependency:

``` mermaid
flowchart BT
Project --> Repository
Dependency --> Project
Manifest --> Repository
RepositoryDependency --> Manifest

```

