### PR TITLE
Fix RepositorySourceRank after the move to projects_dependencies.

### DIFF
--- a/app/models/concerns/repository_source_rank.rb
+++ b/app/models/concerns/repository_source_rank.rb
@@ -73,7 +73,7 @@ module RepositorySourceRank
   end
 
   def any_outdated_dependencies?
-    dependencies.any?(&:outdated?)
+    projects_dependencies.any?(&:outdated?)
   end
 
   def log_scale(number)


### PR DESCRIPTION
one location where I forgot to switch usage of `Repository#dependencies` to `Repository#projects_dependencies`