### PR TITLE
Api::Repositories#show: pass readme back when ?include_readme=true

### DIFF
--- a/app/controllers/api/repositories_controller.rb
+++ b/app/controllers/api/repositories_controller.rb
@@ -4,7 +4,8 @@ class Api::RepositoriesController < Api::ApplicationController
   before_action :find_repo, except: :search
 
   def show
-    repo_json = RepositorySerializer.new(@repository).as_json
+    include_readme = ActiveModel::Type::Boolean.new.cast(params[:include_readme])
+    repo_json = RepositorySerializer.new(@repository, include_readme: include_readme).as_json
     repo_json[:maintenance_stats] = maintenance_stats(@repository) if internal_api_key?
     render json: repo_json
   end

--- a/app/serializers/repository_serializer.rb
+++ b/app/serializers/repository_serializer.rb
@@ -10,4 +10,10 @@ class RepositorySerializer < ActiveModel::Serializer
              :has_threat_model, :has_audit, :status, :last_synced_at, :rank,
              :host_type, :host_domain, :name, :scm, :fork_policy, :github_id,
              :pull_requests_enabled, :logo_url, :github_contributions_count, :keywords
+
+  attribute :readme_html_body, if: -> { instance_options[:include_readme] == true }
+
+  def readme_html_body
+    object.readme&.html_body
+  end
 end

--- a/spec/requests/api/repositories_spec.rb
+++ b/spec/requests/api/repositories_spec.rb
@@ -93,5 +93,19 @@ describe "Api::RepositoriesController" do
 
       expect(json["maintenance_stats"].to_json).to be_json_eql([maintenance_stat.attributes.symbolize_keys.slice(*RepositoryMaintenanceStat::API_FIELDS)].to_json)
     end
+
+    it "doesn't include readme when include_readme=false" do
+      get "/api/github/#{repository.full_name}?include_readme=false", params: { api_key: internal_user.api_key }
+      expect(response).to have_http_status(:success)
+      expect(response.content_type).to start_with("application/json")
+      expect(json.as_json.keys).to_not include("readme_html_body")
+    end
+
+    it "includes readme when include_readme=true" do
+      get "/api/github/#{repository.full_name}?include_readme=true", params: { api_key: internal_user.api_key }
+      expect(response).to have_http_status(:success)
+      expect(response.content_type).to start_with("application/json")
+      expect(json.as_json.keys).to include("readme_html_body")
+    end
   end
 end

--- a/spec/requests/api/repositories_spec.rb
+++ b/spec/requests/api/repositories_spec.rb
@@ -94,18 +94,23 @@ describe "Api::RepositoriesController" do
       expect(json["maintenance_stats"].to_json).to be_json_eql([maintenance_stat.attributes.symbolize_keys.slice(*RepositoryMaintenanceStat::API_FIELDS)].to_json)
     end
 
-    it "doesn't include readme when include_readme=false" do
-      get "/api/github/#{repository.full_name}?include_readme=false", params: { api_key: internal_user.api_key }
-      expect(response).to have_http_status(:success)
-      expect(response.content_type).to start_with("application/json")
-      expect(json.as_json.keys).to_not include("readme_html_body")
-    end
+    context "when repository has a readme" do
+      let!(:repository) { create(:repository, readme: build(:readme, html_body: "<html>this is my readme</html>")) }
 
-    it "includes readme when include_readme=true" do
-      get "/api/github/#{repository.full_name}?include_readme=true", params: { api_key: internal_user.api_key }
-      expect(response).to have_http_status(:success)
-      expect(response.content_type).to start_with("application/json")
-      expect(json.as_json.keys).to include("readme_html_body")
+      it "doesn't include readme when include_readme=false" do
+        get "/api/github/#{repository.full_name}?include_readme=false", params: { api_key: internal_user.api_key }
+        expect(response).to have_http_status(:success)
+        expect(response.content_type).to start_with("application/json")
+        expect(json.as_json.keys).to_not include("readme_html_body")
+      end
+
+      it "includes readme when include_readme=true" do
+        get "/api/github/#{repository.full_name}?include_readme=true", params: { api_key: internal_user.api_key }
+        expect(response).to have_http_status(:success)
+        expect(response.content_type).to start_with("application/json")
+        expect(json.as_json.keys).to include("readme_html_body")
+        expect(json["readme_html_body"]).to include("this is my readme")
+      end
     end
   end
 end

--- a/spec/serializers/repository_serializer_spec.rb
+++ b/spec/serializers/repository_serializer_spec.rb
@@ -18,4 +18,13 @@ describe RepositorySerializer do
       pull_requests_enabled logo_url github_contributions_count keywords
     ])
   end
+
+  context "when :include_readme option is true" do
+    subject { described_class.new(build(:repository, readme: build(:readme, html_body: "<html>this is my readme</html>")), include_readme: true) }
+
+    it "renders readme when flag is passed" do
+      expect(subject.attributes.keys).to include(:readme_html_body)
+      expect(subject.readme_html_body).to eq("<html>this is my readme</html>")
+    end
+  end
 end


### PR DESCRIPTION
### Example

``` shell
curl https://libraries.io/api/github/librariesio/bibliothecary?include_readme=true

{
  "full_name": "librariesio/bibliothecary",
 "readme_html_body": "<!DOCTYPE html PUBLIC \"-//W3C//DT ... ",
 ...
}
```