### PR TITLE
Adds an Api::Repositories#sync internal endpoint

### DIFF
--- a/app/controllers/api/repositories_controller.rb
+++ b/app/controllers/api/repositories_controller.rb
@@ -49,10 +49,10 @@ class Api::RepositoriesController < Api::ApplicationController
   def sync
     if @repository.recently_synced?
       StructuredLog.capture(
-        "REPOSITORY_SYNC_REQUEST_SKIPPED", {
+        "REPOSITORY_MANUAL_SYNC_REQUEST_SKIPPED", {
           host_type: @repository.host_type,
           full_name: @repository.full_name,
-          repository_last_synced_at: @repository.last_synced_at,
+          last_synced_at: @repository.last_synced_at,
         }
       )
       render json: { error: "Repository has already been synced recently" }

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -224,6 +224,12 @@ class Project < ApplicationRecord
   end
 
   def manual_sync
+    StructuredLog.capture("PROJECT_MANUAL_SYNC",
+    {
+      platform: platform,
+      name: name,
+      last_synced_at: last_synced_at,
+    })
     async_sync(force_sync_dependencies: true)
     update_repository_async
     forced_save

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -234,10 +234,6 @@ class Project < ApplicationRecord
     save
   end
 
-  def set_last_synced_at
-    update_attribute(:last_synced_at, Time.zone.now)
-  end
-
   def async_sync(force_sync_dependencies: false)
     return unless platform_class_exists?
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -225,11 +225,11 @@ class Project < ApplicationRecord
 
   def manual_sync
     StructuredLog.capture("PROJECT_MANUAL_SYNC",
-    {
-      platform: platform,
-      name: name,
-      last_synced_at: last_synced_at,
-    })
+                          {
+                            platform: platform,
+                            name: name,
+                            last_synced_at: last_synced_at,
+                          })
     async_sync(force_sync_dependencies: true)
     update_repository_async
     forced_save

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -267,11 +267,11 @@ class Repository < ApplicationRecord
 
   def manual_sync(token = nil)
     StructuredLog.capture("REPOSITORY_MANUAL_SYNC",
-    {
-      host_type: host_type,
-      full_name: full_name,
-      repository_last_synced_at: last_synced_at,
-    })
+                          {
+                            host_type: host_type,
+                            full_name: full_name,
+                            repository_last_synced_at: last_synced_at,
+                          })
     update_all_info_async(token)
     update(last_synced_at: Time.now)
   end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -266,9 +266,14 @@ class Repository < ApplicationRecord
   end
 
   def manual_sync(token = nil)
+    StructuredLog.capture("REPOSITORY_MANUAL_SYNC",
+    {
+      host_type: host_type,
+      full_name: full_name,
+      repository_last_synced_at: last_synced_at,
+    })
     update_all_info_async(token)
-    self.last_synced_at = Time.zone.now
-    save
+    update(last_synced_at: Time.now)
   end
 
   def update_all_info_async(token = nil)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
       get "/:host_type/:owner/:name/dependencies", to: "repositories#dependencies", constraints: { name: /[^\/]+/ }
       get "/:host_type/:owner/:name/shields_dependencies", to: "repositories#shields_dependencies", constraints: { name: /[^\/]+/ }
       get "/:host_type/:owner/:name/projects", to: "repositories#projects", constraints: { name: /[^\/]+/ }
+      get "/:host_type/:owner/:name/sync", to: "repositories#sync", constraints: { name: /[^\/]+/ }
       get "/:host_type/:owner/:name", to: "repositories#show", constraints: { name: /[^\/]+/ }
 
       get "/:host_type/:login", to: "repository_users#show"

--- a/spec/requests/api/repositories_spec.rb
+++ b/spec/requests/api/repositories_spec.rb
@@ -115,6 +115,16 @@ describe "Api::RepositoriesController" do
   end
 
   describe "GET /api/github/:owner/:name/sync", type: :request do
+    context "without api key" do
+      it "forbids action" do
+        get "/api/github/#{repository.full_name}/sync"
+
+        expect(response).to have_http_status(:forbidden)
+        expect(response.content_type).to start_with("application/json")
+        expect(response.body).to include("403")
+      end
+    end
+
     context "without internal api key" do
       it "forbids action" do
         get "/api/github/#{repository.full_name}/sync", params: { api_key: create(:user).api_key }

--- a/spec/requests/api/repositories_spec.rb
+++ b/spec/requests/api/repositories_spec.rb
@@ -113,4 +113,38 @@ describe "Api::RepositoriesController" do
       end
     end
   end
+
+  describe "GET /api/github/:owner/:name/sync", type: :request do
+    context "without internal api key" do
+      it "forbids action" do
+        get "/api/github/#{repository.full_name}/sync", params: { api_key: create(:user).api_key }
+
+        expect(response).to have_http_status(:forbidden)
+        expect(response.content_type).to start_with("application/json")
+        expect(response.body).to include("403")
+      end
+    end
+
+    context "already recently synced" do
+      before { repository.update!(last_synced_at: 1.hour.ago) }
+
+      it "notifies already recently synced" do
+        get "/api/github/#{repository.full_name}/sync", params: { api_key: internal_user.api_key }
+
+        expect(response).to have_http_status(:success)
+        expect(response.content_type).to start_with("application/json")
+        expect(response.body).to include("Repository has already been synced recently")
+      end
+    end
+
+    context "success" do
+      it "notifies the sync is queued" do
+        get "/api/github/#{repository.full_name}/sync", params: { api_key: internal_user.api_key }
+
+        expect(response).to have_http_status(:success)
+        expect(response.content_type).to start_with("application/json")
+        expect(response.body).to include("Repository queued for re-sync")
+      end
+    end
+  end
 end


### PR DESCRIPTION
this endpoint is similar to the `Api::Projects#sync` endpoint, and only works for internal keys as well.

e.g. `curl https://libraries.io/api/github/librariesio/bibliothecary/sync?api_key=...