### PR TITLE
Change Dependencies [project_id] index to [project_id version_id]

### DIFF
--- a/app/models/dependency.rb
+++ b/app/models/dependency.rb
@@ -17,9 +17,9 @@
 #
 # Indexes
 #
-#  index_dependencies_on_project_created_at_date  (project_id, ((created_at)::date))
-#  index_dependencies_on_project_id               (project_id)
-#  index_dependencies_on_version_id               (version_id)
+#  index_dependencies_on_project_created_at_date    (project_id, ((created_at)::date))
+#  index_dependencies_on_project_id_and_version_id  (project_id,version_id)
+#  index_dependencies_on_version_id                 (version_id)
 #
 class Dependency < ApplicationRecord
   include DependencyChecks

--- a/db/migrate/20240501171850_add_index_to_dependencies.rb
+++ b/db/migrate/20240501171850_add_index_to_dependencies.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddIndexToDependencies < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    # this has already been run on production
+    return if Rails.env.production?
+
+    # the covering index (project_id, ((created_at)::date)) already enables this
+    remove_index :dependencies, :project_id, if_exists: true, algorithm: :concurrently
+    add_index :dependencies, %i[project_id version_id], algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_09_222653) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_01_171850) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -66,7 +66,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_09_222653) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index "project_id, ((created_at)::date)", name: "index_dependencies_on_project_created_at_date"
-    t.index ["project_id"], name: "index_dependencies_on_project_id"
+    t.index ["project_id", "version_id"], name: "index_dependencies_on_project_id_and_version_id"
     t.index ["version_id"], name: "index_dependencies_on_version_id"
   end
 


### PR DESCRIPTION
* removes a `dependencies(project_id)` index because we have a `dependencies(project_id, created_at)` covering index now
* adds a `dependencies(:project_id, :version)` to improve the "get a project's dependent repos" query [here](https://github.com/librariesio/libraries.io/commit/8b09b45e87adb05651b5745657274b41ea6751fc#diff-611e7045e8b0212d101cd856c335296959519af63b80129f51c246a7bbfe7b91R409).

This should help the "dependent repos" query on Project, which goes thru Version.

