### PR TITLE
Fix an ambiguous column ref after the repo deps refactor.

### DIFF
--- a/app/models/concerns/monitoring.rb
+++ b/app/models/concerns/monitoring.rb
@@ -40,7 +40,7 @@ module Monitoring
   end
 
   def your_dependent_repos(project)
-    ids = really_all_dependencies.where(project_id: project.id).pluck(:repository_id).uniq
+    ids = really_all_dependencies.where(project_id: project.id).pluck("projects.repository_id").uniq
     all_repositories.where(id: ids).order("fork ASC, pushed_at DESC, rank DESC NULLS LAST")
   end
 end


### PR DESCRIPTION
this fixes a scope that became too ambiguous after the recent refactor and removal of RepsitoryDependency:

```
PG::AmbiguousColumn: ERROR: column reference "repository_id" is ambiguous LINE 1: SELECT "repository_id" FROM "dependencies" INNER JOIN "versi... ^ 
```