### PR TITLE
Set last_synced_at for Removed Repositories

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -282,7 +282,10 @@ class Repository < ApplicationRecord
 
   def update_all_info(token = nil)
     token ||= AuthToken.token if host_type == "GitHub"
-    return unless check_status
+    unless check_status
+      update!(last_synced_at: Time.current)
+      return
+    end
 
     update_from_repository(token)
     unless last_synced_at && last_synced_at > 2.minutes.ago

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -282,13 +282,9 @@ class Repository < ApplicationRecord
 
   def update_all_info(token = nil)
     token ||= AuthToken.token if host_type == "GitHub"
-    unless check_status
-      update!(last_synced_at: Time.current)
-      return
-    end
 
-    update_from_repository(token)
-    unless last_synced_at && last_synced_at > 2.minutes.ago
+    if check_status && (last_synced_at.nil? || last_synced_at < 2.minutes.ago)
+      update_from_repository(token)
       download_owner
       download_fork_source(token)
       download_readme(token)
@@ -296,8 +292,9 @@ class Repository < ApplicationRecord
       download_contributions(token)
       download_metadata(token)
       update_source_rank(force: true)
+      update_unmaintained_status_from_readme
     end
-    update_unmaintained_status_from_readme
+
     self.last_synced_at = Time.current
 
     save

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -570,4 +570,18 @@ describe Repository, type: :model do
       end
     end
   end
+
+  describe "#update_all_info" do
+    let(:repository) { build(:repository) }
+
+    context "with removed repository" do
+      before do
+        allow(Repository).to receive(:check_status).with(repository.host_type, repository.full_name).and_return(false)
+      end
+
+      it "sets last_synced_at for 404" do
+        expect { repository.update_all_info("token") }.to change(repository, :last_synced_at)
+      end
+    end
+  end
 end


### PR DESCRIPTION
It seems like we should be setting this if we get a 404 response when requesting repository data.