### PR TITLE
Add repository#show Route Using Query Parameters Instead of Path Parameters

### DIFF
--- a/app/controllers/api/repositories_controller.rb
+++ b/app/controllers/api/repositories_controller.rb
@@ -64,8 +64,15 @@ class Api::RepositoriesController < Api::ApplicationController
 
   private
 
+  # handle a missing owner or name parameter when doing the lookup for Repository in find_repo
+  # and return a formatted JSON with the missing parameter name with a 400 HTTP status code
+  rescue_from ActionController::ParameterMissing do |e|
+    errors = { e.param => ["is required"] }
+    render json: errors, status: :bad_request
+  end
+
   def find_repo
-    full_name = [params[:owner], params[:name]].join("/")
+    full_name = params.require(%i[owner name]).join("/")
     @repository = Repository.host(current_host).open_source.where("lower(full_name) = ?", full_name.downcase).first
 
     raise ActiveRecord::RecordNotFound if @repository.nil?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
       get "/:host_type/:owner/:name/projects", to: "repositories#projects", constraints: { name: /[^\/]+/ }
       get "/:host_type/:owner/:name/sync", to: "repositories#sync", constraints: { name: /[^\/]+/ }
       get "/:host_type/:owner/:name", to: "repositories#show", constraints: { name: /[^\/]+/ }
+      get "/:host_type/repository", to: "repositories#show" # query params version of the show repository API endpoint
 
       get "/:host_type/:login", to: "repository_users#show"
     end


### PR DESCRIPTION
This adds another route to get to the `repository#show` API endpoint. We occasionally hit route name conflicts when the `name` path parameter matches to another route. For example sending something like `repositories` will link to the `repository_users#repositories` route instead of our intended route. 