### PR TITLE
Remove Logic to Deprecate a PyPI Project if Latest Version is Yanked

### DIFF
--- a/app/models/package_manager/pypi/json_api_project.rb
+++ b/app/models/package_manager/pypi/json_api_project.rb
@@ -130,12 +130,7 @@ module PackageManager
         is_deprecated = false
         message = nil
 
-        latest_stable = releases.reject(&:prerelease?).last
-
-        if latest_stable&.yanked?
-          is_deprecated = true
-          message = latest_stable.yanked_reason
-        elsif classifiers.include?(CLASSIFIER_INACTIVE)
+        if classifiers.include?(CLASSIFIER_INACTIVE)
           is_deprecated = true
           message = CLASSIFIER_INACTIVE
         end

--- a/spec/models/package_manager/pypi/json_api_project_spec.rb
+++ b/spec/models/package_manager/pypi/json_api_project_spec.rb
@@ -157,18 +157,6 @@ describe PackageManager::Pypi::JsonApiProject do
       allow(project).to receive(:classifiers).and_return(classifiers)
     end
 
-    context "with latest stable yanked" do
-      let(:latest_stable_yanked) { true }
-
-      it "#deprecated? returns true" do
-        expect(project.deprecated?).to eq(true)
-      end
-
-      it "#deprecation_message returns value" do
-        expect(project.deprecation_message).to eq("because")
-      end
-    end
-
     context "with inactive classifier" do
       let(:classifiers) { [described_class::CLASSIFIER_INACTIVE] }
 


### PR DESCRIPTION
I could not find any support for this logic when researching how to deprecate a package on PyPI and it is causing issues for legitimate packages being labeled incorrectly.