### PR TITLE
Speed up Api::Repositories#sync by avoiding callbacks

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -273,7 +273,7 @@ class Repository < ApplicationRecord
                             repository_last_synced_at: last_synced_at,
                           })
     update_all_info_async(token)
-    update(last_synced_at: Time.now)
+    update_column(:last_synced_at, Time.now)
   end
 
   def update_all_info_async(token = nil)


### PR DESCRIPTION
`Api::Repositories#sync` should be fast because it just kicks off a sidekiq job via `Repository#manual_sync`, but the traces are very slow (DD is not displaying them for me ATTM). 

after kicking off the job, `Repository#manual_sync` then updates the `last_synced_at` field so it doesn't get re-synced before it finishes syncing, but that `update()` kicks off a chain of callbacks in Repository and for all Repository#projects. So I'm minimizing the work done on this endpoint by changing it to a direct column update instead of a full save with callbacks.