### PR TITLE
Project#manual_sync: cease saving the project record bc we're just kicking off async workers.

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -232,7 +232,6 @@ class Project < ApplicationRecord
                           })
     async_sync(force_sync_dependencies: true)
     update_repository_async
-    forced_save
   end
 
   def forced_save


### PR DESCRIPTION
The `Project#manual_sync` method was added in https://github.com/librariesio/libraries.io/commit/e95cee4857425e139b6946378f48efe6fcc692ab and kicks off async jobs to update a project, so nothing in that method call actually should update the Project. But there's a `forced_save` in that method that just saves the record with a new `:updated_at`. 

From my archaeological dig, I believe that `forced_save` was just to ensure that Elasticsearch record for the Project was updated, but `manual_sync` shouldn't be updating anything in the Project since it just kicks off async jobs. 

The unintended side-effects of this `forced_save` call is the callback chain that happens with it:

```
  # kicks off an expensive job that queries the `dependencies` table
  after_commit :set_dependents_count_async, on: %i[create update]

  # kicks off a job to update the source rank
  after_commit :update_source_rank_async, on: %i[create update]

  # kicks off a ProjectUpdatedWorker for every webhook that wants project updates (!!!)
  after_commit :send_project_updated, on: %i[create update]

  # does a bunch of column-setting
  before_save  :update_details
```

the above is a waste of effort, considering that it will happen **again** after the async PackageManagerDownloadWorker has completed. The part that I really want to eliminate is the `ProjectUpdatedWorker` jobs.