### PR TITLE
Mark a PyPI Project Deprecated If All Versions are Yanked

### DIFF
--- a/app/models/package_manager/pypi/json_api_project.rb
+++ b/app/models/package_manager/pypi/json_api_project.rb
@@ -133,6 +133,10 @@ module PackageManager
         stable_releases = releases.reject(&:prerelease?)
         latest_stable = stable_releases.last
 
+        # The VersionProcessor class is also inspecting yanked status
+        # on Releases. Make sure that the code here and in the VersionProcessor
+        # do not conflict.
+        # TODO: refactor this deprecation method to reuse the VersionProcessor status logic
         if stable_releases.all?(&:yanked?)
           is_deprecated = true
           message = latest_stable.yanked_reason

--- a/app/models/package_manager/pypi/json_api_project.rb
+++ b/app/models/package_manager/pypi/json_api_project.rb
@@ -130,7 +130,13 @@ module PackageManager
         is_deprecated = false
         message = nil
 
-        if classifiers.include?(CLASSIFIER_INACTIVE)
+        stable_releases = releases.reject(&:prerelease?)
+        latest_stable = stable_releases.last
+
+        if stable_releases.all?(&:yanked?)
+          is_deprecated = true
+          message = latest_stable.yanked_reason
+        elsif classifiers.include?(CLASSIFIER_INACTIVE)
           is_deprecated = true
           message = CLASSIFIER_INACTIVE
         end

--- a/app/models/package_manager/pypi/version_processor.rb
+++ b/app/models/package_manager/pypi/version_processor.rb
@@ -2,6 +2,12 @@
 
 module PackageManager
   class Pypi
+    # The VersionProcess class is responsible for converting PyPI version
+    # data and preparing each release for persisting to the database. It
+    # is setting the status for each Version based on if it has been yanked
+    # within PyPI. Please note that the JsonApiProject class is also inspecting
+    # the yanked status of each release to determine deprecation information
+    # and that the logic here and in the deprecation method should be n*sync.
     class VersionProcessor
       def initialize(project_releases:, project_name:, known_versions:)
         @project_releases = project_releases


### PR DESCRIPTION
Follow up to https://github.com/librariesio/libraries.io/pull/3389

This PR uses the upstream API data to determine if a PyPI project should be marked as deprecated. It checks for all non pre-release version numbers and if they are all yanked then takes the reason text from the most recent release. This should capture projects like https://pypi.org/project/gitlab/#history which have essentially been completely pulled down for use.