### PR TITLE
Adds builder classes for mapping() and versions() methods.

### DIFF
--- a/app/models/package_manager/alcatraz.rb
+++ b/app/models/package_manager/alcatraz.rb
@@ -30,11 +30,11 @@ module PackageManager
     end
 
     def self.mapping(raw_project)
-      {
+      MappingBuilder.build_hash(
         name: raw_project["name"],
         description: raw_project["description"],
-        repository_url: raw_project["url"],
-      }
+        repository_url: raw_project["url"]
+      )
     end
   end
 end

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -5,6 +5,8 @@ module PackageManager
   # specific release of a pacakge. This retrieval can be triggered via
   # asynchronous jobs, or directly by API endpoints or the console.
   class Base
+    class MethodNotImplementedError < StandardError; end
+
     COLOR = "#fff"
     BIBLIOTHECARY_SUPPORT = false
     BIBLIOTHECARY_PLANNED = false
@@ -164,14 +166,14 @@ module PackageManager
     # package manager. This can be any arbitrary data, and will passed on to the
     # mapping() method to get a standard shape of data.
     def self.project(_name)
-      nil
+      raise MethodNotImplementedError
     end
 
     # Override this in the subclass to map the raw data from project() to
     # a Hash of data that we'll need to save Project and Version records.
     # Use the PackageManager::MappingBuilder to create the Hash.
     def self.mapping(_raw_project)
-      nil
+      raise MethodNotImplementedError
     end
 
     # Returns the versions found within the raw project data for the package.
@@ -179,7 +181,7 @@ module PackageManager
     # retrieve all the information to pass into
     # version_hash_to_version_object.
     def self.versions(_raw_project, _name)
-      nil
+      raise MethodNotImplementedError
     end
 
     def self.versions_as_version_objects(raw_project, name)

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -101,7 +101,7 @@ module PackageManager
       db_project = Project.find_or_initialize_by({ name: mapped_project[:name], platform: db_platform })
       db_project.reformat_repository_url if reformat_repository_url && !db_project.new_record?
       mapped_project[:repository_url] = db_project.repository_url if mapped_project[:repository_url].blank?
-      db_project.attributes = mapped_project.except(:name, :releases, :versions, :version, :dependencies, :properties)
+      db_project.attributes = mapped_project.except(:name, :versions, :version, :dependencies, :properties)
 
       begin
         db_project.save!
@@ -158,6 +158,20 @@ module PackageManager
 
       save_dependencies(mapped_project, sync_version: sync_version, force_sync_dependencies: force_sync_dependencies) if self::HAS_DEPENDENCIES
       finalize_db_project(db_project)
+    end
+
+    # Override this in the subclass to fetch the raw data from the upstream
+    # package manager. This can be any arbitrary data, and will passed on to the
+    # mapping() method to get a standard shape of data.
+    def self.project(_name)
+      nil
+    end
+
+    # Override this in the subclass to map the raw data from project() to
+    # a Hash of data that we'll need to save Project and Version records.
+    # Use the PackageManager::MappingBuilder to create the Hash.
+    def self.mapping(_raw_project)
+      nil
     end
 
     # Returns the versions found within the raw project data for the package.

--- a/app/models/package_manager/base/mapping_builder.rb
+++ b/app/models/package_manager/base/mapping_builder.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module PackageManager
+  class Base
+    # This builder class only exists to ensure we have a defined set
+    # of keys that we allow PackageManager::Base.mapping() to return.
+    class MappingBuilder
+      MISSING = Object.new
+
+      def self.build_hash(name:, description:, repository_url:, homepage: MISSING, keywords_array: MISSING, licenses: MISSING, versions: MISSING)
+        hash = {
+          name: name,
+          description: description,
+          repository_url: repository_url,
+        }
+
+        hash[:homepage] = homepage if homepage != MISSING
+        hash[:keywords_array] = keywords_array if keywords_array != MISSING
+        hash[:licenses] = licenses if licenses != MISSING
+        hash[:versions] = versions if versions != MISSING
+
+        hash
+      end
+    end
+  end
+end

--- a/app/models/package_manager/base/version_builder.rb
+++ b/app/models/package_manager/base/version_builder.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module PackageManager
+  class Base
+    # This builder class only exists to ensure we have a defined set
+    # of keys that we allow PackageManager::Base.versions() to return.
+    class VersionBuilder
+      MISSING = Object.new
+
+      def self.build_hash(number:, status: MISSING, created_at: MISSING, published_at: MISSING, original_license: MISSING)
+        hash = {
+          number: number,
+        }
+
+        hash[:status] = status if status != MISSING
+        # TODO: created_at might not be needed here, we're just passing it from Go.versions().
+        hash[:created_at] = created_at if created_at != MISSING
+        hash[:published_at] = published_at if published_at != MISSING
+        hash[:original_license] = original_license if original_license != MISSING
+
+        hash
+      end
+    end
+  end
+end

--- a/app/models/package_manager/bower.rb
+++ b/app/models/package_manager/bower.rb
@@ -36,14 +36,14 @@ module PackageManager
 
     def self.mapping(raw_project)
       bower_json = load_bower_json(raw_project) || raw_project
-      {
+      MappingBuilder.build_hash(
         name: raw_project["name"],
         repository_url: raw_project["url"],
         licenses: bower_json["license"],
         keywords_array: bower_json["keywords"],
         homepage: bower_json["homepage"],
-        description: bower_json["description"],
-      }
+        description: bower_json["description"]
+      )
     end
 
     def self.load_bower_json(mapped_project)

--- a/app/models/package_manager/cargo.rb
+++ b/app/models/package_manager/cargo.rb
@@ -99,11 +99,11 @@ module PackageManager
 
     def self.versions(raw_project, _name)
       raw_project["versions"].map do |version|
-        {
+        VersionBuilder.build_hash(
           number: version["num"],
           published_at: version["created_at"],
-          original_license: version["license"],
-        }
+          original_license: version["license"]
+        )
       end
     end
 

--- a/app/models/package_manager/carthage.rb
+++ b/app/models/package_manager/carthage.rb
@@ -43,14 +43,14 @@ module PackageManager
     end
 
     def self.mapping(raw_project)
-      {
+      MappingBuilder.build_hash(
         name: raw_project[:full_name],
         description: raw_project[:description],
         homepage: raw_project[:homepage],
         keywords_array: raw_project[:topics],
         licenses: (raw_project.fetch(:license, {}) || {})[:key],
-        repository_url: raw_project[:html_url],
-      }
+        repository_url: raw_project[:html_url]
+      )
     end
   end
 end

--- a/app/models/package_manager/cocoa_pods.rb
+++ b/app/models/package_manager/cocoa_pods.rb
@@ -39,13 +39,13 @@ module PackageManager
     end
 
     def self.mapping(raw_project)
-      {
+      MappingBuilder.build_hash(
         name: raw_project["name"],
         description: raw_project["summary"],
         homepage: raw_project["homepage"],
         licenses: parse_license(raw_project["license"]),
-        repository_url: repo_fallback(raw_project.dig("source", "git"), ""),
-      }
+        repository_url: repo_fallback(raw_project.dig("source", "git"), "")
+      )
     end
 
     def self.versions(raw_project, _name)

--- a/app/models/package_manager/cocoa_pods.rb
+++ b/app/models/package_manager/cocoa_pods.rb
@@ -50,9 +50,9 @@ module PackageManager
 
     def self.versions(raw_project, _name)
       raw_project.fetch("versions", {}).keys.map do |v|
-        {
-          number: v.to_s,
-        }
+        VersionBuilder.build_hash({
+                                    number: v.to_s,
+                                  })
       end
     end
 

--- a/app/models/package_manager/conda.rb
+++ b/app/models/package_manager/conda.rb
@@ -83,7 +83,13 @@ module PackageManager
     end
 
     def self.versions(raw_project, _name)
-      raw_project["versions"].map { |version| version.deep_symbolize_keys.slice(:number, :original_license, :published_at) }
+      raw_project["versions"].map do |version|
+        VersionBuilder.build_hash(
+          number: version["number"],
+          original_license: version["original_license"],
+          published_at: version["published_at"]
+        )
+      end
     end
 
     def self.dependencies(name, version, _mapped_project)

--- a/app/models/package_manager/conda.rb
+++ b/app/models/package_manager/conda.rb
@@ -72,8 +72,14 @@ module PackageManager
     end
 
     def self.mapping(raw_project)
-      # TODO: can we make this more explicit?
-      raw_project.deep_symbolize_keys
+      MappingBuilder.build_hash(
+        name: raw_project["name"],
+        description: raw_project["description"],
+        repository_url: raw_project["repository_url"],
+        homepage: raw_project["homepage"],
+        licenses: raw_project["licenses"],
+        versions: raw_project["versions"]
+      )
     end
 
     def self.versions(raw_project, _name)

--- a/app/models/package_manager/cpan.rb
+++ b/app/models/package_manager/cpan.rb
@@ -48,10 +48,10 @@ module PackageManager
     def self.versions(raw_project, _name)
       versions = get("https://fastapi.metacpan.org/v1/release/_search?q=distribution:#{raw_project['distribution']}&size=5000&_source=version,date")["hits"]["hits"]
       versions.map do |version|
-        {
+        VersionBuilder.build_hash(
           number: version["_source"]["version"],
-          published_at: version["_source"]["date"],
-        }
+          published_at: version["_source"]["date"]
+        )
       end
     end
 

--- a/app/models/package_manager/cpan.rb
+++ b/app/models/package_manager/cpan.rb
@@ -35,14 +35,14 @@ module PackageManager
     end
 
     def self.mapping(raw_project)
-      {
+      MappingBuilder.build_hash(
         name: raw_project["distribution"],
         homepage: raw_project.fetch("resources", {})["homepage"],
         description: raw_project["abstract"],
         licenses: raw_project.fetch("license", []).join(","),
         repository_url: repo_fallback(raw_project.fetch("resources", {}).fetch("repository", {})["web"], raw_project.fetch("resources", {})["homepage"]),
-        versions: versions(raw_project, raw_project["distribution"]),
-      }
+        versions: versions(raw_project, raw_project["distribution"])
+      )
     end
 
     def self.versions(raw_project, _name)

--- a/app/models/package_manager/cran.rb
+++ b/app/models/package_manager/cran.rb
@@ -48,13 +48,13 @@ module PackageManager
     end
 
     def self.mapping(raw_project)
-      {
+      MappingBuilder.build_hash(
         name: raw_project[:name],
         homepage: raw_project[:info].fetch("URL:", "").split(",").first,
         description: raw_project[:html].css("h2").text.split(":")[1..].join(":").strip,
         licenses: raw_project[:info]["License:"],
-        repository_url: repo_fallback("", (raw_project[:info].fetch("URL:", "").split(",").first.presence || raw_project[:info]["BugReports:"])).to_s[0, 255],
-      }
+        repository_url: repo_fallback("", (raw_project[:info].fetch("URL:", "").split(",").first.presence || raw_project[:info]["BugReports:"])).to_s[0, 255]
+      )
     end
 
     def self.versions(raw_project, _name)

--- a/app/models/package_manager/cran.rb
+++ b/app/models/package_manager/cran.rb
@@ -58,10 +58,10 @@ module PackageManager
     end
 
     def self.versions(raw_project, _name)
-      [{
+      [VersionBuilder.build_hash(
         number: raw_project[:info]["Version:"],
-        published_at: raw_project[:info]["Published:"],
-      }] + find_old_versions(raw_project)
+        published_at: raw_project[:info]["Published:"]
+      )] + find_old_versions(raw_project)
     end
 
     def self.find_old_versions(project)
@@ -72,10 +72,10 @@ module PackageManager
       end
       trs.map do |tr|
         tds = tr.css("td")
-        {
+        VersionBuilder.build_hash(
           number: tds[1].text.strip.split("_").last.gsub(".tar.gz", ""),
-          published_at: tds[2].text.strip,
-        }
+          published_at: tds[2].text.strip
+        )
       end
     end
 

--- a/app/models/package_manager/dub.rb
+++ b/app/models/package_manager/dub.rb
@@ -26,15 +26,15 @@ module PackageManager
 
     def self.mapping(raw_project)
       latest_version = raw_project["versions"].last
-      {
+      MappingBuilder.build_hash(
         name: raw_project["name"],
         description: latest_version["description"],
         homepage: latest_version["homepage"],
         keywords_array: format_keywords(raw_project["categories"]),
         licenses: latest_version["license"],
         repository_url: repo_fallback(repository(raw_project["repository"]), latest_version["homepage"]),
-        versions: raw_project["versions"],
-      }
+        versions: raw_project["versions"]
+      )
     end
 
     def self.versions(raw_project, _name)

--- a/app/models/package_manager/dub.rb
+++ b/app/models/package_manager/dub.rb
@@ -39,10 +39,10 @@ module PackageManager
 
     def self.versions(raw_project, _name)
       acceptable_versions(raw_project).map do |v|
-        {
+        VersionBuilder.build_hash(
           number: v["version"],
-          published_at: v["date"],
-        }
+          published_at: v["date"]
+        )
       end
     end
 

--- a/app/models/package_manager/elm.rb
+++ b/app/models/package_manager/elm.rb
@@ -47,10 +47,10 @@ module PackageManager
     def self.versions(_raw_project, name)
       get("https://package.elm-lang.org/packages/#{name}/releases.json")
         .map do |version, timestamp|
-          {
+          VersionBuilder.build_hash(
             number: version,
-            published_at: Time.at(timestamp),
-          }
+            published_at: Time.at(timestamp)
+          )
         end
     end
 

--- a/app/models/package_manager/elm.rb
+++ b/app/models/package_manager/elm.rb
@@ -37,11 +37,11 @@ module PackageManager
     end
 
     def self.mapping(raw_project)
-      {
+      MappingBuilder.build_hash(
         name: raw_project["name"],
         description: raw_project["summary"],
-        repository_url: "https://github.com/#{raw_project['name']}",
-      }
+        repository_url: "https://github.com/#{raw_project['name']}"
+      )
     end
 
     def self.versions(_raw_project, name)

--- a/app/models/package_manager/go.rb
+++ b/app/models/package_manager/go.rb
@@ -74,16 +74,15 @@ module PackageManager
       # e.g. https://proxy.golang.org/github.com/ysweid/aws-sdk-go/@v/v1.12.68.info
       version_string = info.nil? ? version_string : info["Version"]
       published_at = info && info["Time"].presence && Time.parse(info["Time"])
-      data = {
-        number: version_string,
-        published_at: published_at,
-      }
 
       # Supplement with license info from pkg.go.dev
       doc_html = get_html("#{DISCOVER_URL}/#{raw_project[:name]}")
-      data[:original_license] = doc_html.css('*[data-test-id="UnitHeader-license"]').map(&:text).join(",")
 
-      data
+      VersionBuilder.build_hash(
+        number: version_string,
+        published_at: published_at,
+        original_license: doc_html.css('*[data-test-id="UnitHeader-license"]').map(&:text).join(",")
+      )
     end
 
     def self.project(name)
@@ -147,7 +146,12 @@ module PackageManager
         known = known_versions[v]
 
         if known && known[:original_license].present?
-          known.slice(:number, :created_at, :published_at, :original_license)
+          VersionBuilder.build_hash(
+            number: known[:number],
+            created_at: known[:created_at], # TODO: do we need created_at?
+            published_at: known[:published_at],
+            original_license: known[:original_license]
+          )
         else
           one_version(raw_project, v)
         end

--- a/app/models/package_manager/go.rb
+++ b/app/models/package_manager/go.rb
@@ -195,13 +195,13 @@ module PackageManager
           end
         end
 
-        {
+        MappingBuilder.build_hash(
           name: existing_project_name.presence || raw_project[:name],
           description: raw_project[:html].css(".Documentation-overview p").map(&:text).join("\n").strip,
           licenses: raw_project[:html].css('*[data-test-id="UnitHeader-license"]').map(&:text).join(","),
           repository_url: url,
-          homepage: url,
-        }
+          homepage: url
+        )
       else
         { name: raw_project[:name] }
       end

--- a/app/models/package_manager/hackage.rb
+++ b/app/models/package_manager/hackage.rb
@@ -52,9 +52,9 @@ module PackageManager
       versions = find_attribute(raw_project[:page], "Versions")
       versions = find_attribute(raw_project[:page], "Version") if versions.nil?
       versions.delete("(info)").split(",").map(&:strip).map do |v|
-        {
-          number: v,
-        }
+        VersionBuilder.build_hash(
+          number: v
+        )
       end
     end
 

--- a/app/models/package_manager/hackage.rb
+++ b/app/models/package_manager/hackage.rb
@@ -38,14 +38,14 @@ module PackageManager
     end
 
     def self.mapping(raw_project)
-      {
+      MappingBuilder.build_hash(
         name: raw_project[:name],
         keywords_array: Array(raw_project[:page].css("#content div:first a")[1..].map(&:text)),
         description: description(raw_project[:page]),
         licenses: find_attribute(raw_project[:page], "License"),
         homepage: find_attribute(raw_project[:page], "Home page"),
-        repository_url: repo_fallback(repository_url(find_attribute(raw_project[:page], "Source repository")), find_attribute(raw_project[:page], "Home page")),
-      }
+        repository_url: repo_fallback(repository_url(find_attribute(raw_project[:page], "Source repository")), find_attribute(raw_project[:page], "Home page"))
+      )
     end
 
     def self.versions(raw_project, _name)

--- a/app/models/package_manager/haxelib.rb
+++ b/app/models/package_manager/haxelib.rb
@@ -46,10 +46,10 @@ module PackageManager
 
     def self.versions(raw_project, _name)
       raw_project["info"]["versions"].map do |version|
-        {
+        VersionBuilder.build_hash(
           number: version["name"],
-          published_at: version["date"],
-        }
+          published_at: version["date"]
+        )
       end
     end
 

--- a/app/models/package_manager/hex.rb
+++ b/app/models/package_manager/hex.rb
@@ -46,13 +46,13 @@ module PackageManager
 
     def self.mapping(raw_project)
       links = raw_project["meta"].fetch("links", {}).transform_keys(&:downcase)
-      {
+      MappingBuilder.build_hash(
         name: raw_project["name"],
         homepage: links.except("github").first.try(:last),
         repository_url: links["github"],
         description: raw_project["meta"]["description"],
-        licenses: repo_fallback(raw_project["meta"].fetch("licenses", []).join(","), links.except("github").first.try(:last)),
-      }
+        licenses: repo_fallback(raw_project["meta"].fetch("licenses", []).join(","), links.except("github").first.try(:last))
+      )
     end
 
     def self.versions(raw_project, _name)

--- a/app/models/package_manager/hex.rb
+++ b/app/models/package_manager/hex.rb
@@ -57,10 +57,10 @@ module PackageManager
 
     def self.versions(raw_project, _name)
       raw_project["releases"].map do |version|
-        {
+        VersionBuilder.build_hash(
           number: version["version"],
-          published_at: version["inserted_at"],
-        }
+          published_at: version["inserted_at"]
+        )
       end
     end
 

--- a/app/models/package_manager/homebrew.rb
+++ b/app/models/package_manager/homebrew.rb
@@ -46,9 +46,9 @@ module PackageManager
       return [] if stable.blank?
 
       [
-        {
-          number: stable,
-        },
+        VersionBuilder.build_hash(
+          number: stable
+        ),
       ]
     end
 

--- a/app/models/package_manager/julia.rb
+++ b/app/models/package_manager/julia.rb
@@ -27,10 +27,11 @@ module PackageManager
     end
 
     def self.mapping(raw_project)
-      {
+      MappingBuilder.build_hash(
         name: raw_project[:name],
-        repository_url: repo_fallback(raw_project[:repository_url], ""),
-      }
+        description: nil, # TODO: can we get description?
+        repository_url: repo_fallback(raw_project[:repository_url], "")
+      )
     end
 
     def self.versions(raw_project, _name)

--- a/app/models/package_manager/julia.rb
+++ b/app/models/package_manager/julia.rb
@@ -36,9 +36,9 @@ module PackageManager
 
     def self.versions(raw_project, _name)
       raw_project["versions"].map do |v|
-        {
-          number: v,
-        }
+        VersionBuilder.build_hash(
+          number: v
+        )
       end
     end
   end

--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -126,7 +126,7 @@ module PackageManager
         properties: parent[:properties].merge(extract_pom_properties(xml)),
       }.select { |_k, v| v.present? }
 
-      parent.merge(child)
+      MappingBuilder.build_hash(**parent.merge(child))
     end
 
     def self.extract_pom_value(xml, location, parent_properties = {})

--- a/app/models/package_manager/maven/google.rb
+++ b/app/models/package_manager/maven/google.rb
@@ -45,7 +45,9 @@ class PackageManager::Maven::Google < PackageManager::Maven::Common
     return [] unless package_details
 
     package_details["versions"].split(",").map do |version_number|
-      { number: version_number }
+      VersionBuilder.build_hash(
+        number: version_number
+      )
     end
   end
 

--- a/app/models/package_manager/meteor.rb
+++ b/app/models/package_manager/meteor.rb
@@ -40,11 +40,11 @@ module PackageManager
     end
 
     def self.mapping(raw_project)
-      {
+      MappingBuilder.build_hash(
         name: raw_project["name"],
         description: raw_project["description"],
-        repository_url: repo_fallback(raw_project["git"], nil),
-      }
+        repository_url: repo_fallback(raw_project["git"], nil)
+      )
     end
 
     def self.versions(raw_project, _name)

--- a/app/models/package_manager/meteor.rb
+++ b/app/models/package_manager/meteor.rb
@@ -48,10 +48,10 @@ module PackageManager
     end
 
     def self.versions(raw_project, _name)
-      [{
+      [VersionBuilder.build_hash(
         number: raw_project["version"],
-        published_at: Time.at(raw_project["published"]["$date"] / 1000.0),
-      }]
+        published_at: Time.at(raw_project["published"]["$date"] / 1000.0)
+      )]
     end
   end
 end

--- a/app/models/package_manager/nimble.rb
+++ b/app/models/package_manager/nimble.rb
@@ -32,14 +32,14 @@ module PackageManager
     end
 
     def self.mapping(raw_project)
-      {
+      MappingBuilder.build_hash(
         name: raw_project["name"],
         description: raw_project["description"],
         repository_url: repo_fallback(raw_project["url"], raw_project["web"]),
         keywords_array: Array.wrap(raw_project["tags"]),
         licenses: raw_project["license"],
-        homepage: raw_project["web"],
-      }
+        homepage: raw_project["web"]
+      )
     end
   end
 end

--- a/app/models/package_manager/npm.rb
+++ b/app/models/package_manager/npm.rb
@@ -75,15 +75,15 @@ module PackageManager
       repo = repo[0] if repo.is_a?(Array)
       repo_url = repo.try(:fetch, "url", nil)
 
-      {
+      MappingBuilder.build_hash(
         name: raw_project["name"],
         description: latest_version["description"],
         homepage: raw_project["homepage"],
         keywords_array: Array.wrap(latest_version.fetch("keywords", [])),
         licenses: licenses(latest_version),
         repository_url: repo_fallback(repo_url, raw_project["homepage"]),
-        versions: raw_project["versions"],
-      }
+        versions: raw_project["versions"]
+      )
     end
 
     def self.licenses(latest_version)

--- a/app/models/package_manager/npm.rb
+++ b/app/models/package_manager/npm.rb
@@ -114,11 +114,11 @@ module PackageManager
         license = v.fetch("license", nil)
         license = licenses(v) unless license.is_a?(String)
         license = "" if license.nil?
-        {
+        VersionBuilder.build_hash(
           number: k,
           published_at: raw_project.fetch("time", {}).fetch(k, nil),
-          original_license: license,
-        }
+          original_license: license
+        )
       end
     end
 

--- a/app/models/package_manager/nu_get.rb
+++ b/app/models/package_manager/nu_get.rb
@@ -137,15 +137,15 @@ module PackageManager
       nuspec_repo = raw_nuspec&.locate("package/metadata/repository")&.first
       nuspec_repo = nuspec_repo["url"] if nuspec_repo
 
-      {
+      MappingBuilder.build_hash(
         name: raw_project[:name],
         description: item.description,
         homepage: item.project_url,
         keywords_array: item.tags,
         repository_url: repo_fallback(nuspec_repo, item.project_url),
-        releases: raw_project[:releases],
         licenses: item.licenses,
-      }
+        versions: versions(raw_project, raw_project[:name])
+      )
     end
 
     def self.versions(raw_project, _name)

--- a/app/models/package_manager/nu_get.rb
+++ b/app/models/package_manager/nu_get.rb
@@ -150,11 +150,11 @@ module PackageManager
 
     def self.versions(raw_project, _name)
       raw_project[:releases].map do |item|
-        {
+        VersionBuilder.build_hash(
           number: item.version_number,
           published_at: item.published_at,
-          original_license: item.original_license,
-        }
+          original_license: item.original_license
+        )
       end
     end
 

--- a/app/models/package_manager/packagist.rb
+++ b/app/models/package_manager/packagist.rb
@@ -88,11 +88,11 @@ module PackageManager
 
     def self.versions(raw_project, _name)
       acceptable_versions(raw_project).map do |version|
-        {
+        VersionBuilder.build_hash(
           number: version["version"],
           published_at: version["time"],
-          original_license: version["license"],
-        }
+          original_license: version["license"]
+        )
       end
     end
 

--- a/app/models/package_manager/packagist.rb
+++ b/app/models/package_manager/packagist.rb
@@ -75,15 +75,15 @@ module PackageManager
 
       return if latest_version.nil?
 
-      {
+      MappingBuilder.build_hash(
         name: latest_version["name"],
         description: latest_version["description"],
         homepage: latest_version["homepage"],
         keywords_array: Array.wrap(latest_version["keywords"]),
         licenses: latest_version["license"]&.join(","),
         repository_url: repo_fallback(latest_version["source"]&.fetch("url"), latest_version["homepage"]),
-        versions: raw_project, # packagist has the list of versions as raw_project and this then lets us pull dependencies in self.dependencies
-      }
+        versions: raw_project # packagist has the list of versions as raw_project and this then lets us pull dependencies in self.dependencies
+      )
     end
 
     def self.versions(raw_project, _name)

--- a/app/models/package_manager/packagist/drupal.rb
+++ b/app/models/package_manager/packagist/drupal.rb
@@ -23,7 +23,7 @@ class PackageManager::Packagist::Drupal < PackageManager::Packagist
 
     homepage = raw_project.css("link[rel=canonical]").attr("href").value
 
-    {
+    MappingBuilder.build_hash(
       name: "drupal/#{homepage.split('/project/', 2)[1]}",
       description: raw_project.css("meta[name=description]").first&.attr("content"),
       homepage: homepage,
@@ -31,8 +31,8 @@ class PackageManager::Packagist::Drupal < PackageManager::Packagist
       repository_url: raw_project
         .css("#block-drupalorg-project-development .links a")
         .find { |l| l.text =~ /code repository|source code/i }
-        &.attr("href"),
-    }
+        &.attr("href")
+    )
   end
 
   def self.versions(_raw_project, name)

--- a/app/models/package_manager/packagist/drupal.rb
+++ b/app/models/package_manager/packagist/drupal.rb
@@ -55,11 +55,11 @@ class PackageManager::Packagist::Drupal < PackageManager::Packagist
             &.first
             &.strip # e.g. "12 May 2021 at 15:19 UTC"
           published_at = Time.parse(published_at) if published_at
-          {
+          VersionBuilder.build_hash(
             number: number,
             published_at: published_at,
-            original_license: DRUPAL_MODULE_LICENSE,
-          }
+            original_license: DRUPAL_MODULE_LICENSE
+          )
         end
       page += 1
       doc = get_html("https://www.drupal.org/project/#{name}/releases?page=#{page}")

--- a/app/models/package_manager/pub.rb
+++ b/app/models/package_manager/pub.rb
@@ -54,9 +54,9 @@ module PackageManager
 
     def self.versions(raw_project, _name)
       raw_project["versions"].map do |v|
-        {
-          number: v["version"],
-        }
+        VersionBuilder.build_hash(
+          number: v["version"]
+        )
       end
     end
 

--- a/app/models/package_manager/pub.rb
+++ b/app/models/package_manager/pub.rb
@@ -43,13 +43,13 @@ module PackageManager
 
     def self.mapping(raw_project)
       latest_version = raw_project["versions"].last
-      {
+      MappingBuilder.build_hash(
         name: raw_project["name"],
         homepage: latest_version["pubspec"]["homepage"],
         description: latest_version["pubspec"]["description"],
         repository_url: repo_fallback("", latest_version["pubspec"]["homepage"]),
-        versions: raw_project["versions"],
-      }
+        versions: raw_project["versions"]
+      )
     end
 
     def self.versions(raw_project, _name)

--- a/app/models/package_manager/puppet.rb
+++ b/app/models/package_manager/puppet.rb
@@ -41,10 +41,10 @@ module PackageManager
 
     def self.versions(raw_project, _name)
       raw_project["releases"].map do |release|
-        {
+        VersionBuilder.build_hash(
           number: release["version"],
-          published_at: release["created_at"],
-        }
+          published_at: release["created_at"]
+        )
       end
     end
 

--- a/app/models/package_manager/puppet.rb
+++ b/app/models/package_manager/puppet.rb
@@ -29,13 +29,14 @@ module PackageManager
     def self.mapping(raw_project)
       current_release = raw_project["current_release"]
       metadata = current_release["metadata"]
-      {
+
+      MappingBuilder.build_hash(
         name: raw_project["slug"],
         repository_url: metadata["source"],
         description: metadata["description"],
         keywords_array: current_release["tags"],
-        licenses: metadata["license"],
-      }
+        licenses: metadata["license"]
+      )
     end
 
     def self.versions(raw_project, _name)

--- a/app/models/package_manager/pure_script.rb
+++ b/app/models/package_manager/pure_script.rb
@@ -20,10 +20,11 @@ module PackageManager
     end
 
     def self.mapping(raw_project)
-      {
+      MappingBuilder.build_hash(
         name: raw_project["name"],
-        repository_url: raw_project["repo"],
-      }
+        description: nil, # TODO: can we get description?
+        repository_url: raw_project["repo"]
+      )
     end
 
     def self.install_instructions(db_project, _version = nil)

--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -67,9 +67,16 @@ module PackageManager
     end
 
     # mapping eventually receives the return value of the project method.
-    # This happens in PackageManager:Base.
+    # This happens in PackageManager::Base.
     def self.mapping(json_api_project)
-      json_api_project.to_mapping
+      MappingBuilder.build_hash(
+        name: json_api_project.name,
+        description: json_api_project.description,
+        homepage: json_api_project.homepage,
+        keywords_array: json_api_project.keywords_array,
+        licenses: json_api_project.licenses,
+        repository_url: json_api_project.preferred_repository_url
+      )
     end
 
     # versions eventually receives the return value of the project method.

--- a/app/models/package_manager/pypi/json_api_project.rb
+++ b/app/models/package_manager/pypi/json_api_project.rb
@@ -93,19 +93,6 @@ module PackageManager
         )
       end
 
-      # Various parts of this process still want raw hashes for a type
-      # of data called a "mapping".
-      def to_mapping
-        {
-          name: name,
-          description: description,
-          homepage: homepage,
-          keywords_array: keywords_array,
-          licenses: licenses,
-          repository_url: preferred_repository_url,
-        }
-      end
-
       def deprecated?
         deprecation_status[:is_deprecated]
       end

--- a/app/models/package_manager/pypi/version_processor.rb
+++ b/app/models/package_manager/pypi/version_processor.rb
@@ -35,12 +35,12 @@ module PackageManager
             published_at = project_release.published_at || rss_api_release&.published_at
             status = project_release&.yanked? ? "Removed" : nil
 
-            {
+            VersionBuilder.build_hash(
               number: version_number,
               published_at: published_at,
               original_license: original_license,
-              status: status,
-            }
+              status: status
+            )
           end
         end
       end

--- a/app/models/package_manager/pypi/version_processor.rb
+++ b/app/models/package_manager/pypi/version_processor.rb
@@ -35,7 +35,7 @@ module PackageManager
             published_at = project_release.published_at || rss_api_release&.published_at
             status = project_release&.yanked? ? "Removed" : nil
 
-            VersionBuilder.build_hash(
+            PackageManager::Base::VersionBuilder.build_hash(
               number: version_number,
               published_at: published_at,
               original_license: original_license,

--- a/app/models/package_manager/racket.rb
+++ b/app/models/package_manager/racket.rb
@@ -24,13 +24,13 @@ module PackageManager
     end
 
     def self.mapping(raw_project)
-      {
+      MappingBuilder.build_hash(
         name: raw_project[:name],
         repository_url: raw_project[:page].at('a:contains("Code")')&.attributes.try(:[], "href")&.text,
         description: raw_project[:page].css(".jumbotron p")&.first&.children&.first&.text,
         homepage: homepage_link(raw_project[:page]).present? ? homepage_link(raw_project[:page]).attributes["href"].value : "",
-        keywords_array: raw_project[:page].at('th:contains("Tags")').parent.css("a")&.map { |el| el.children.first.try(:text) },
-      }
+        keywords_array: raw_project[:page].at('th:contains("Tags")').parent.css("a")&.map { |el| el.children.first.try(:text) }
+      )
     end
 
     def self.homepage_link(page)

--- a/app/models/package_manager/rubygems.rb
+++ b/app/models/package_manager/rubygems.rb
@@ -153,11 +153,11 @@ module PackageManager
       json.map do |v|
         license = v.fetch("licenses", "")
         license = "" if license.nil?
-        {
+        VersionBuilder.build_hash(
           number: v["number"],
           published_at: v["created_at"],
-          original_license: license,
-        }
+          original_license: license
+        )
       end
     end
   end

--- a/app/models/package_manager/rubygems.rb
+++ b/app/models/package_manager/rubygems.rb
@@ -52,13 +52,13 @@ module PackageManager
     end
 
     def self.mapping(raw_project)
-      {
+      MappingBuilder.build_hash(
         name: raw_project["name"],
         description: raw_project["info"],
         homepage: raw_project["homepage_uri"],
         licenses: raw_project.fetch("licenses", []).try(:join, ","),
-        repository_url: repo_fallback(raw_project["source_code_uri"], raw_project["homepage_uri"]),
-      }
+        repository_url: repo_fallback(raw_project["source_code_uri"], raw_project["homepage_uri"])
+      )
     end
 
     def self.versions(raw_project, _name, parse_html: false)

--- a/app/models/package_manager/swift_pm.rb
+++ b/app/models/package_manager/swift_pm.rb
@@ -21,10 +21,11 @@ module PackageManager
     end
 
     def self.mapping(raw_project)
-      {
+      MappingBuilder.build_hash(
         name: raw_project[:name],
-        repository_url: raw_project[:repository_url],
-      }
+        description: nil, # TODO: can we get description?
+        repository_url: raw_project[:repository_url]
+      )
     end
   end
 end

--- a/docs/add-a-package-manager.md
+++ b/docs/add-a-package-manager.md
@@ -125,10 +125,10 @@ Here's an example from [NuGet](../app/models/package_manager/nu_get.rb):
 ```ruby
 def self.versions(raw_project, _name)
   raw_project[:releases].map do |item|
-    {
+    VersionBuilder.build_hash({
       number: item['catalogEntry']['version'],
       published_at: item['catalogEntry']['published']
-    }
+    })
   end
 end
 ```

--- a/docs/add-a-package-manager.md
+++ b/docs/add-a-package-manager.md
@@ -99,14 +99,14 @@ Here's an example from [Cargo](../app/models/package_manager/cargo.rb):
 
 ```ruby
 def self.mapping(raw_project)
-  {
-    :name => raw_project['crate']['id'],
-    :homepage => raw_project['crate']['homepage'],
-    :description => raw_project['crate']['description'],
-    :keywords_array => Array.wrap(raw_project['crate']['keywords']),
-    :licenses => raw_project['crate']['license'],
-    :repository_url => repo_fallback(raw_project['crate']['repository'], raw_project['crate']['homepage'])
-  }
+  MappingBuilder.build_hash({
+    name: raw_project['crate']['id'],
+    homepage: raw_project['crate']['homepage'],
+    description: raw_project['crate']['description'],
+    keywords_array: Array.wrap(raw_project['crate']['keywords']),
+    licenses: raw_project['crate']['license'],
+    repository_url: repo_fallback(raw_project['crate']['repository'], raw_project['crate']['homepage'])
+  })
 end
 ```
 

--- a/spec/models/package_manager/base/mapping_builder_spec.rb
+++ b/spec/models/package_manager/base/mapping_builder_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe PackageManager::Base::MappingBuilder do
+  context ".build_hash" do
+    it "requires name, description, and repository_url" do
+      expect { described_class.build_hash }
+        .to raise_exception(ArgumentError, "missing keywords: :name, :description, :repository_url")
+    end
+
+    it "raises an error on disallowed keywords" do
+      expect do
+        described_class.build_hash(
+          name: "a-name",
+          description: "a-description",
+          repository_url: "a-repository-url",
+          foo: "bar"
+        )
+      end.to raise_exception(ArgumentError, "unknown keyword: :foo")
+    end
+
+    it "returns a Hash containing the params that were passed" do
+      hash = described_class.build_hash(
+        name: "a-name",
+        description: "a-description",
+        repository_url: "a-repository-url",
+        homepage: "homepage",
+        keywords_array: "keywords-array",
+        licenses: ["licenses"],
+        versions: ["a-version"]
+      )
+
+      expect(hash[:name]).to eq("a-name")
+      expect(hash[:description]).to eq("a-description")
+      expect(hash[:repository_url]).to eq("a-repository-url")
+      expect(hash[:homepage]).to eq("homepage")
+      expect(hash[:keywords_array]).to eq("keywords-array")
+      expect(hash[:licenses]).to eq(["licenses"])
+      expect(hash[:versions]).to eq(["a-version"])
+    end
+  end
+end

--- a/spec/models/package_manager/base/version_builder_spec.rb
+++ b/spec/models/package_manager/base/version_builder_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe PackageManager::Base::VersionBuilder do
+  context ".build_hash" do
+    it "requires number" do
+      expect { described_class.build_hash }
+        .to raise_exception(ArgumentError, "missing keyword: :number")
+    end
+
+    it "raises an error on disallowed keywords" do
+      expect do
+        described_class.build_hash(
+          number: "a-number",
+          foo: "bar"
+        )
+      end.to raise_exception(ArgumentError, "unknown keyword: :foo")
+    end
+
+    it "returns a Hash containing the params that were passed" do
+      hash = described_class.build_hash(
+        number: "a-number",
+        status: "a-status",
+        created_at: "a-created-at",
+        published_at: "a-published-at",
+        original_license: "original-license"
+      )
+
+      expect(hash[:number]).to eq("a-number")
+      expect(hash[:status]).to eq("a-status")
+      expect(hash[:created_at]).to eq("a-created-at")
+      expect(hash[:published_at]).to eq("a-published-at")
+      expect(hash[:original_license]).to eq("original-license")
+    end
+  end
+end


### PR DESCRIPTION
The sub-classes of `PackageManager::Base` must define `mapping()` and `versions()` class methods, which return Hashes of data we need to update the project/versions in `PackageManager::Base.update()`.

these two changes should help standardize those two methods:

* adds a `PackageManager::Base::MappingBuilder.build_hash()` method that defines a required set of key and optional set of keys, and returns a Hash with the given keywords. 
* adds a `PackageManager::Base::VersionBuilder.build_hash()` method that defines a required set of keys and optional set of keys, and returns a Hash with the given keywords.

with these two classes, passing unknown or accidental keys back will raise an error, and we'll have a documented way of returning this data so it's obvious and clear.