### PR TITLE
PackageManager::NuGet: stop recording "1900" published dates

### DIFF
--- a/app/models/package_manager/nu_get.rb
+++ b/app/models/package_manager/nu_get.rb
@@ -151,11 +151,21 @@ module PackageManager
 
     def self.versions(raw_project, _name)
       raw_project[:raw_versions].map do |raw_version|
-        VersionBuilder.build_hash(
+        version_data = {
           number: raw_version.version_number,
           published_at: raw_version.published_at,
-          original_license: raw_version.original_license
-        )
+          original_license: raw_version.original_license,
+        }
+
+        if raw_version.deprecation.present?
+          # We considered NuGet versions that are unlisted as "Deprecated", and those
+          # versions have their "published" reset to 1/1/1900 in the NuGet API.
+          # Keep the original "published_at" on our side but mark it as deprecated.
+          version_data.delete(:published_at)
+          version_data[:status] = "Deprecated"
+        end
+
+        VersionBuilder.build_hash(**version_data)
       end
     end
 

--- a/app/models/package_manager/nu_get.rb
+++ b/app/models/package_manager/nu_get.rb
@@ -28,7 +28,7 @@ module PackageManager
     end
 
     def self.deprecation_info(db_project)
-      releases = get_releases(db_project.name)
+      releases = raw_versions(db_project.name)
 
       deprecation = releases.last&.deprecation
 
@@ -84,7 +84,7 @@ module PackageManager
       h = {
         name: name,
       }
-      h[:releases] = get_releases(name)
+      h[:raw_versions] = raw_versions(name)
       h[:versions] = versions(h, name)
       return {} unless h[:versions].any?
 
@@ -123,7 +123,8 @@ module PackageManager
       nil
     end
 
-    def self.get_releases(name)
+    # These are the raw version data we get from the upstream API
+    def self.raw_versions(name)
       SemverRegistrationApiProjectReleasesBuilder.build(project_name: escaped_name(name)).releases
     rescue StandardError => e
       Rails.logger.error("Unable to retrieve releases for NuGet project #{name}: #{e.message}")
@@ -132,34 +133,34 @@ module PackageManager
     end
 
     def self.mapping(raw_project)
-      item = raw_project[:releases].last
-      raw_nuspec = nuspec(raw_project[:name], item.version_number)
+      latest_raw_version = raw_project[:raw_versions].last
+      raw_nuspec = nuspec(raw_project[:name], latest_raw_version.version_number)
       nuspec_repo = raw_nuspec&.locate("package/metadata/repository")&.first
       nuspec_repo = nuspec_repo["url"] if nuspec_repo
 
       MappingBuilder.build_hash(
         name: raw_project[:name],
-        description: item.description,
-        homepage: item.project_url,
-        keywords_array: item.tags,
-        repository_url: repo_fallback(nuspec_repo, item.project_url),
-        licenses: item.licenses,
+        description: latest_raw_version.description,
+        homepage: latest_raw_version.project_url,
+        keywords_array: latest_raw_version.tags,
+        repository_url: repo_fallback(nuspec_repo, latest_raw_version.project_url),
+        licenses: latest_raw_version.licenses,
         versions: versions(raw_project, raw_project[:name])
       )
     end
 
     def self.versions(raw_project, _name)
-      raw_project[:releases].map do |item|
+      raw_project[:raw_versions].map do |raw_version|
         VersionBuilder.build_hash(
-          number: item.version_number,
-          published_at: item.published_at,
-          original_license: item.original_license
+          number: raw_version.version_number,
+          published_at: raw_version.published_at,
+          original_license: raw_version.original_license
         )
       end
     end
 
     def self.dependencies(_name, version, mapped_project)
-      current_version = mapped_project[:releases].find { |v| v.version_number == version }
+      current_version = mapped_project[:raw_versions].find { |v| v.version_number == version }
 
       current_version.dependencies.map do |dep|
         {

--- a/spec/models/package_manager/nu_get_spec.rb
+++ b/spec/models/package_manager/nu_get_spec.rb
@@ -156,7 +156,7 @@ describe PackageManager::NuGet do
       let(:name) { "Steeltoe.Common" }
       let(:cassette) { "nu_get/package" }
 
-      before { allow(described_class).to receive(:get_releases).and_return([]) }
+      before { allow(described_class).to receive(:raw_versions).and_return([]) }
 
       it "is not deprecated" do
         expect(deprecation_info[:is_deprecated]).to eq(false)

--- a/spec/models/package_manager/nu_get_spec.rb
+++ b/spec/models/package_manager/nu_get_spec.rb
@@ -65,7 +65,7 @@ describe PackageManager::NuGet do
     let(:raw_project) do
       {
         name: name,
-        releases: [
+        raw_versions: [
           PackageManager::NuGet::SemverRegistrationProjectRelease.new(
             published_at: Time.now,
             version_number: version,
@@ -79,6 +79,11 @@ describe PackageManager::NuGet do
             dependencies: []
           ),
         ],
+        versions: {
+          number: version,
+          published_at: Time.now,
+          original_license: "licenses"
+        }
       }
     end
 

--- a/spec/models/package_manager/nu_get_spec.rb
+++ b/spec/models/package_manager/nu_get_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 describe PackageManager::NuGet do
+  before { freeze_time }
+
   let(:project) { create(:project, name: "foo", platform: described_class.formatted_name) }
 
   it 'has formatted name of "NuGet"' do
@@ -82,8 +84,8 @@ describe PackageManager::NuGet do
         versions: {
           number: version,
           published_at: Time.now,
-          original_license: "licenses"
-        }
+          original_license: "licenses",
+        },
       }
     end
 
@@ -363,7 +365,82 @@ describe PackageManager::NuGet do
     end
   end
 
-  describe "::update" do
+  describe ".versions" do
+    let(:name) { "name" }
+    let(:version) { "version" }
+    let(:raw_project) do
+      {
+        name: name,
+        raw_versions: [
+          PackageManager::NuGet::SemverRegistrationProjectRelease.new(
+            published_at: Time.now,
+            version_number: version,
+            project_url: "project_url",
+            deprecation: nil,
+            description: "description",
+            summary: "summary",
+            tags: [],
+            licenses: "licenses",
+            license_url: "license_url",
+            dependencies: []
+          ),
+        ],
+        # Note that :versions is usually set in project() but we're not
+        # setting it here yet to show that it returns the proper thing
+      }
+    end
+
+    it "maps raw_versions to versions correctly" do
+      versions = described_class.versions(raw_project, name)
+
+      expect(versions).to eq([
+        {
+          number: "version",
+          published_at: Time.now.iso8601,
+          original_license: "licenses",
+        },
+      ])
+    end
+
+    context "when it contains a deprecated release" do
+      before do
+        raw_project[:raw_versions] << PackageManager::NuGet::SemverRegistrationProjectRelease.new(
+          published_at: DateTime.new(1900, 1, 1),
+          version_number: "version2",
+          project_url: "project_url",
+          deprecation: PackageManager::NuGet::SemverRegistrationProjectDeprecation.new(
+            message: "this release is deprecated, but the package is still fine",
+            alternate_package: nil
+          ),
+          description: "description",
+          summary: "summary",
+          tags: [],
+          licenses: "licenses",
+          license_url: "license_url",
+          dependencies: []
+        )
+      end
+
+      it "sets deprecated status and doesn't set published_at" do
+        versions = described_class.versions(raw_project, name)
+
+        expect(versions).to eq([
+          {
+            number: "version",
+            published_at: Time.now.iso8601,
+            original_license: "licenses",
+          },
+          {
+            number: "version2",
+            original_license: "licenses",
+            status: "Deprecated",
+          },
+        ])
+      end
+    end
+  end
+
+  describe ".update" do
     subject(:result) do
       VCR.use_cassette(cassette) { described_class.update(name) }
     end


### PR DESCRIPTION
changes to `PackageManager::Nuget`:
* rename `get_releases()` to `raw_versions()`, to avoid confusion and make more consistent with the `versions()` method
* also rename the `:releases` key in its raw project data to `:raw_versions` for consistency
* when we get a raw version from NuGet's API that has "published=1900-01-01...", **do not** update the "published_at" on our side to 1900 (so we keep the original published_at date, and set the `Version`'s "status" column to "Deprecated"

this would be Libraries' first use-case for deprecated Versions.