### PR TITLE
CocoaPods bugfix: pass kwargs to VersionBuilder instead of a Hash

### DIFF
--- a/app/models/package_manager/cocoa_pods.rb
+++ b/app/models/package_manager/cocoa_pods.rb
@@ -50,9 +50,7 @@ module PackageManager
 
     def self.versions(raw_project, _name)
       raw_project.fetch("versions", {}).keys.map do |v|
-        VersionBuilder.build_hash({
-                                    number: v.to_s,
-                                  })
+        VersionBuilder.build_hash(number: v.to_s)
       end
     end
 

--- a/docs/add-a-package-manager.md
+++ b/docs/add-a-package-manager.md
@@ -125,10 +125,10 @@ Here's an example from [NuGet](../app/models/package_manager/nu_get.rb):
 ```ruby
 def self.versions(raw_project, _name)
   raw_project[:releases].map do |item|
-    VersionBuilder.build_hash({
+    VersionBuilder.build_hash(
       number: item['catalogEntry']['version'],
       published_at: item['catalogEntry']['published']
-    })
+    )
   end
 end
 ```

--- a/spec/models/package_manager/cocoa_pods_spec.rb
+++ b/spec/models/package_manager/cocoa_pods_spec.rb
@@ -48,4 +48,22 @@ describe PackageManager::CocoaPods do
       expect(described_class.parse_license({ "type" => "foobar" })).to eq("foobar")
     end
   end
+
+  describe ".versions" do
+    it "returns mapped versions" do
+      versions = described_class.versions({
+                                            "name" => "some-package",
+                                            "versions" => {
+                                              "1.0.0" => {
+                                                "name" => "some-package",
+                                                "version" => "1.0.0",
+                                              },
+                                            },
+                                          }, "some-package")
+
+      expect(versions).to eq([{
+                               number: "1.0.0",
+                             }])
+    end
+  end
 end


### PR DESCRIPTION
(followup to https://github.com/librariesio/libraries.io/pull/3397)

```ArgumentError 
PackageManagerDownloadWorker@critical
wrong number of arguments (given 1, expected 0; required keyword: number)
```