### PR TITLE
Add rake task to backfill nuget published_at dates

### DIFF
--- a/lib/tasks/one_off.rake
+++ b/lib/tasks/one_off.rake
@@ -25,4 +25,66 @@ namespace :one_off do
       end
     end
   end
+
+  # This task tracks down the original "published" dates for NuGet Versions that
+  # are marked as "published_at=1900-01-01 00:00:00" in Libraries, and updates
+  # them with the original "published" date, and marks them 'status: "Deprecated"'.
+  #
+  # It processes lists-of-lists from NuGet's API:
+  #   * [CatalogRoot] Catalog API (https://learn.microsoft.com/en-us/nuget/api/catalog-resource)
+  #     * .items => [CatalogPage]
+  #       * .items => [PackageDetails] (each PackageDetails may contain the original "published")
+  #
+  # @param catalog_start_idx Integer the index of the catalog page to start with,
+  #                          to skip already-processed pages (default: 0)
+  # @param threads Integer the number of parallel threads to process version items (default: 8)
+  desc "backfill unknown nuget published_at dates"
+  task :backfill_nuget_published_at, %i[catalog_start_idx threads] => :environment do |_t, args|
+    require "parallel"
+
+    catalog_start_idx = args.catalog_start_idx.to_i
+    threads = args.threads || 8
+
+    print "Loading 'unlisted' NuGet Version records... "
+    unlisted_name_versions = Version
+      .joins(:project)
+      .where(projects: { platform: "NuGet" })
+      .where("published_at < ?", DateTime.new(1901, 1, 1))
+      .pluck("projects.name, versions.number")
+      .index_by(&:itself)
+    puts "found #{unlisted_name_versions.size} records."
+
+    print "Loading NuGet's catalog listing of events pages... "
+    catalog = PackageManager::ApiService.request_json_with_headers("https://api.nuget.org/v3/catalog0/index.json")
+    catalog_size = catalog["items"].size
+    puts "found #{catalog_size} pages."
+
+    catalog["items"][catalog_start_idx..].each.with_index do |catalog_item, idx|
+      puts "Processing NuGet catalog page #{idx}, out of #{catalog_size} pages..."
+      page = PackageManager::ApiService.request_json_with_headers(catalog_item["@id"])
+
+      Parallel.each(page["items"], in_threads: threads, progress: "Page #{idx} (out of #{page['items'].size} items)") do |item|
+        page_item = PackageManager::ApiService.request_json_with_headers(item["@id"])
+        name = page_item["id"]
+        version = page_item["version"]
+        published = page_item["published"]
+
+        if published.nil?
+          raise "'published' field not found on page #{catalog_item['@id']} in #{item['@id']}."
+        elsif unlisted_name_versions.key?([version, name]) && published !~ /1900-/
+          p = Project.find_by(platform: "NuGet", name: name)
+          v = p.versions.find_by(number: version)
+          if v.published_at.year == 1900
+            published_at = Time.parse(published)
+            v.update_columns(published_at: published, status: "Deprecated")
+            unlisted_name_versions.delete([version, name])
+            puts "Updating #{p.name}@#{v.number} to #{published_at}."
+          else
+            puts "Skipping #{p.name}@#{v.number}. Version is already #{v.published_at}."
+          end
+        end
+      end
+    end
+    puts "Catalog page idx #{idx} (#{(idx / catalog_size.to_f) * 100}% complete)"
+  end
 end


### PR DESCRIPTION
(followup to https://github.com/librariesio/libraries.io/pull/3398 )

This adds a `one_off:backfill_nuget_published_at` rake task that will 
1) pull a list of all NuGet Version records where `published_at: '1900-01-01 00:00:00'`, which means unlisted (or "Deprecated" in Libraries terms)
2) iterate over [NuGet's Catalog API endpoint](https://learn.microsoft.com/en-us/nuget/api/catalog-resource#catalog-leaf)
3) if one of the releases from the API is in the list from step (1), and the API date is not 1900, then update the Version record to the original "published" date (and mark it as `status: "Deprecated"`)

* the `catalog_start_idx` argument lets you skip over catalog pages, to not re-do work if you restart the task
* the `threads` argument lets you adjust the level of parallelism when fetching release pages

<img width="1417" alt="Screenshot 2024-06-07 at 12 01 49 PM" src="https://github.com/librariesio/libraries.io/assets/5054/ba0ade8a-89dc-47f1-83e0-3e61e2a28601">
