### PR TITLE
Ensure we set "status: nil" on non-Deprecated NuGet packages.

### DIFF
--- a/app/models/package_manager/nu_get.rb
+++ b/app/models/package_manager/nu_get.rb
@@ -163,6 +163,10 @@ module PackageManager
           # Keep the original "published_at" on our side but mark it as deprecated.
           version_data.delete(:published_at)
           version_data[:status] = "Deprecated"
+        else
+          # If the version is listed on NuGet and not deprecated, then we'd currently
+          # consider it "Active", or status: nil.
+          version_data[:status] = nil
         end
 
         VersionBuilder.build_hash(**version_data)

--- a/spec/models/package_manager/nu_get_spec.rb
+++ b/spec/models/package_manager/nu_get_spec.rb
@@ -398,6 +398,7 @@ describe PackageManager::NuGet do
           number: "version",
           published_at: Time.now.iso8601,
           original_license: "licenses",
+          status: nil,
         },
       ])
     end
@@ -421,7 +422,7 @@ describe PackageManager::NuGet do
         )
       end
 
-      it "sets deprecated status and doesn't set published_at" do
+      it "sets deprecated status and doesn't modify published_at" do
         versions = described_class.versions(raw_project, name)
 
         expect(versions).to eq([
@@ -429,6 +430,7 @@ describe PackageManager::NuGet do
             number: "version",
             published_at: Time.now.iso8601,
             original_license: "licenses",
+            status: nil,
           },
           {
             number: "version2",


### PR DESCRIPTION
this is to handle the case of an "unlisted" package on NuGet being "re-listed". We're not sure if this is possible yet, but we should handle it JIC.

re this convo: https://github.com/librariesio/libraries.io/pull/3400#discussion_r1631631024

(followup to https://github.com/librariesio/libraries.io/pull/3398)
