### PR TITLE
Cache Timed Out Go Project Names

### DIFF
--- a/app/models/package_manager/go.rb
+++ b/app/models/package_manager/go.rb
@@ -249,7 +249,7 @@ module PackageManager
         )
 
         chosen_name
-      rescue Faraday::ConnectionFailed => e
+      rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
         # We can get here from go modules that don't exist anymore, or having server troubles:
         # Fallback to the given name, cache the host as "bad" for a day,
         # log it (to analyze later) and notify us to be safe.


### PR DESCRIPTION
Cache a timeout response the same way that we cache an unreachable host name when trying to resolve an unknown go project name to avoid trying to resolve it multiple times. 