### PR TITLE
Ensure that NuGet releases that don't have "deprecation" field but have "published=1900" are not saved with "published_at: 1900"

### DIFF
--- a/spec/models/package_manager/nu_get_spec.rb
+++ b/spec/models/package_manager/nu_get_spec.rb
@@ -440,6 +440,41 @@ describe PackageManager::NuGet do
         ])
       end
     end
+
+    context "when it contains an unlisted release" do
+      before do
+        raw_project[:raw_versions] << PackageManager::NuGet::SemverRegistrationProjectRelease.new(
+          published_at: DateTime.new(1900, 1, 1),
+          version_number: "version2",
+          project_url: "project_url",
+          deprecation: nil,
+          description: "description",
+          summary: "summary",
+          tags: [],
+          licenses: "licenses",
+          license_url: "license_url",
+          dependencies: []
+        )
+      end
+
+      it "sets deprecated status and doesn't modify published_at" do
+        versions = described_class.versions(raw_project, name)
+
+        expect(versions).to eq([
+          {
+            number: "version",
+            published_at: Time.now.iso8601,
+            original_license: "licenses",
+            status: nil,
+          },
+          {
+            number: "version2",
+            original_license: "licenses",
+            status: "Deprecated",
+          },
+        ])
+      end
+    end
   end
 
   describe ".update" do


### PR DESCRIPTION
It turns out that a release on NuGet can be "unlisted" but not "deprecated" on their side, e.g. `"RestSharp@105.2.0"`, and it's not clear why. 

But we consider both "unlisted" and "deprecated" on the NuGet side as "status: 'Deprecated'" on our side. This fix ensures we don't save the 1900 "published" date on these cases.

