### PR TITLE
Handle weird case where latest in maven-metadata doesn't exist

### DIFF
--- a/app/models/package_manager/maven/maven_central.rb
+++ b/app/models/package_manager/maven/maven_central.rb
@@ -18,19 +18,24 @@ class PackageManager::Maven::MavenCentral < PackageManager::Maven::Common
 
   # Attempt to scrape MavenCentral's index HTML to infer the latest version.
   def self.latest_version_scraped(name)
-    get_html(MavenUrl.from_name(name, repository_base, NAME_DELIMITER).base)
+    versions = get_html(MavenUrl.from_name(name, repository_base, NAME_DELIMITER).base)
       .css("#contents a")                                  # scrape the list of file/folders
       .map(&:text)                                         # get each innerText
       .select { |text| text.end_with?("/") }               # only look at folders
       .map { |folder| folder.chomp("/") }                  # remove folder trailing slash
       .grep(/^\d+.\d/)                                     # only folders that look like versions
-      .max_by do |text|
-        # Maven versions range from 1 to many "." and may not be valid SemVer. Use the more forgiving Gem::Version to sort
-        Gem::Version.new(text)
-      rescue ArgumentError
-        Bugsnag.notify("Couldn't find scraped HTML version for #{name}. Check the HTML and ensure scraping still works.")
-        nil
-      end
+
+    # Maven versions range from 1 to many "." and may not be valid SemVer. Use the more forgiving Gem::Version to sort
+    # but we also want to prefer things that _don't_ look like a date as that's an ancient maven practice
+    dated_versions, nodate_versions = versions.partition { |v| v =~ /\d{8}.\d+/ }
+    if nodate_versions.count > 0
+      nodate_versions.max_by { |v| Gem::Version.new(v) }
+    else
+      dated_versions.max_by { |v| Gem::Version.new(v) }
+    end
+  rescue ArgumentError
+    Bugsnag.notify("Couldn't find scraped HTML version for #{name}. Check the HTML and ensure scraping still works.")
+    nil
   end
 
   # maven-metadata.xml for Maven Central does not appear to be guaranteed to contain all relevant versions for a package

--- a/app/models/package_manager/maven/maven_central.rb
+++ b/app/models/package_manager/maven/maven_central.rb
@@ -19,7 +19,7 @@ class PackageManager::Maven::MavenCentral < PackageManager::Maven::Common
   # Attempt to scrape MavenCentral's index HTML to infer the latest version.
   def self.latest_version_scraped(name)
     versions = get_html(MavenUrl.from_name(name, repository_base, NAME_DELIMITER).base)
-      .css("#contents a")                                  # scrape the list of file/folders
+      .css("a")                                            # scrape the list of file/folders
       .map(&:text)                                         # get each innerText
       .select { |text| text.end_with?("/") }               # only look at folders
       .map { |folder| folder.chomp("/") }                  # remove folder trailing slash


### PR DESCRIPTION
There are some cases (for example, commons-discovery:commons-discovery) where the version listed as latest in maven-metadata.xml isn't actually present on central. This lets us fallback to our scraping and using that.

Also improves the scraping of the latest version to prefer non date formatted versions as that's an older maven practice

Thanks taking the time to contribute. This template should help guide you through the process of creating a pull request for review. Please erase any part of this template that is not relevant to your pull request:
