### PR TITLE
Upgrade charlock_holmes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,7 +147,7 @@ GEM
       xpath (~> 3.2)
     case_transform (0.2)
       activesupport
-    charlock_holmes (0.7.7)
+    charlock_holmes (0.7.9)
     chartkick (3.4.0)
     chronic (0.10.2)
     coderay (1.1.3)


### PR DESCRIPTION
On my setup, I was unable to `bundle install`. I was getting the issue described [here](https://github.com/brianmario/charlock_holmes/issues/172#issuecomment-2200823928). Upgrading the transitive dependency `charlock_holmes` fixed this for me.