### PR TITLE
Find a v4 Token When Updating Repository

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -285,7 +285,7 @@ class Repository < ApplicationRecord
   end
 
   def update_all_info(token = nil)
-    token ||= AuthToken.token if host_type == "GitHub"
+    token ||= AuthToken.find_token(:v4) if host_type == "GitHub"
 
     if check_status && (last_synced_at.nil? || last_synced_at < 2.minutes.ago)
       update_from_repository(token)


### PR DESCRIPTION
We need to try and find a GraphQL enabled API key for updating repositories with the new query added in for policy document URLs.