### PR TITLE
Save Scopes an Auth Token Has Access To

### DIFF
--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -7,6 +7,7 @@
 #  id         :integer          not null, primary key
 #  authorized :boolean
 #  login      :string
+#  scopes     :string           default([]), is an Array
 #  token      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -67,6 +68,13 @@ class AuthToken < ApplicationRecord
     !!github_client.rate_limit
   rescue Octokit::Unauthorized, Octokit::AccountSuspended
     false
+  end
+
+  def fetch_auth_scopes
+    client = github_client
+    client.rate_limit!.remaining unless client.last_response
+
+    client.last_response.headers.fetch("x-oauth-scopes", "").split(", ")
   end
 
   def github_client(options = {})

--- a/db/migrate/20240722132217_add_scopes_to_auth_token.rb
+++ b/db/migrate/20240722132217_add_scopes_to_auth_token.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddScopesToAuthToken < ActiveRecord::Migration[7.0]
+  def up
+    add_column :auth_tokens, :scopes, :string, array: true
+    change_column_default :auth_tokens, :scopes, []
+  end
+
+  def down
+    remove_column :auth_tokens, :scopes
+  end
+end

--- a/db/migrate/20240722132336_backfill_add_scopes_to_auth_token.rb
+++ b/db/migrate/20240722132336_backfill_add_scopes_to_auth_token.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class BackfillAddScopesToAuthToken < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    AuthToken.unscoped.in_batches do |relation|
+      relation.update_all scopes: []
+      sleep(0.01)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_17_173229) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_22_132336) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -34,6 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_17_173229) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.boolean "authorized"
+    t.string "scopes", default: [], array: true
   end
 
   create_table "contributions", id: :serial, force: :cascade do |t|

--- a/lib/tasks/auth_tokens.rake
+++ b/lib/tasks/auth_tokens.rake
@@ -19,6 +19,7 @@ namespace :auth_tokens do
             result = token.still_authorized?
             if result
               token.login = token.github_client.user[:login]
+              token.scopes = token.fetch_auth_scopes
             else
               token.authorized = false
             end


### PR DESCRIPTION
This would be useful data to have when we need to make an API call with a specific scope. We can query directly for any authorized tokens we have with the required scope before attempting to make the API call.