### PR TITLE
Add Logic To Fetch Tokens With Specific Scopes

### DIFF
--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -16,7 +16,7 @@ class AuthToken < ApplicationRecord
   validates_presence_of :token
   scope :authorized, -> { where(authorized: [true, nil]) }
   # find tokens that include ANY of the scopes provided
-  scope :with_either_scope, ->(required_scope) { where("scopes && array[?]::varchar[]", Array(required_scope)) }
+  scope :has_scope, ->(searched_scopes) { where("scopes && array[?]::varchar[]", Array(searched_scopes)) }
 
   LOW_RATE_LIMIT_REMAINING_THRESHOLD = 500
 
@@ -107,7 +107,7 @@ class AuthToken < ApplicationRecord
   def self.find_token(api_version, retries: 0, required_scope: [])
     query = authorized.order(Arel.sql("RANDOM()"))
     unless required_scope.blank?
-      query = query.with_either_scope(required_scope)
+      query = query.has_scope(required_scope)
     end
     auth_token = query.first
     return auth_token if auth_token.safe_to_use?(api_version)

--- a/app/models/repository_host/github.rb
+++ b/app/models/repository_host/github.rb
@@ -58,23 +58,31 @@ module RepositoryHost
 
     def self.fetch_repo(id_or_name, token = nil)
       id_or_name = id_or_name.to_i if id_or_name.match(/\A\d+\Z/)
-      token ||= AuthToken.find_token(:v4).token
+      required_scope = %w[repo public_repo]
+      token ||= AuthToken.find_token(:v4, required_scope: required_scope).token
 
-      api_hash = AuthToken.fallback_client(token).repo(id_or_name, accept: "application/vnd.github.drax-preview+json,application/vnd.github.mercy-preview+json").to_hash
+      github_client = AuthToken.fallback_client(token)
+      api_hash = github_client.repo(id_or_name, accept: "application/vnd.github.drax-preview+json,application/vnd.github.mercy-preview+json").to_hash
 
-      # disabling for now due to some permission issues in the GH API
-      # owner = api_hash.dig(:owner, :login)
-      # repository_name = api_hash[:name]
-      # graphql_client = AuthToken.new_v4_client(token)
-      # graphql_values = GraphqlRepositoryFieldsQuery.new(graphql_client).query(params: { owner: owner, repository_name: repository_name })
-      # graphql_hash = {
-      #   code_of_conduct_url: graphql_values.code_of_conduct_url,
-      #   contribution_guidelines_url: graphql_values.contribution_guidelines_url,
-      #   funding_urls: graphql_values.funding_urls,
-      #   security_policy_url: graphql_values.security_policy_url,
-      # }
+      owner = api_hash.dig(:owner, :login)
+      repository_name = api_hash[:name]
 
-      RawUpstreamDataConverter.convert_from_github_api(api_hash)
+      # verify the token being used has the correct scopes for the document URLs API call
+      unless AuthToken.fetch_auth_scopes(token, github_client.last_response).any? { |scope| required_scope.include?(scope) }
+        token = AuthToken.find_token(:v4, required_scope: %w[repo public_repo]).token
+        StructuredLog.capture("GITHUB_FETCH_REPO_FINDING_NEW_TOKEN", { id_or_name: id_or_name })
+      end
+
+      graphql_client = AuthToken.new_v4_client(token)
+      graphql_values = GraphqlRepositoryFieldsQuery.new(graphql_client).query(params: { owner: owner, repository_name: repository_name })
+      graphql_hash = {
+        code_of_conduct_url: graphql_values.code_of_conduct_url,
+        contribution_guidelines_url: graphql_values.contribution_guidelines_url,
+        funding_urls: graphql_values.funding_urls,
+        security_policy_url: graphql_values.security_policy_url,
+      }
+
+      RawUpstreamDataConverter.convert_from_github_api(api_hash.merge(graphql_hash))
     rescue *IGNORABLE_EXCEPTIONS
       nil
     end

--- a/lib/tasks/auth_tokens.rake
+++ b/lib/tasks/auth_tokens.rake
@@ -19,7 +19,7 @@ namespace :auth_tokens do
             result = token.still_authorized?
             if result
               token.login = token.github_client.user[:login]
-              token.scopes = token.fetch_auth_scopes
+              token.scopes = AuthToken.fetch_auth_scopes(token.token, token.github_client.last_response)
             else
               token.authorized = false
             end

--- a/spec/models/auth_token_spec.rb
+++ b/spec/models/auth_token_spec.rb
@@ -76,26 +76,26 @@ describe AuthToken, type: :model do
     end
   end
 
-  describe "with_either_scope" do
+  describe "has_scope" do
     let(:scope1) { "scope1" }
     let(:scope2) { "scope2" }
     let!(:auth_token1) { create(:auth_token, scopes: [scope1, scope2]) }
     let!(:auth_token2) { create(:auth_token, scopes: [scope2]) }
 
     it "finds auth token with scope" do
-      result = described_class.with_either_scope(scope1)
+      result = described_class.has_scope(scope1)
       expect(result.size).to eql(1)
       expect(result.first).to eql(auth_token1)
     end
 
     it "finds auth tokens with either scope" do
-      result = described_class.with_either_scope([scope1, scope2])
+      result = described_class.has_scope([scope1, scope2])
       expect(result.size).to eql(2)
       expect(result.ids).to contain_exactly(auth_token1.id, auth_token2.id)
     end
 
     it "does not find tokens with missing scope" do
-      result = described_class.with_either_scope("something-else")
+      result = described_class.has_scope("something-else")
       expect(result.size).to eql(0)
     end
   end


### PR DESCRIPTION
This adds some logic to grab tokens with specific scopes when needed. The logic is used to help re-enable to the API call to gather document URLs for repositories as that call needs some sort of repo scope enabled.