### PR TITLE
Don't Set last_synced_at When Queueing Repository Resync

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -277,7 +277,6 @@ class Repository < ApplicationRecord
                             repository_last_synced_at: last_synced_at,
                           })
     update_all_info_async(token)
-    update_column(:last_synced_at, Time.now)
   end
 
   def update_all_info_async(token = nil)


### PR DESCRIPTION
We have this `last_synced_at` datetime stored on the `Repository` and I think it is mainly used to guard against syncing the data for a Repository more than once [within a two minute period](https://github.com/librariesio/libraries.io/blob/c121c579406c47b9ed29ba32495003b1f3b5efcb/app/models/repository.rb#L289). We set this time when we manually want to resync a repository which I think makes it never update due to the guard code that eventually gets called via an async worker. 