### PR TITLE
Pass Through Scope Argument When find_token Retries

### DIFF
--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -115,6 +115,6 @@ class AuthToken < ApplicationRecord
     retries += 1
     raise "No Authorized AuthToken Could Be Found!" if retries >= 10
 
-    find_token(api_version, retries: retries)
+    find_token(api_version, retries: retries, required_scope: required_scope)
   end
 end


### PR DESCRIPTION
I forgot to include the argument in the call made to the function when it needs to retry finding a token.