### PR TITLE
Handle removed Pypi projects gracefully when fetching releases

### DIFF
--- a/app/models/package_manager/pypi/json_api_project.rb
+++ b/app/models/package_manager/pypi/json_api_project.rb
@@ -79,7 +79,7 @@ module PackageManager
 
       def releases
         JsonApiProjectReleases.new(
-          @data["releases"].map do |version_number, details|
+          @data.fetch("releases", []).map do |version_number, details|
             # this assumes that each file type distribution of the package/version has the same yanked status & reason
             first_details = details.first || {}
 

--- a/spec/models/package_manager/pypi/json_api_project_spec.rb
+++ b/spec/models/package_manager/pypi/json_api_project_spec.rb
@@ -242,6 +242,14 @@ describe PackageManager::Pypi::JsonApiProject do
     end
     let(:raw_releases) { {} }
 
+    context "with a removed project with no data" do
+      let(:raw_project) { {} }
+
+      it "returns nothing" do
+        expect(project.releases).to be_empty
+      end
+    end
+
     context "with no releases" do
       it "returns nothing" do
         expect(project.releases).to be_empty


### PR DESCRIPTION
fixes this error:

```
NoMethodError 
CheckStatusWorker@status
undefined method `map' for nil:NilClass @data["releases"].map do |version_number, details| ^^^^
```