### PR TITLE
Bs/handle removed npm packages

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -668,6 +668,8 @@ class Project < ApplicationRecord
       update_attribute(:status, "Removed") if created_at < 1.week.ago
     elsif !platform.downcase.in?(%w[packagist go]) && [400, 404, 410].include?(response.response_code)
       update_attribute(:status, "Removed")
+    elsif !platform.downcase == "npm" && response.response_code == 404
+      update_attribute(:status, "Removed")
     elsif response.timed_out? || response.failure?
       # failure could be a problem checking so let's just log for now
       StructuredLog.capture("CHECK_STATUS_FAILURE", { platform: platform, name: name, status_code: response.response_code })

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -259,10 +259,11 @@ describe Project, type: :model do
 
     context "removed NPM project" do
       let!(:project) { create(:project, platform: "NPM", name: "react-for-pets", status: nil, created_at: 1.month.ago) }
+      let(:check_status_url) { PackageManager::NPM.check_status_url(project) }
 
       it "should mark it as Removed for a 404" do
         WebMock.stub_request(:get, check_status_url).to_return(status: 302)
-        
+
         project.check_status
         project.reload
         expect(project.status).to eq("Removed")

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -257,6 +257,19 @@ describe Project, type: :model do
       end
     end
 
+    context "removed NPM project" do
+      let!(:project) { create(:project, platform: "NPM", name: "react-for-pets", status: nil, created_at: 1.month.ago) }
+
+      it "should mark it as Removed for a 404" do
+        WebMock.stub_request(:get, check_status_url).to_return(status: 302)
+        
+        project.check_status
+        project.reload
+        expect(project.status).to eq("Removed")
+        expect(project.status_checked_at).to eq(DateTime.current)
+      end
+    end
+
     context "some of project deprecated" do
       let!(:project) { create(:project, platform: "NPM", name: "react", status: nil, updated_at: 1.week.ago) }
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -262,7 +262,7 @@ describe Project, type: :model do
       let(:check_status_url) { PackageManager::NPM.check_status_url(project) }
 
       it "should mark it as Removed for a 404" do
-        WebMock.stub_request(:get, check_status_url).to_return(status: 302)
+        WebMock.stub_request(:get, check_status_url).to_return(status: 404)
 
         project.check_status
         project.reload


### PR DESCRIPTION
packages which were removed from NPM but exist in libraries, have been unmarking deprecation statuses manually added to them


this happens because `check_status` does not check for a 404 from NPM and handle as a removed package. instead, it falls back to `deprecation_info` to check if it's deprecated, and it's lack of presence (because it's been removed not deprecated) means it resets `status` and `deprecation_reason` to `nil`

fix this behavior by handling 404s from NPM