### PR TITLE
Revert "Bs/handle removed npm packages"

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -668,8 +668,6 @@ class Project < ApplicationRecord
       update_attribute(:status, "Removed") if created_at < 1.week.ago
     elsif !platform.downcase.in?(%w[packagist go]) && [400, 404, 410].include?(response.response_code)
       update_attribute(:status, "Removed")
-    elsif !platform.downcase == "npm" && response.response_code == 404
-      update_attribute(:status, "Removed")
     elsif response.timed_out? || response.failure?
       # failure could be a problem checking so let's just log for now
       StructuredLog.capture("CHECK_STATUS_FAILURE", { platform: platform, name: name, status_code: response.response_code })

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -257,20 +257,6 @@ describe Project, type: :model do
       end
     end
 
-    context "removed NPM project" do
-      let!(:project) { create(:project, platform: "NPM", name: "react-for-pets", status: nil, created_at: 1.month.ago) }
-      let(:check_status_url) { PackageManager::NPM.check_status_url(project) }
-
-      it "should mark it as Removed for a 404" do
-        WebMock.stub_request(:get, check_status_url).to_return(status: 404)
-
-        project.check_status
-        project.reload
-        expect(project.status).to eq("Removed")
-        expect(project.status_checked_at).to eq(DateTime.current)
-      end
-    end
-
     context "some of project deprecated" do
       let!(:project) { create(:project, platform: "NPM", name: "react", status: nil, updated_at: 1.week.ago) }
 


### PR DESCRIPTION
Reverts librariesio/libraries.io#3428


this is actually just a noop, and handled by `elsif !platform.downcase.in?(%w[packagist go]) && [400, 404, 410].include?(response.response_code)`