### PR TITLE
handle response error codes more explicitly & guard revert to nil status unless response status is a success

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -680,14 +680,14 @@ class Project < ApplicationRecord
       if result[:is_deprecated]
         update_attribute(:status, "Deprecated")
         update_attribute(:deprecation_reason, result[:message])
-      elsif (response.response_code >= 200 && response.response_code <= 299) # in case package was accidentally marked as deprecated (their logic or ours), mark it as not deprecated
+      elsif response.response_code >= 200 && response.response_code <= 299 # in case package was accidentally marked as deprecated (their logic or ours), mark it as not deprecated
         update_attribute(:status, nil)
         update_attribute(:deprecation_reason, nil)
       end
-    else
-      # only update status to nil if the response code is a success
-      update_attribute(:status, nil) if (response.response_code >= 200 && response.response_code <= 299)
+    elsif response.response_code >= 200 && response.response_code <= 299
+      update_attribute(:status, nil)
     end
+    # only update status to nil if the response code is a success
   end
 
   def unique_project_requirement_ranges

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -660,7 +660,6 @@ class Project < ApplicationRecord
     return if hidden?
 
     response = Typhoeus.get(url)
-    # 429 200 404 503 302 0
 
     StructuredLog.capture("CHECK_STATUS_CHANGE", { platform: platform, name: name, status_code: response.response_code }) if platform.downcase == "npm"
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -671,7 +671,7 @@ class Project < ApplicationRecord
       update_attribute(:status, "Removed") if created_at < 1.week.ago
     elsif !platform.downcase.in?(%w[packagist go]) && [400, 404, 410].include?(response.response_code)
       update_attribute(:status, "Removed")
-    elsif response.timed_out? || response.failure?
+    elsif response.timed_out? || response.failure? || response.response_code == 429
       # failure could be a problem checking so let's just log for now
       StructuredLog.capture("CHECK_STATUS_FAILURE", { platform: platform, name: name, status_code: response.response_code })
     elsif can_have_entire_package_deprecated?

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -257,6 +257,34 @@ describe Project, type: :model do
       end
     end
 
+    context "should not change status in case of error" do
+      let!(:project) { create(:project, platform: "NPM", name: "coolpackage", status: nil, created_at: 1.month.ago) }
+
+      it "error 429" do
+        WebMock.stub_request(:get, check_status_url).to_return(status: 429)
+
+        status_before = project.status
+        last_changed = project.status_checked_at
+
+        project.check_status
+        project.reload
+        expect(project.status).to eq(status_before)
+        expect(project.status_checked_at).to eq(last_changed)
+      end
+
+      it "error 429" do
+        WebMock.stub_request(:get, check_status_url).to_return(status: 500)
+
+        status_before = project.status
+        last_changed = project.status_checked_at
+
+        project.check_status
+        project.reload
+        expect(project.status).to eq(status_before)
+        expect(project.status_checked_at).to eq(last_changed)
+      end
+    end
+
     context "some of project deprecated" do
       let!(:project) { create(:project, platform: "NPM", name: "react", status: nil, updated_at: 1.week.ago) }
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -265,24 +265,20 @@ describe Project, type: :model do
         WebMock.stub_request(:get, check_status_url).to_return(status: 429)
 
         status_before = project.status
-        last_changed = project.status_checked_at
 
         project.check_status
         project.reload
         expect(project.status).to eq(status_before)
-        expect(project.status_checked_at).to eq(last_changed)
       end
 
       it "error 429" do
         WebMock.stub_request(:get, check_status_url).to_return(status: 500)
 
         status_before = project.status
-        last_changed = project.status_checked_at
 
         project.check_status
         project.reload
         expect(project.status).to eq(status_before)
-        expect(project.status_checked_at).to eq(last_changed)
       end
     end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -259,6 +259,7 @@ describe Project, type: :model do
 
     context "should not change status in case of error" do
       let!(:project) { create(:project, platform: "NPM", name: "coolpackage", status: nil, created_at: 1.month.ago) }
+      let(:check_status_url) { PackageManager::NPM.check_status_url(project) }
 
       it "error 429" do
         WebMock.stub_request(:get, check_status_url).to_return(status: 429)


### PR DESCRIPTION
* handle 429 response code

* handle response error codes more explicitly (directly checking the response code numbers instead of previously used `.failure?` check), & guard revert to status: `nil` unless response status is a success