### PR TITLE
Introduce "audited" gem to Librarires

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby "3.1.5"
 gem "active_model_serializers"
 gem "api-pagination"
 gem "asciidoctor"
+gem "audited"
 gem "bibliothecary", ">= 8.7.6"
 gem "bitbucket_rest_api", git: "https://github.com/librariesio/bitbucket"
 gem "bootsnap", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,9 @@ GEM
     api-pagination (4.8.2)
     asciidoctor (2.0.20)
     ast (2.4.2)
+    audited (5.7.0)
+      activerecord (>= 5.2, < 8.0)
+      activesupport (>= 5.2, < 8.0)
     autoprefixer-rails (9.5.1.1)
       execjs
     base64 (0.1.1)
@@ -612,6 +615,7 @@ DEPENDENCIES
   annotate
   api-pagination
   asciidoctor
+  audited
   bibliothecary (>= 8.7.6)
   bitbucket_rest_api!
   bootsnap

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -105,6 +105,7 @@ class Project < ApplicationRecord
     status
   ].freeze
 
+  # Currently these are the fields defined in PackageManager::Base::MappingBuilder
   audited only: %w[name description repository_url homepage keywords_array licenses]
 
   delegate :code_of_conduct_url, :contribution_guidelines_url, :funding_urls, :security_policy_url, to: :repository, allow_nil: true

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -105,6 +105,8 @@ class Project < ApplicationRecord
     status
   ].freeze
 
+  audited only: %w[name description repository_url homepage keywords_array licenses]
+
   delegate :code_of_conduct_url, :contribution_guidelines_url, :funding_urls, :security_policy_url, to: :repository, allow_nil: true
 
   validates :name, :platform, presence: true

--- a/db/migrate/20240815181932_install_audited.rb
+++ b/db/migrate/20240815181932_install_audited.rb
@@ -14,16 +14,16 @@ class InstallAudited < ActiveRecord::Migration[7.0]
       t.column :username, :string
       t.column :action, :string
       t.column :audited_changes, :text
-      t.column :version, :integer, :default => 0
+      t.column :version, :integer, default: 0
       t.column :comment, :string
       t.column :remote_address, :string
       t.column :request_uuid, :string
       t.column :created_at, :datetime
     end
 
-    add_index :audits, [:auditable_type, :auditable_id, :version], :name => 'auditable_index', algorithm: :concurrently
-    add_index :audits, [:associated_type, :associated_id], :name => 'associated_index', algorithm: :concurrently
-    add_index :audits, [:user_id, :user_type], :name => 'user_index', algorithm: :concurrently
+    add_index :audits, %i[auditable_type auditable_id version], name: "auditable_index", algorithm: :concurrently
+    add_index :audits, %i[associated_type associated_id], name: "associated_index", algorithm: :concurrently
+    add_index :audits, %i[user_id user_type], name: "user_index", algorithm: :concurrently
     add_index :audits, :request_uuid, algorithm: :concurrently
     add_index :audits, :created_at, algorithm: :concurrently
   end

--- a/db/migrate/20240815181932_install_audited.rb
+++ b/db/migrate/20240815181932_install_audited.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class InstallAudited < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def self.up
+    create_table :audits do |t|
+      t.column :auditable_id, :integer
+      t.column :auditable_type, :string
+      t.column :associated_id, :integer
+      t.column :associated_type, :string
+      t.column :user_id, :integer
+      t.column :user_type, :string
+      t.column :username, :string
+      t.column :action, :string
+      t.column :audited_changes, :text
+      t.column :version, :integer, :default => 0
+      t.column :comment, :string
+      t.column :remote_address, :string
+      t.column :request_uuid, :string
+      t.column :created_at, :datetime
+    end
+
+    add_index :audits, [:auditable_type, :auditable_id, :version], :name => 'auditable_index', algorithm: :concurrently
+    add_index :audits, [:associated_type, :associated_id], :name => 'associated_index', algorithm: :concurrently
+    add_index :audits, [:user_id, :user_type], :name => 'user_index', algorithm: :concurrently
+    add_index :audits, :request_uuid, algorithm: :concurrently
+    add_index :audits, :created_at, algorithm: :concurrently
+  end
+
+  def self.down
+    drop_table :audits
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_22_132336) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_15_181932) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -26,6 +26,28 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_22_132336) do
     t.boolean "is_internal", default: false, null: false
     t.index ["access_token"], name: "index_api_keys_on_access_token"
     t.index ["user_id"], name: "index_api_keys_on_user_id"
+  end
+
+  create_table "audits", force: :cascade do |t|
+    t.integer "auditable_id"
+    t.string "auditable_type"
+    t.integer "associated_id"
+    t.string "associated_type"
+    t.integer "user_id"
+    t.string "user_type"
+    t.string "username"
+    t.string "action"
+    t.text "audited_changes"
+    t.integer "version", default: 0
+    t.string "comment"
+    t.string "remote_address"
+    t.string "request_uuid"
+    t.datetime "created_at"
+    t.index ["associated_type", "associated_id"], name: "associated_index"
+    t.index ["auditable_type", "auditable_id", "version"], name: "auditable_index"
+    t.index ["created_at"], name: "index_audits_on_created_at"
+    t.index ["request_uuid"], name: "index_audits_on_request_uuid"
+    t.index ["user_id", "user_type"], name: "user_index"
   end
 
   create_table "auth_tokens", id: :serial, force: :cascade do |t|

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -16,6 +16,7 @@ describe Project, type: :model do
   it { should have_one(:readme) }
   it { should belong_to(:repository) }
   it { should have_many(:repository_maintenance_stats) }
+  it { should be_audited.only(%w[name description repository_url homepage keywords_array licenses]) }
 
   it { should validate_presence_of(:name) }
   it { should validate_presence_of(:platform) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 require "pry"
 require "simplecov"
 require "custom_matchers"
+require "audited/rspec_matchers"
 SimpleCov.start "rails"
 
 RSpec.configure do |config|
@@ -29,4 +30,5 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
 
   config.include(CustomMatchers)
+  config.include(Audited::RspecMatchers)
 end


### PR DESCRIPTION
this adds the [`audited` gem](https://github.com/collectiveidea/audited) to Libraries so we can start tracking historical data, e.g. `Project#homepage`. 

In a following PR, I'll lax-en the requirements for a Project's data to be updated, so having `audited` around will give us a little backup in case something goes wrong.

#### Note 

I tried overwriting the "audited" method so that it requires you to pass the "only:" key, such that we limit the data we audit to specific data, but I'm having trouble monkeypatching that method.