### PR TITLE
Start setting "nil" values we get from upstream package managers.

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -95,7 +95,7 @@ module PackageManager
 
     private_class_method def self.transform_mapping_values(mapping)
       mapping.try do |p|
-        p.compact.transform_values { |v| v.is_a?(String) ? StringUtils.strip_null_bytes(v) : v }
+        p.transform_values { |v| v.is_a?(String) ? StringUtils.strip_null_bytes(v) : v }
       end
     end
 

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -93,12 +93,6 @@ module PackageManager
       find(platform).try(:formatted_name) || platform
     end
 
-    private_class_method def self.transform_mapping_values(mapping)
-      mapping.try do |p|
-        p.transform_values { |v| v.is_a?(String) ? StringUtils.strip_null_bytes(v) : v }
-      end
-    end
-
     private_class_method def self.ensure_project(mapped_project, reformat_repository_url: false)
       db_project = Project.find_or_initialize_by({ name: mapped_project[:name], platform: db_platform })
       db_project.reformat_repository_url if reformat_repository_url && !db_project.new_record?
@@ -142,7 +136,7 @@ module PackageManager
       raw_project = project(name)
       return false unless raw_project.present?
 
-      mapped_project = transform_mapping_values(mapping(raw_project))
+      mapped_project = mapping(raw_project)
       return false unless mapped_project.present?
 
       db_project = ensure_project(mapped_project, reformat_repository_url: sync_version == :all)

--- a/app/models/package_manager/base/mapping_builder.rb
+++ b/app/models/package_manager/base/mapping_builder.rb
@@ -19,7 +19,8 @@ module PackageManager
         hash[:licenses] = licenses if licenses != MISSING
         hash[:versions] = versions if versions != MISSING
 
-        hash
+        # Clean up any string values
+        hash.transform_values { |val| val.is_a?(String) ? StringUtils.strip_null_bytes(val) : val }
       end
     end
   end

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -398,7 +398,7 @@ describe PackageManager::Pypi do
             "name" => project_name,
             "license" => project_license,
             "summary" => project_summary,
-            "homepage" => "https://www.libraries.io/package_name/home",
+            "home_page" => "https://www.libraries.io/package_name/home",
             "project_urls" => { "Source" => project_source_repository_url },
           },
           "releases" =>
@@ -437,6 +437,24 @@ describe PackageManager::Pypi do
       expect(actual_project.description).to eq(project_summary)
       expect(actual_project.repository_url).to eq(project_source_repository_url)
       expect(actual_project.licenses).to eq(project_license)
+      expect(actual_project.homepage).to eq("https://www.libraries.io/package_name/home")
+    end
+
+    context "when project already exists" do
+      let!(:db_project) { create(:project, platform: "Pypi", name: project_name, homepage: "https://my.project.homepage") }
+
+      it "overwrites the homepage" do
+        described_class.update(project_name)
+
+        expect(db_project.reload.homepage).to eq("https://www.libraries.io/package_name/home")
+      end
+
+      it "overwrites the homepage even when upstream value is nil" do
+        expect(project).to receive(:homepage).and_return(nil).exactly(2).times
+        described_class.update(project_name)
+
+        expect(db_project.reload.homepage).to eq(nil)
+      end
     end
 
     it "adds the versions with correct statuses" do


### PR DESCRIPTION
since 2016 (b066184c9a565f8e1da1e75978d156677e5846ba), Libraries has been ignoring "nil" values it gets from upstream package managers, when updating Projects.

the drawback of this is that we don't update attributes when they become "nil", such as DefinitelyTyped projects (which automatically get replaced with a stubbed empty package when they become deprecated):

[
<img width="1211" alt="Screenshot 2024-08-15 at 2 30 57 PM" src="https://github.com/user-attachments/assets/abf8440a-0b9a-4ce6-912e-1a156132ed3e">
](url)

now that Libraries has a defined "MappingBuilder" class that explicitly defines the fields that we update (https://github.com/librariesio/libraries.io/pull/3397), we can be more confident about the fields that could be "nil", and we can update fields like "homepage" when they go nil.