### PR TITLE
Lock RepositoryDownloadWorker while it's executing too

### DIFF
--- a/app/workers/repository_download_worker.rb
+++ b/app/workers/repository_download_worker.rb
@@ -2,7 +2,7 @@
 
 class RepositoryDownloadWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :repo, lock: :until_executed
+  sidekiq_options queue: :repo, lock: :until_and_while_executing, lock_ttl: 10.minutes.to_i
 
   def perform(repo_id, token = nil)
     Repository.find_by_id(repo_id).try(:update_all_info, token)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -64,4 +64,15 @@ SidekiqUniqueJobs.configure do |config|
   config.lock_ttl = 1.day.to_i
 end
 
+SidekiqUniqueJobs.reflect do |on|
+  on.lock_failed do |job_hash|
+    message = {
+      message: "Skipping duplicate job",
+      worker: job_hash["class"],
+      args: job_hash["args"],
+    }
+    Sidekiq.logger.info(message)
+  end
+end
+
 Marginalia::SidekiqInstrumentation.enable!


### PR DESCRIPTION
now that we have [audited on Libraries](https://github.com/librariesio/libraries.io/pull/3438), we're noticing a curious race condition situation:

* Repo1 has two projects: Project1 and Project2
* Project1 and Project2 both get pushed by their maintainer at the same time
* Depper picks up the two updates and enqueues two PackageManagerDownloadWorkers jobs for Libraries
* each PackageManagerDownloadWorker job kicks off a Repository update for the same Repository here: https://github.com/librariesio/libraries.io/blob/96225bffe6ff7bf90535f8dd29fa195b5b8993a6/app/models/package_manager/base.rb#L253
* ... so Project1 kicks off RepositoryDownloadWorker
* and while that RepositoryDownloadWorker ^ is running, Project2 kicks off another RepositoryDownloadWorker
* the first RepositoryDownloadWorker updates the Repository#status 
* and then the second RepositoryDownloadWorker also updates the Repository#status
* so we get two Audited::Audit records for the same repo changes

currently we are locking RepositoryDownloadWorker **from** when it enqueues **until** it starts working, but we should be able to prevent this race condition if we lock it **from** when it enqueues **until** it stops working.