### PR TITLE
Fix PackageManager::NuGet.dependencies()

### DIFF
--- a/app/models/package_manager/base/version_builder.rb
+++ b/app/models/package_manager/base/version_builder.rb
@@ -7,7 +7,7 @@ module PackageManager
     class VersionBuilder
       MISSING = Object.new
 
-      def self.build_hash(number:, status: MISSING, created_at: MISSING, published_at: MISSING, original_license: MISSING)
+      def self.build_hash(number:, status: MISSING, created_at: MISSING, published_at: MISSING, original_license: MISSING, dependencies: MISSING)
         hash = {
           number: number,
         }
@@ -17,6 +17,11 @@ module PackageManager
         hash[:created_at] = created_at if created_at != MISSING
         hash[:published_at] = published_at if published_at != MISSING
         hash[:original_license] = original_license if original_license != MISSING
+
+        # This is really only a hack for PackageManager::NuGet.dependencies() because that method only accepts a
+        # mapped project, but the raw project contains the dependencies. We could consider making this official
+        # and adding a DependencyBuilder, so we could use mapped_project->versions->dependencies to set deps in Base.
+        hash[:dependencies] = dependencies if dependencies != MISSING
 
         hash
       end

--- a/app/models/package_manager/nu_get.rb
+++ b/app/models/package_manager/nu_get.rb
@@ -155,6 +155,8 @@ module PackageManager
           number: raw_version.version_number,
           published_at: raw_version.published_at,
           original_license: raw_version.original_license,
+          # This is a one-off VersionBuilder field for NuGet -- see VersionBuilder for more details.
+          dependencies: raw_version.dependencies,
         }
 
         # NuGet releases can be:
@@ -179,17 +181,18 @@ module PackageManager
     end
 
     def self.dependencies(_name, version, mapped_project)
-      current_version = mapped_project[:raw_versions].find { |v| v.version_number == version }
+      mapped_version = mapped_project[:versions].find { |v| v[:number] == version }
 
-      current_version.dependencies.map do |dep|
-        {
-          project_name: dep.name,
-          requirements: dep.requirements,
-          kind: "runtime",
-          optional: false,
-          platform: name.demodulize,
-        }
-      end
+      mapped_version[:dependencies]
+        .map do |dep|
+          {
+            project_name: dep.name,
+            requirements: dep.requirements,
+            kind: "runtime",
+            optional: false,
+            platform: name.demodulize,
+          }
+        end
     end
 
     class ParseCanonicalNameFailedError < StandardError; end

--- a/spec/models/package_manager/base/version_builder_spec.rb
+++ b/spec/models/package_manager/base/version_builder_spec.rb
@@ -24,7 +24,8 @@ describe PackageManager::Base::VersionBuilder do
         status: "a-status",
         created_at: "a-created-at",
         published_at: "a-published-at",
-        original_license: "original-license"
+        original_license: "original-license",
+        dependencies: [] # this is a one-off for NuGet, see VersionBuilder for details
       )
 
       expect(hash[:number]).to eq("a-number")
@@ -32,6 +33,7 @@ describe PackageManager::Base::VersionBuilder do
       expect(hash[:created_at]).to eq("a-created-at")
       expect(hash[:published_at]).to eq("a-published-at")
       expect(hash[:original_license]).to eq("original-license")
+      expect(hash[:dependencies]).to eq([])
     end
   end
 end

--- a/spec/models/package_manager/nu_get_spec.rb
+++ b/spec/models/package_manager/nu_get_spec.rb
@@ -365,6 +365,21 @@ describe PackageManager::NuGet do
     end
   end
 
+  describe ".dependencies" do
+    let(:name) { "name" }
+    let(:version) { "version" }
+    let(:raw_project) do
+      it "fetch the deps" do
+        mapped_project = described_class.mapping(raw_project)
+        dependencies = described_class.dependencies(name, version, mapped_project)
+
+        expect(dependencies.size).to eq(1)
+        expect(dependencies[0][:project_name]).to eq("another-name")
+        expect(dependencies[0][:requirements]).to eq("1.0.0")
+      end
+    end
+  end
+
   describe ".versions" do
     let(:name) { "name" }
     let(:version) { "version" }
@@ -399,6 +414,7 @@ describe PackageManager::NuGet do
           published_at: Time.now.iso8601,
           original_license: "licenses",
           status: nil,
+          dependencies: [],
         },
       ])
     end
@@ -431,11 +447,13 @@ describe PackageManager::NuGet do
             published_at: Time.now.iso8601,
             original_license: "licenses",
             status: nil,
+            dependencies: [],
           },
           {
             number: "version2",
             original_license: "licenses",
             status: "Deprecated",
+            dependencies: [],
           },
         ])
       end
@@ -466,11 +484,13 @@ describe PackageManager::NuGet do
             published_at: Time.now.iso8601,
             original_license: "licenses",
             status: nil,
+            dependencies: [],
           },
           {
             number: "version2",
             original_license: "licenses",
             status: "Deprecated",
+            dependencies: [],
           },
         ])
       end


### PR DESCRIPTION
it looks like this method has been broken for a while, but PackageManager::Base [logs the error and never notifies us via Bugsnag](https://github.com/librariesio/libraries.io/blob/96225bffe6ff7bf90535f8dd29fa195b5b8993a6/app/models/package_manager/base.rb#L311-L316), so I only discovered it via DD:

```
ERROR Error while trying to get dependencies for NuGet/LocalisedString@1.3.0: undefined method `find' for nil:NilClass
      current_version = mapped_project[:raw_versions].find { |v| v.version_number == version }
```

