### PR TITLE
Cease keeping around stale Project#repository_urls if they go nil on updates

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -96,7 +96,6 @@ module PackageManager
     private_class_method def self.ensure_project(mapped_project, reformat_repository_url: false)
       db_project = Project.find_or_initialize_by({ name: mapped_project[:name], platform: db_platform })
       db_project.reformat_repository_url if reformat_repository_url && !db_project.new_record?
-      mapped_project[:repository_url] = db_project.repository_url if mapped_project[:repository_url].blank?
       db_project.attributes = mapped_project.except(:name, :versions, :version, :dependencies, :properties)
 
       begin


### PR DESCRIPTION
about [2 years ago](https://github.com/librariesio/libraries.io/pull/2922), a change was made to preserve a `Project#repository_url` if it suddenly goes `nil` upstream, so that we still have *something* of a value. 

but this is still incorrect data, and we have [audits on `Project#repository_url` now](https://github.com/librariesio/libraries.io/pull/3438), so we can look up historical values if they go `nil`.