### PR TITLE
CheckStatusWorker: better lock, and retry 429s.

### DIFF
--- a/app/workers/check_status_worker.rb
+++ b/app/workers/check_status_worker.rb
@@ -2,9 +2,13 @@
 
 class CheckStatusWorker
   include Sidekiq::Worker
-  sidekiq_options queue: :status, lock: :until_executed
+  sidekiq_options queue: :status, lock: :until_and_while_executing, lock_ttl: 10.minutes.to_i
 
   def perform(project_id, _ignored = nil)
     Project.find_by_id(project_id).try(:check_status)
+  rescue Project::CheckStatusRateLimited
+    # Don't give up when we are rate-limited: we would get 429'ed when we are checking many statuses at once,
+    # so detect these and retry them within the next 10-60 minutes.
+    CheckStatusWorker.perform_in(rand(10..59))
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -267,7 +267,7 @@ describe Project, type: :model do
 
         status_before = project.status
 
-        project.check_status
+        expect { project.check_status }.to raise_error(Project::CheckStatusRateLimited)
         project.reload
         expect(project.status).to eq(status_before)
       end

--- a/spec/workers/check_status_worker_spec.rb
+++ b/spec/workers/check_status_worker_spec.rb
@@ -14,4 +14,13 @@ describe CheckStatusWorker do
       subject.perform(project.id)
     end
   end
+
+  it "should rescue CheckStatusRateLimited and retry later" do
+    project = create(:project, name: "rails")
+    expect(Project).to receive(:find_by_id).with(project.id).and_return(project)
+    expect(project).to receive(:check_status).and_raise(Project::CheckStatusRateLimited)
+    expect(CheckStatusWorker).to receive(:perform_in)
+
+    subject.perform(project.id)
+  end
 end


### PR DESCRIPTION
`Project#check_status` gets rate-limited occasionally by NPM and NuGet for up to 50k packages within a 1-2 hour time period.

currently we're skipping these updates if we get 429'ed, so we are probably missing status updates for many projects. 

this offers two quick fixes:
1) lock `CheckStatusWorker` **during the job** to avoid cases where a Project might be simultaneously enqueued >1 at a time.
2) when we get 429'ed, re-queue the `CheckStatusWorker` for 10-60 minutes from now, so we don't lose the status update, and to distribute the requests evenly.

### Alternatives?

the bigger fix for this could be creating a semaphore around each platform's "check_status" request, so we could only have X requests at a time per platform.