### PR TITLE
Carthage.project_names: fix the scope after projects_dependencies refactor

### DIFF
--- a/app/models/package_manager/carthage.rb
+++ b/app/models/package_manager/carthage.rb
@@ -9,7 +9,14 @@ module PackageManager
     COLOR = "#ffac45"
 
     def self.project_names
-      Project.platform("Carthage").map { |m| m.projects_dependencies.map(&:project_name).compact.map(&:downcase) }.flatten.uniq
+      Project.platform("Carthage")
+        .joins(:repository)
+        .includes(:repository)
+        .map(&:repository)
+        .flat_map do |r|
+          r.projects_dependencies.map(&:project_name).compact.map(&:downcase)
+        end
+        .uniq
     end
 
     def self.project(name)


### PR DESCRIPTION
(followup to https://github.com/librariesio/libraries.io/pull/3362)