### PR TITLE
make logged in /dashboard the same as not logged in experience

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -27,7 +27,6 @@ class ProjectsController < ApplicationController
     if current_user
       muted_ids = params[:include_muted].present? ? [] : current_user.muted_project_ids
       @versions = current_user.all_subscribed_versions.where.not(project_id: muted_ids).where.not(published_at: nil).newest_first.includes(project: :versions).paginate(per_page: 20, page: page_number)
-      render "dashboard/home"
     else
       @platforms = Project.maintained.group(:platform).order("count_id DESC").count("id").map { |k, v| { "key" => k, "doc_count" => v } }
     end

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -79,16 +79,22 @@
 </div>
 
 <div class="row">
+<% if not logged_in? %>
   <div class="col-md-4"></div>
-  <% if not logged_in? %>
-    <div class="col-md-2">
-      <%= link_to 'Login', login_path, class:'btn btn-primary center-block' %>
-    </div>
-  <% end %>
+  <div class="col-md-2">
+    <%= link_to 'Login', login_path, class:'btn btn-primary center-block' %>
+  </div>
   <div class="col-md-2">
     <%= link_to 'API Documentation', '/api', class:'btn btn-primary center-block'%>
   </div>
   <div class="col-md-4"></div>
+<% else %>
+<div class="col-md-5"></div>
+    <div class="col-md-2">
+      <%= link_to 'API Documentation', '/api', class:'btn btn-primary center-block'%>
+    </div>
+    <div class="col-md-5"></div>
+<% end %>
 </div>
 
 <hr>


### PR DESCRIPTION
make logged in user dashboard / homepage experience the same as a logged out user (just without "log in" buttons)

the old page is still accessible from the user dropdown in the top right, under "Repository Monitoring"

https://github.com/user-attachments/assets/6fcbe4f2-feb5-4143-8f54-1b2cc7e79f06

