### PR TITLE
PackageManager::Base.update(): kick off CheckStatusWorker whenever we update a Project.

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -153,7 +153,6 @@ module PackageManager
 
       save_dependencies(mapped_project, sync_version: sync_version, force_sync_dependencies: force_sync_dependencies) if self::HAS_DEPENDENCIES
       finalize_db_project(db_project)
-      CheckStatusWorker.perform_async(db_project.id) if db_project.status_checked_at.nil? || db_project.status_checked_at < 1.day.ago
     end
 
     # Override this in the subclass to fetch the raw data from the upstream
@@ -251,6 +250,7 @@ module PackageManager
       db_project.download_registry_users
       db_project.update!(last_synced_at: Time.now)
       db_project.try(:update_repository_async)
+      CheckStatusWorker.perform_async(db_project.id) if db_project.status_checked_at.nil? || db_project.status_checked_at < 1.day.ago
       db_project
     end
 

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -153,6 +153,7 @@ module PackageManager
 
       save_dependencies(mapped_project, sync_version: sync_version, force_sync_dependencies: force_sync_dependencies) if self::HAS_DEPENDENCIES
       finalize_db_project(db_project)
+      CheckStatusWorker.perform_async(db_project.id) if db_project.status_checked_at.nil? || db_project.status_checked_at < 1.day.ago
     end
 
     # Override this in the subclass to fetch the raw data from the upstream


### PR DESCRIPTION
currently libraries updates a Project's `status` via `CheckStatusWorker` in two situations:

1) via `Project#async_sync`, which is triggered via manual syncs via the Web UI
3) `rake projects:check_status` will kick off nightly batches of 150k CheckStatusWorker prioritizing oldest/nil "status_checked_at".