### PR TITLE
Fix silently ignoring invalid dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "active_model_serializers"
 gem "api-pagination"
 gem "asciidoctor"
 gem "audited"
-gem "bibliothecary", ">= 8.7.6"
+gem "bibliothecary", "~> 10.2.0"
 gem "bitbucket_rest_api", git: "https://github.com/librariesio/bitbucket"
 gem "bootsnap", require: false
 gem "bootstrap-sass"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
     autoprefixer-rails (9.5.1.1)
       execjs
     base64 (0.1.1)
-    bibliothecary (8.7.6)
+    bibliothecary (10.2.0)
       commander
       deb_control
       librariesio-gem-parser
@@ -154,8 +154,8 @@ GEM
     chartkick (3.4.0)
     chronic (0.10.2)
     coderay (1.1.3)
-    commander (4.6.0)
-      highline (~> 2.0.0)
+    commander (5.0.0)
+      highline (~> 3.0.0)
     commonmarker (0.23.10)
     concurrent-ruby (1.2.3)
     concurrent-ruby-ext (1.2.3)
@@ -254,7 +254,7 @@ GEM
       activesupport (>= 5.2)
     hashdiff (1.0.1)
     hashie (5.0.0)
-    highline (2.0.3)
+    highline (3.0.1)
     hiredis (0.6.3)
     htmlentities (4.3.4)
     httparty (0.21.0)
@@ -364,7 +364,7 @@ GEM
       omniauth (~> 2.0)
     org-ruby (0.9.12)
       rubypants (~> 0.2)
-    ox (2.14.17)
+    ox (2.14.18)
     packageurl-ruby (0.1.0)
     parallel (1.23.0)
     parser (3.2.2.3)
@@ -616,7 +616,7 @@ DEPENDENCIES
   api-pagination
   asciidoctor
   audited
-  bibliothecary (>= 8.7.6)
+  bibliothecary (~> 10.2.0)
   bitbucket_rest_api!
   bootsnap
   bootstrap-sass

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -328,11 +328,11 @@ module PackageManager
         new_dep_attributes = deps
           .reject { |dep| existing_dep_names.include?(dep[:project_name]) }
           .map do |dep|
-            dep_platform_and_name = [db_platform, dep[:project_name].strip]
+            dep_platform_and_name = [db_platform, dep[:project_name].to_s.strip]
             named_project_id = if platform_and_names_to_project_ids.key?(dep_platform_and_name)
                                  platform_and_names_to_project_ids[dep_platform_and_name]
                                else
-                                 platform_and_names_to_project_ids[dep_platform_and_name] = Project.find_best(db_platform, dep[:project_name].strip)&.id
+                                 platform_and_names_to_project_ids[dep_platform_and_name] = Project.find_best(db_platform, dep[:project_name].to_s.strip)&.id
                                end
 
             dep.merge(version_id: db_version.id, project_id: named_project_id)

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -326,7 +326,7 @@ module PackageManager
         existing_dep_names = db_version.dependencies.map(&:project_name)
 
         new_dep_attributes = deps
-          .reject { |dep| dep[:project_name].blank? || dep[:requirements].blank? || existing_dep_names.include?(dep[:project_name]) }
+          .reject { |dep| existing_dep_names.include?(dep[:project_name]) }
           .map do |dep|
             dep_platform_and_name = [db_platform, dep[:project_name].strip]
             named_project_id = if platform_and_names_to_project_ids.key?(dep_platform_and_name)
@@ -336,8 +336,17 @@ module PackageManager
                                end
 
             dep.merge(version_id: db_version.id, project_id: named_project_id)
-              .tap { |attrs| Dependency.new(attrs).validate! } # upsert_all doesn't validate, so run validation manually but don't save
           end
+
+        # Validate the new dependencies before performing the upsert
+        new_dep_attributes.each do |attrs|
+          dependency = Dependency.new(attrs)
+          dependency.validate!
+        rescue ActiveRecord::RecordInvalid => e
+          # If we don't have a valid dependency to upsert, log it, and fail noisily
+          StructuredLog.capture("SAVE_DEPENDENCIES_FAILURE", { platform: db_platform, name: name, version: db_version, dependency_name: dependency.project_name, message: dependency.errors.full_messages.join })
+          raise e
+        end
 
         # bulk insert all the Dependencies for the Version: note that as of writing there are no unique indices on Dependency, so any de-duping
         # was done in the reject() above. So doing an upsert here would be pointless which is why we only do a bulk insert.

--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -186,7 +186,7 @@ module PackageManager
           project_name: dep[:name],
           requirements: dep[:requirement],
           kind: dep[:type],
-          optional: dep.key?(:optional) ? dep[:optional] : false,
+          optional: dep.optional.blank? ? false : dep.optional,
           platform: db_platform,
         }
       end

--- a/spec/models/package_manager/maven/google_spec.rb
+++ b/spec/models/package_manager/maven/google_spec.rb
@@ -27,7 +27,7 @@ describe PackageManager::Maven::Google do
   describe ".dependencies" do
     before do
       allow(described_class).to receive(:parse_pom_manifest).and_return(
-        [{ name: "bibliothecary", requirement: "*", type: "runtime" }]
+        [Bibliothecary::Dependency.new(name: "bibliothecary", requirement: "*", type: "runtime")]
       )
     end
 

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -261,6 +261,13 @@ describe PackageManager::Pypi do
         expect(version.dependencies.count).to be 1
         expect(version.dependencies.first).to eql(dependency)
       end
+
+      it "raises an error if the dependency info is invalid" do
+        expect(PackageManager::Pypi).to receive(:dependencies).and_return([{ project_name: nil, requirements: nil }])
+        expect do
+          described_class.save_dependencies(mapped_project, sync_version: version_number, force_sync_dependencies: true)
+        end.to raise_error(ActiveRecord::RecordInvalid)
+      end
     end
   end
 


### PR DESCRIPTION
This bumps bibliothecary to the latest version, which also replaces the dependency hash with the new `Bibliothecary::Dependency` class. This also gives us a valid `requirement` attribute by default to use. So, hopefully we'll have mostly valid entries to upsert now and this won't be noisy. 

Re-raising the error so we halt seemed like the safe route to take, but if it's too pernicious, we can take that out and just rely on the logging.