### PR TITLE
Consider privately scoped NPM packages that return 302 as Removed.

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -668,7 +668,8 @@ class Project < ApplicationRecord
 
     StructuredLog.capture("CHECK_STATUS_CHANGE", { platform: platform, name: name, status_code: response.response_code }) if platform.downcase == "npm"
 
-    if platform.downcase == "packagist" && [302, 404].include?(response.response_code)
+    if platform.downcase.in?(%w[packagist npm]) && [302, 404].include?(response.response_code)
+      # NPM 302 happens with privately scoped packages, which should be considered Removed.
       update(status: "Removed", audit_comment: "Response #{response.response_code}")
     elsif platform.downcase == "go" && [302, 400, 404].include?(response.response_code)
       # pkg.go.dev can be 404 on first-hit for a new package (or alias for the package), so ensure that the package existed in the past

--- a/spec/fixtures/vcr_cassettes/project/check_status/private_package.yml
+++ b/spec/fixtures/vcr_cassettes/project/check_status/private_package.yml
@@ -1,0 +1,147 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://www.npmjs.com/package/@abcdefgh/ijklmnop
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      Expect:
+      - ''
+  response:
+    status:
+      code: 302
+      message: ''
+    headers:
+      Date:
+      - Tue, 27 Aug 2024 20:35:35 GMT
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Content-Length:
+      - '20'
+      Location:
+      - "/login?next=%2Fpackage%2F%40abcdefgh%2Fijklmnop"
+      Cf-Ray:
+      - 8b9ed94eca5252ff-SLC
+      Cf-Cache-Status:
+      - MISS
+      Cache-Control:
+      - public, max-age=14400
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - x-requested-with, x-spiferack, Accept-Encoding
+      Npm-Cost:
+      - '1'
+      Npm-Remaining:
+      - '99'
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - 1; mode=block
+      Set-Cookie:
+      - __cf_bm=7o.l._891JRrUC0Lm.csMtIbYvHAb02C_.cj0SlZGq8-1724790935-1.0.1.1-u9BN.GlOiECYD0SUtqGYvstNFEWA.EL4CjusdX.V3G2EX.F5JCiAdOla5Zg3d8Ls3dppkF3uyqoySMwiI_Ozfw;
+        path=/; expires=Tue, 27-Aug-24 21:05:35 GMT; domain=.npmjs.com; HttpOnly;
+        Secure; SameSite=None
+      - __cfruid=5dc5b57c5b777ed14ddf59b121f07b722ccd424e-1724790935; path=/; domain=.npmjs.com;
+        HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+    body:
+      encoding: ASCII-8BIT
+      string: "<h1>Redirect...</h1>"
+  recorded_at: Tue, 27 Aug 2024 20:35:34 GMT
+- request:
+    method: get
+    uri: http://registry.npmjs.org/@abcdefgh%2Fijklmnop
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.6
+      Accept-Encoding:
+      - gzip,deflate,br
+      X-Datadog-Trace-Id:
+      - '3454897174776194814'
+      X-Datadog-Parent-Id:
+      - '2344045752864091268'
+      X-Datadog-Sampling-Priority:
+      - '1'
+      X-Datadog-Tags:
+      - _dd.p.dm=-0
+      Expect:
+      - ''
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Date:
+      - Tue, 27 Aug 2024 20:35:35 GMT
+      Content-Type:
+      - text/plain;charset=UTF-8
+      Content-Length:
+      - '0'
+      Connection:
+      - keep-alive
+      Location:
+      - https://registry.npmjs.org/@abcdefgh%2Fijklmnop
+      Vary:
+      - Accept-Encoding
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8b9ed950da1727d8-SLC
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+  recorded_at: Tue, 27 Aug 2024 20:35:34 GMT
+- request:
+    method: get
+    uri: https://registry.npmjs.org/@abcdefgh%2Fijklmnop
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.6
+      Accept-Encoding:
+      - gzip,deflate,br
+      X-Datadog-Trace-Id:
+      - '2436969725848342521'
+      X-Datadog-Parent-Id:
+      - '2346715009131915843'
+      X-Datadog-Sampling-Priority:
+      - '1'
+      X-Datadog-Tags:
+      - _dd.p.dm=-0
+      Expect:
+      - ''
+  response:
+    status:
+      code: 404
+      message: ''
+    headers:
+      Date:
+      - Tue, 27 Aug 2024 20:35:35 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '21'
+      Vary:
+      - Accept-Encoding
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8b9ed953999f2c69-SLC
+    body:
+      encoding: ASCII-8BIT
+      string: '{"error":"Not found"}'
+  recorded_at: Tue, 27 Aug 2024 20:35:34 GMT
+recorded_with: VCR 6.2.0

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -301,6 +301,23 @@ describe Project, type: :model do
       end
     end
 
+    context "a private NPM package that returns 302" do
+      let!(:project) { create(:project, platform: "NPM", name: "@abcdefgh/ijklmnop", status: nil, updated_at: 1.week.ago) }
+
+      it "should mark it as Removed since it's not accessible" do
+        VCR.use_cassette("project/check_status/private_package") do
+          project.check_status
+
+          project.reload
+
+          expect(project.status).to eq("Removed")
+          expect(project.audits.last.comment).to eq("Response 302")
+          expect(project.status_checked_at).to eq(DateTime.current)
+          expect(project.updated_at).to eq(DateTime.current)
+        end
+      end
+    end
+
     context "deprecated project no longer deprecated" do
       let!(:project) { create(:project, platform: "NPM", name: "react", status: "Deprecated", updated_at: 1.week.ago) }
 


### PR DESCRIPTION
there are some packages in Libraries that return `302` when we fetch them from NPM, which means they're not accessible, i.e. not open-source. This starts marking those libraries as "Removed":

```
> curl -I "https://www.npmjs.com/package/@abcdef/ghijk"
HTTP/2 302 
location: /login?next=%2Fpackage%2F%40abcdef%2Fghijk
```