### PR TITLE
dont highlight the space after the link

### DIFF
--- a/app/views/shared/flashes/libraries-and-tidelift.html.erb
+++ b/app/views/shared/flashes/libraries-and-tidelift.html.erb
@@ -1,6 +1,4 @@
 <strong>
   <a href="https://tidelift.com/webinar/understanding-the-difference-between-data-from-libraries.io-and-the-tidelift-subscription"
-    style="text-decoration:underline;color: white;">Watch our latest webinar
-  </a>
-    to understand the difference between data from Libraries.io and the Tidelift Subscription.
+    style="text-decoration:underline;color: white;">Watch our latest webinar</a> to understand the difference between data from Libraries.io and the Tidelift Subscription.
 </strong>


### PR DESCRIPTION
space got included in the link, oopsie

# New and Improved
<img width="223" alt="image" src="https://github.com/user-attachments/assets/158b19d2-74c1-4b78-87b1-a629ae659850">

# Current
<img width="216" alt="image" src="https://github.com/user-attachments/assets/8bf71d7a-9f0f-4fb6-a737-cfcea84bc339">
