### PR TITLE
Refactor away base method only used in one subclass

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -375,21 +375,6 @@ module PackageManager
       end
     end
 
-    def self.find_and_map_dependencies(name, version, _mapped_project)
-      dependencies = find_dependencies(name, version)
-      return [] unless dependencies&.any?
-
-      dependencies.map do |dependency|
-        dependency = dependency.deep_stringify_keys
-        {
-          project_name: dependency["name"],
-          requirements: dependency["requirement"] || "*",
-          kind: dependency["type"],
-          platform: db_platform,
-        }
-      end
-    end
-
     def self.repo_fallback(repo, homepage)
       RepositoryService.repo_fallback(repo, homepage)
     end

--- a/app/models/package_manager/cran.rb
+++ b/app/models/package_manager/cran.rb
@@ -79,8 +79,19 @@ module PackageManager
       end
     end
 
-    def self.dependencies(name, version, mapped_project)
-      find_and_map_dependencies(name, version, mapped_project)
+    def self.dependencies(name, version, _mapped_project)
+      dependencies = find_dependencies(name, version)
+      return [] unless dependencies&.any?
+
+      dependencies.map do |dependency|
+        dependency = dependency.deep_stringify_keys
+        {
+          project_name: dependency["name"],
+          requirements: dependency["requirement"] || "*",
+          kind: dependency["type"],
+          platform: db_platform,
+        }
+      end
     end
 
     def self.find_dependencies(name, version)


### PR DESCRIPTION
This particular method existed on PackageManager::Base, but currently was only used by cran, and since it calls a method `find_dependencies` that currently only exists on cran, I just inlined it. Hopefully reduces some confusion!