### PR TITLE
NPM: when `"deprecated":false` handle it correctly

### DIFF
--- a/app/models/package_manager/npm.rb
+++ b/app/models/package_manager/npm.rb
@@ -58,7 +58,18 @@ module PackageManager
         .last
 
       message = last_stable_version&.dig("deprecated")
-      is_deprecated = !message.nil?
+      # sometimes message is a boolean `false`, and it may be `true` sometimes (not sure but
+      # may as well handle it, apparently we return any type we like)
+      if message.nil?
+        is_deprecated = false
+      elsif [true, false].include?(message)
+        is_deprecated = message
+        message = nil
+      elsif message.is_a? String
+        is_deprecated = true
+      else
+        is_deprecated = false
+      end
 
       {
         is_deprecated: is_deprecated,

--- a/spec/models/package_manager/npm_spec.rb
+++ b/spec/models/package_manager/npm_spec.rb
@@ -55,17 +55,31 @@ describe PackageManager::NPM do
       end
     end
 
-    context "latest version is deprecated" do
+    context "latest version isn't deprecated and the value of deprecated field is false" do
       let(:version_data) do
         {
           "0.0.1" => { "version" => "0.0.1", "deprecated" => "This package is deprecated" },
           "0.0.2" => { "version" => "0.0.2", "deprecated" => "This package is deprecated" },
-          "0.0.3" => { "version" => "0.0.3" },
+          "0.0.3" => { "version" => "0.0.3", "deprecated" => false },
         }
       end
 
       it "project not considered deprecated" do
         expect(deprecation_info).to eq({ is_deprecated: false, message: nil })
+      end
+    end
+
+    context "latest version is deprecated with a true boolean" do
+      let(:version_data) do
+        {
+          "0.0.1" => { "version" => "0.0.1", "deprecated" => "This package is deprecated" },
+          "0.0.2" => { "version" => "0.0.2", "deprecated" => "This package is deprecated" },
+          "0.0.3" => { "version" => "0.0.3", "deprecated" => true },
+        }
+      end
+
+      it "project is considered deprecated" do
+        expect(deprecation_info).to eq({ is_deprecated: true, message: nil })
       end
     end
 


### PR DESCRIPTION
We were expecting this field to be a string or nil, but apparently
it can also be `false`

Handle it being `true` too just in case, though we haven't confirmed
that this happens, we do have some examples where deprecation_reason
is "t" which looks suspiciously like that could be what happened.
