### PR TITLE
CheckStatusWorker: fix the time unit for retry from seconds to minutes

### DIFF
--- a/app/workers/check_status_worker.rb
+++ b/app/workers/check_status_worker.rb
@@ -9,6 +9,6 @@ class CheckStatusWorker
   rescue Project::CheckStatusRateLimited
     # Don't give up when we are rate-limited: we would get 429'ed when we are checking many statuses at once,
     # so detect these and retry them within the next 10-60 minutes.
-    CheckStatusWorker.perform_in(rand(10..59), project_id)
+    CheckStatusWorker.perform_in(rand(10..59).minutes, project_id)
   end
 end


### PR DESCRIPTION
followup to https://github.com/librariesio/libraries.io/pull/3447