### PR TITLE
Check the canonical Go project name against the passed in Go project name

### DIFF
--- a/app/models/package_manager/go.rb
+++ b/app/models/package_manager/go.rb
@@ -94,7 +94,7 @@ module PackageManager
       # that is not a valid module. https://go.dev/ref/mod#goproxy-protocol describes
       # how a $base/$module/@v/$version.mod request will return back a virtual go.mod file
       # with whatever name was passed in if there is not a go.mod file found for that version.
-      name_in_go_mod = canonical_module_name(name)
+      name_in_go_mod = name_in_go_mod(name)
       search_name = if name_in_go_mod.present?
                       if name.downcase.include?(name_in_go_mod.downcase)
                         name_in_go_mod
@@ -314,7 +314,7 @@ module PackageManager
 
     # looks at the module declaration for the latest version's go.mod file and returns that if found
     # if nothing is found, nil is returned
-    def self.canonical_module_name(name)
+    def self.name_in_go_mod(name)
       fetch_mod(name)&.canonical_module_name
     end
 

--- a/app/workers/go_project_verification_worker.rb
+++ b/app/workers/go_project_verification_worker.rb
@@ -21,6 +21,17 @@ class GoProjectVerificationWorker
       # if we can't get a canonical name then bail out of here and we'll have to investigate further
       return if canonical_name.blank?
 
+      unless name.downcase.include?(canonical_name.downcase)
+        StructuredLog.capture(
+          "GO_PROJECT_NAME_DOES_NOT_MATCH_GO_MOD_NAME",
+          {
+            go_mod_name: canonical_name,
+            project_name: name,
+            source: self.name,
+          }
+        )
+      end
+
       # if the name for the project doesn't match the canonical name then we can remove it
       PackageManager::Go.update(canonical_name) unless Project.where(platform: "Go", name: canonical_name).exists?
 

--- a/spec/models/package_manager/go_spec.rb
+++ b/spec/models/package_manager/go_spec.rb
@@ -390,10 +390,10 @@ describe PackageManager::Go do
     end
   end
 
-  describe ".canonical_module_name" do
+  describe ".name_in_go_mod" do
     it "maps only major revision versions to module" do
       VCR.use_cassette("go/pkg_go_dev") do
-        result = described_class.canonical_module_name(package_name)
+        result = described_class.name_in_go_mod(package_name)
         expect(result).to eq(package_name)
       end
     end


### PR DESCRIPTION
In the case of [this forked Go package](https://libraries.io/go/github.com%2Fphilipatl%2Fwebsocket/v1.4.2), the name listed in their [go.mod file](https://github.com/philipatl/websocket/blob/master/go.mod) (which is used to get the canonical Go name in libraries) does not match their github url/name. This means libraries is pulling the incorrect information for this package.

The change here is to log when the name listed in the repository's go.mod file is not the same as the input package name, and favor the package name for lookups when they don't match. 