### PR TITLE
CheckStatusWorker 429s: reset timestamp to nil instead of retrying

### DIFF
--- a/spec/workers/check_status_worker_spec.rb
+++ b/spec/workers/check_status_worker_spec.rb
@@ -19,7 +19,7 @@ describe CheckStatusWorker do
     project = create(:project, name: "rails")
     expect(Project).to receive(:find_by_id).with(project.id).and_return(project)
     expect(project).to receive(:check_status).and_raise(Project::CheckStatusRateLimited)
-    expect(CheckStatusWorker).to receive(:perform_in)
+    expect(project.reload.status_checked_at).to be_nil
 
     subject.perform(project.id)
   end


### PR DESCRIPTION
the last fix for retrying Project status 429s didn't help a ton, so this tries a new strategy:

* when we get a 429 while checking status, *don't* retry again in X.minutes. 
* instead, set the`Project#status_checked_at` timestamp to nil so that our nightly `projects:check_status` rake task picks it up during the nightly run