### PR TITLE
Project#check_status: relax our throttle a bit.

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -672,7 +672,7 @@ class Project < ApplicationRecord
 
     # Don't overload NPM by limiting the number of concurrent requests we make.
     response = if downcased_platform == "npm"
-                 RateLimitService.new(what_to_limit: "check_status_npm", limit: 10, period: 60)
+                 RateLimitService.new(what_to_limit: "check_status_npm", limit: 10, period: 5)
                    .rate_limited { Typhoeus.get(url) }
                else
                  Typhoeus.get(url)


### PR DESCRIPTION
(followup to https://github.com/librariesio/libraries.io/pull/3477)

now that we're not getting constant 429s, I've tested `Project#check_status` against NPM, and found that `10 requests per 5 seconds` should be a safe rate at which to query NPM projects.