### PR TITLE
Project#check_status: change the strategy of rate-limiting ourselves

### DIFF
--- a/app/workers/check_status_worker.rb
+++ b/app/workers/check_status_worker.rb
@@ -7,12 +7,12 @@ class CheckStatusWorker
   def perform(project_id)
     project = Project.find_by_id(project_id)
     project.try(:check_status)
-  rescue Project::CheckStatusInternallyRateLimited, Project::CheckStatusExternallyRateLimited
+  rescue Project::CheckStatusInternallyRateLimited, Project::CheckStatusExternallyRateLimited => e
     # status_check_at is eagerly updated in Project#check_status, so reset it to nil
     # so we can tell if it was throttled.
     project.update_column(:status_checked_at, nil)
-    # By retrying in 5 minutes, when we have a big queue of CheckStatusWorker, we'll
-    # work it down gradually by retrying things 5 minutes at a time.
-    CheckStatusWorker.perform_in(5.minutes, project.id)
+    if e.retry_after_seconds
+      CheckStatusWorker.perform_in(e.retry_after_seconds.seconds.from_now, project.id)
+    end
   end
 end

--- a/spec/workers/check_status_worker_spec.rb
+++ b/spec/workers/check_status_worker_spec.rb
@@ -18,7 +18,7 @@ describe CheckStatusWorker do
   it "should rescue CheckStatusExternallyRateLimited and retry later" do
     project = create(:project, name: "rails")
     expect(Project).to receive(:find_by_id).with(project.id).and_return(project)
-    expect(project).to receive(:check_status).and_raise(Project::CheckStatusExternallyRateLimited)
+    expect(project).to receive(:check_status).and_raise(Project::CheckStatusExternallyRateLimited.new(5))
     expect(project.reload.status_checked_at).to be_nil
 
     subject.perform(project.id)


### PR DESCRIPTION
(followup to https://github.com/librariesio/libraries.io/pull/3477)

this changes up our strategy of fetching NPM package urls:

* fetch the `"retry-after"` value from the NPM response
* instead of using `RateLimitService`, just store `"retry-after"` in Redis with an expiry
* if we are checking an NPM package url, and `"retry-after"` exists, reschedule the request to the proper time
* ensure that we store this value **per host**, since different hosts will receive different values

