### PR TITLE
PackageManager::Base.save_dependencies: use pluck instead of select

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -323,7 +323,7 @@ module PackageManager
           db_version.dependencies.destroy_all
         end
 
-        existing_dep_names = db_version.dependencies.map(&:project_name)
+        existing_dep_names = db_version.dependencies.pluck(:project_name)
 
         new_dep_attributes = deps
           .reject { |dep| existing_dep_names.include?(dep[:project_name]) }

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -299,7 +299,10 @@ module PackageManager
       # Some Projects have thousands of Versions, so load them in batches to avoid
       # a list of thousands of Version ids in a single query, each of which is returning
       # possibly hundreds or thousands of Dependencies.
-      db_versions = db_versions.includes(:dependencies).in_batches(of: 200).to_a.flatten
+      # Do preloads in batches of 200 versions, because we don't want a big preload query that
+      # queries on thousands of Version ids, especially when each Version could have thousands
+      # of Dependencies.
+      db_versions = db_versions.in_batches(of: 200).map { |vs| vs.includes(:dependencies) }.flatten
 
       # cached lookup of dependency platform/names => project ids, so we avoid repetitive project lookups in find_best! below.
       platform_and_names_to_project_ids = {}

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -296,9 +296,6 @@ module PackageManager
 
       db_versions = db_project.versions
       db_versions = db_versions.where(number: sync_version) unless sync_version == :all
-      # Some Projects have thousands of Versions, so load them in batches to avoid
-      # a list of thousands of Version ids in a single query, each of which is returning
-      # possibly hundreds or thousands of Dependencies.
       # Do preloads in batches of 200 versions, because we don't want a big preload query that
       # queries on thousands of Version ids, especially when each Version could have thousands
       # of Dependencies.


### PR DESCRIPTION
* use `.pluck` instead of `.select` to avoid hydrating AR models and also pull less data from the db