### PR TITLE
Set Project#dependents_count explicitly instead of in hook

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -366,6 +366,8 @@ module PackageManager
         db_version.set_runtime_dependencies_count
         db_version.set_dependencies_count
       end
+
+      db_project.set_dependents_count_async
     end
 
     def self.dependencies(_name, _version, _mapped_project)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -211,7 +211,6 @@ class Project < ApplicationRecord
   scope :recently_created, -> { with_repo.where("repositories.created_at > ?", 2.weeks.ago) }
 
   after_commit :update_repository_async, on: :create
-  after_commit :set_dependents_count_async, on: %i[create update]
   after_commit :update_source_rank_async, on: %i[create update]
   after_commit :send_project_updated, on: %i[create update]
   before_save  :update_details
@@ -417,7 +416,7 @@ class Project < ApplicationRecord
     return if destroyed?
 
     # TEMPFIX: pushing these workers out a day to let the db catch up on indices
-    SetProjectDependentsCountWorker.perform_in(6.hours, id)
+    SetProjectDependentsCountWorker.perform_async(id)
   end
 
   def set_dependents_count

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -240,6 +240,7 @@ describe PackageManager::Pypi do
         end
           .to change { version.reload.dependencies_count }.to(6)
           .and change { version.runtime_dependencies_count }.to(4)
+          .and change { SetProjectDependentsCountWorker.jobs.size }.by(1)
       end
 
       it "updates the dependencies counters when there are zero deps" do


### PR DESCRIPTION
* remove the "after_commit" callback that updates `Project#dependents_count` 
* instead, explicitly set `Project#dependents_count` in `PackageManager::Base.save_dependencies()`

I'd argue that we don't need to update this counter every time we save a Project, which includes after `Project#check_status` has run, which doesn't affect deps at all.

the counter is also based on an association, so it's better to explicitly update the counter whenever we change that association, which should be only in `PackageManager::Base.save_dependencies`