### PR TITLE
Debounce Project#check_status to once per day

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -667,7 +667,7 @@ class Project < ApplicationRecord
   end
 
   def check_status
-    return if status_checked_at > CHECK_STATUS_FREQUENCY_LIMIT.ago
+    return if status_checked_at && status_checked_at > CHECK_STATUS_FREQUENCY_LIMIT.ago
 
     downcased_platform = platform.downcase
     url = platform_class.check_status_url(self)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -116,6 +116,7 @@ class Project < ApplicationRecord
     stars
     status
   ].freeze
+  CHECK_STATUS_FREQUENCY_LIMIT = 1.day
 
   # Currently these are the fields defined in PackageManager::Base::MappingBuilder
   audited only: %w[status name description repository_url homepage keywords_array licenses]
@@ -666,9 +667,12 @@ class Project < ApplicationRecord
   end
 
   def check_status
+    return if status_checked_at > CHECK_STATUS_FREQUENCY_LIMIT.ago
+
     downcased_platform = platform.downcase
     url = platform_class.check_status_url(self)
     update_column(:status_checked_at, DateTime.current)
+
     return if url.blank?
 
     # "Hidden" is a state set by admins, and we don't want to override that decision.

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -192,14 +192,14 @@ class Repository < ApplicationRecord
   def deprecate!
     update_attribute(:status, "Deprecated")
     projects.each do |project|
-      project.update_attribute(:status, "Deprecated")
+      project.update_attribute(:status, "Deprecated", audit_comment: "Repository#deprecate!")
     end
   end
 
   def unmaintain!
     update_attribute(:status, "Unmaintained")
     projects.each do |project|
-      project.update_attribute(:status, "Unmaintained")
+      project.update_attribute(:status, "Unmaintained", audit_comment: "Repository#unmaintain!")
     end
   end
 
@@ -336,7 +336,7 @@ class Repository < ApplicationRecord
       projects.each do |project|
         next unless %w[bower go elm alcatraz julia nimble].include?(project.platform.downcase)
 
-        project.update(status: "Removed", audit_comment: "Response 404") unless project.status == "Removed"
+        project.update(status: "Removed", audit_comment: "Repository#check_status: Response 404") unless project.status == "Removed"
       end
 
       return false

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -193,6 +193,17 @@ describe Project, type: :model do
   describe "#check_status" do
     before { freeze_time }
 
+    context "already checked recently" do
+      let!(:project) { create(:project, platform: "NPM", name: "jade", status: "", status_checked_at: 12.hours.ago) }
+
+      it "should not check status" do
+        allow(Typhoeus).to receive(:get)
+
+        expect { project.check_status }.to_not change(project, :status_checked_at)
+        expect(Typhoeus).to_not have_received(:get)
+      end
+    end
+
     context "entire project deprecated with message" do
       let!(:project) { create(:project, platform: "NPM", name: "jade", status: "", updated_at: 1.week.ago) }
 


### PR DESCRIPTION
the `Project#check_status` 429 issue is resolved, but I've come across thousands of projects that now have thousands of blank audits that indicates that `check_status` is being called on them frequently. 

I can't find the exact codepath that would trigger `CheckStatusWorker`, but the main culprit is `Project#async_sync`, which is called from many places.

we should probably just limit `Project#check_status` to once per day, which should solve the issue!

```
> Project.find(6990999).audits.pluck(:created_at, :comment, :audited_changes).reverse

[[Mon, 07 Oct 2024 19:58:55.382661000 UTC +00:00, "Response 404", {}],
 [Mon, 07 Oct 2024 18:50:25.421502000 UTC +00:00, "Response 404", {}],
 [Mon, 07 Oct 2024 17:26:34.656901000 UTC +00:00, "Response 404", {}],
 [Mon, 07 Oct 2024 16:59:48.967348000 UTC +00:00, "Response 404", {}],
 [Mon, 07 Oct 2024 16:06:03.402261000 UTC +00:00, "Response 404", {}],
 [Mon, 07 Oct 2024 16:00:57.141240000 UTC +00:00, "Response 404", {}],
 [Mon, 07 Oct 2024 15:55:23.923696000 UTC +00:00, "Response 404", {}],
 [Mon, 07 Oct 2024 15:49:55.480664000 UTC +00:00, "Response 404", {}],
 [Mon, 07 Oct 2024 15:44:17.574283000 UTC +00:00, "Response 404", {}],
 [Mon, 07 Oct 2024 15:28:45.744124000 UTC +00:00, "Response 404", {}],
...
```