### PR TITLE
Pass "source" down to PackageManager::Base#save_dependencies() for logging

### DIFF
--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -153,7 +153,7 @@ class Api::ProjectsController < Api::ApplicationController
         version.update_column(:dependencies_count, deps.size)
       elsif deps.empty? && version.updated_at < 1.day.ago
         version.touch
-        PackageManagerDownloadWorker.perform_async(platform, name, version.number)
+        PackageManagerDownloadWorker.perform_async(platform, name, version.number, "Api::Projects##{action_name}")
       end
     end
 

--- a/app/models/concerns/dependency_checks.rb
+++ b/app/models/concerns/dependency_checks.rb
@@ -48,7 +48,7 @@ module DependencyChecks
   def update_project
     return unless project_name.present? && package_manager
 
-    package_manager.update(project_name)
+    package_manager.update(project_name, source: "DependencyChecks#update_project")
   end
 
   def package_manager

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -326,7 +326,7 @@ module PackageManager
         # so that we have the fresh and correct dependency information from the most recent
         # call to dependencies() from the platform provider
         if force_sync_dependencies
-          Rails.logger.info("[Full Dependency Refresh] platform=#{db_platform} name=#{name} version=#{db_version.number}")
+          Rails.logger.info("[Full Dependency Refresh] platform=#{db_platform} name=#{name} version=#{db_version.number} source=#{source}")
           db_version.dependencies.destroy_all
         end
 

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -326,7 +326,7 @@ module PackageManager
         # so that we have the fresh and correct dependency information from the most recent
         # call to dependencies() from the platform provider
         if force_sync_dependencies
-          Rails.logger.info("[Full Dependency Refresh] platform=#{db_platform} name=#{name} version=#{db_version.number} source=#{source}")
+          StructuredLog.capture("SAVE_DEPENDENCIES_FULL_REFRESH", { platform: db_platform, name: name, version: db_version.number, source: source })
           db_version.dependencies.destroy_all
         end
 

--- a/app/models/package_manager/cran.rb
+++ b/app/models/package_manager/cran.rb
@@ -84,7 +84,7 @@ module PackageManager
       return [] unless dependencies&.any?
 
       dependencies.map do |dependency|
-        dependency = dependency.deep_stringify_keys
+        dependency = dependency.to_h.deep_stringify_keys
         {
           project_name: dependency["name"],
           requirements: dependency["requirement"] || "*",

--- a/app/workers/go_project_verification_worker.rb
+++ b/app/workers/go_project_verification_worker.rb
@@ -22,7 +22,7 @@ class GoProjectVerificationWorker
       return if name_in_go_mod.blank?
 
       # if the name for the project doesn't match the canonical name then we can remove it
-      PackageManager::Go.update(name_in_go_mod) unless Project.where(platform: "Go", name: name_in_go_mod).exists?
+      PackageManager::Go.update(name_in_go_mod, source: "GoProjectVerificationWorker") unless Project.where(platform: "Go", name: name_in_go_mod).exists?
 
       if project.name != name_in_go_mod
         if name_in_go_mod.downcase == project.name.downcase
@@ -56,7 +56,7 @@ class GoProjectVerificationWorker
       # The goal is to have only one remaining Project for the name passed in here to avoid having multiple projects
       # with different cased names for the same package.
       if name != module_name
-        PackageManager::Go.update(module_name) unless module_name.nil? || Project.where(platform: "Go", name: module_name).exists?
+        PackageManager::Go.update(module_name, source: "GoProjectVerificationWorker") unless module_name.nil? || Project.where(platform: "Go", name: module_name).exists?
 
         StructuredLog.capture(
           "GO_PROJECT_VERIFICATION_DESTROY_NON_MODULE_PROJECT",

--- a/app/workers/package_manager_download_worker.rb
+++ b/app/workers/package_manager_download_worker.rb
@@ -76,7 +76,7 @@ class PackageManagerDownloadWorker
     end
 
     Rails.logger.info("Package update for platform=#{key} name=#{name} version=#{version} source=#{source}")
-    project = package_manager.update(name, sync_version: sync_version, force_sync_dependencies: force_sync_dependencies)
+    project = package_manager.update(name, sync_version: sync_version, force_sync_dependencies: force_sync_dependencies, source: source)
 
     # Raise/log if version was requested but not found
     if version.present? && project && !project&.versions&.exists?(number: version)

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -186,9 +186,9 @@ namespace :projects do
     projects.each_key do |project_name|
       project = Project.find_by(platform: "Conda", name: project_name)
       if project.nil?
-        PackageManager::Conda.update(project_name)
+        PackageManager::Conda.update(project_name, source: "backfill_conda")
       elsif project.versions.count != projects[project_name]["versions"].count
-        PackageManager::Conda.update(project_name)
+        PackageManager::Conda.update(project_name, source: "backfill_conda")
         LicenseBackfillWorker.perform_async("Conda", project_name)
       else
         LicenseBackfillWorker.perform_async("Conda", project_name)

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -357,7 +357,8 @@ describe "Api::ProjectsController" do
       expect(PackageManagerDownloadWorker).to have_received(:perform_async).with(
         "Rubygems",
         project_with_unknown_deps.name,
-        version_with_unknown_deps.number
+        version_with_unknown_deps.number,
+        "Api::Projects#dependencies_bulk"
       )
     end
   end

--- a/spec/workers/package_manager_download_worker_spec.rb
+++ b/spec/workers/package_manager_download_worker_spec.rb
@@ -8,7 +8,7 @@ describe PackageManagerDownloadWorker do
   end
 
   it "should sync all versions if none are specified" do
-    expect(PackageManager::Rubygems).to receive(:update).with("rails", sync_version: :all, force_sync_dependencies: false)
+    expect(PackageManager::Rubygems).to receive(:update).with("rails", sync_version: :all, force_sync_dependencies: false, source: "unknown")
     subject.perform("PackageManager::Rubygems", "rails")
   end
 
@@ -19,7 +19,7 @@ describe PackageManagerDownloadWorker do
   it "should delay version requested if version didn't get created" do
     project = create(:project, platform: "Go", name: "github.com/hi/ima.package")
     expect(PackageManagerDownloadWorker).to receive(:perform_in).with(5.seconds, "go", "github.com/hi/ima.package", "1.2.3", "unknown", 1, false)
-    expect(PackageManager::Go).to receive(:update).with("github.com/hi/ima.package", sync_version: "1.2.3", force_sync_dependencies: false).and_return(project)
+    expect(PackageManager::Go).to receive(:update).with("github.com/hi/ima.package", sync_version: "1.2.3", force_sync_dependencies: false, source: "unknown").and_return(project)
     expect(Rails.logger).to receive(:info).with(a_string_matching("Package update"))
     expect(Rails.logger).to receive(:info).with("[Version Update Failure] platform=go name=github.com/hi/ima.package version=1.2.3")
 
@@ -40,7 +40,7 @@ describe PackageManagerDownloadWorker do
     it "should raise an error if version didn't get created after 15 attempts" do
       project = create(:project, platform: "Pypi", name: "a-package")
       expect(PackageManagerDownloadWorker).to_not receive(:perform_in)
-      expect(PackageManager::Pypi).to receive(:update).with("a-package", sync_version: "1.2.3", force_sync_dependencies: false).and_return(project)
+      expect(PackageManager::Pypi).to receive(:update).with("a-package", sync_version: "1.2.3", force_sync_dependencies: false, source: nil).and_return(project)
       expect(Rails.logger).to receive(:info).with(a_string_matching("Package update"))
       expect(Rails.logger).to receive(:info).with("[Version Update Failure] platform=pypi name=a-package version=1.2.3")
 
@@ -51,7 +51,7 @@ describe PackageManagerDownloadWorker do
   it "should not raise an error if version didn't get created after 15 attempts and is golang" do
     project = create(:project, platform: "Go", name: "github.com/hi/ima.package")
     expect(PackageManagerDownloadWorker).to_not receive(:perform_in)
-    expect(PackageManager::Go).to receive(:update).with("github.com/hi/ima.package", sync_version: "1.2.3", force_sync_dependencies: false).and_return(project)
+    expect(PackageManager::Go).to receive(:update).with("github.com/hi/ima.package", sync_version: "1.2.3", force_sync_dependencies: false, source: nil).and_return(project)
     expect(Rails.logger).to receive(:info).with(a_string_matching("Package update"))
     expect(Rails.logger).to receive(:info).with("[Version Update Failure] platform=go name=github.com/hi/ima.package version=1.2.3")
 


### PR DESCRIPTION
* adds "source" to some logs in `PackageManager::Base` so we can track down some superfluous "save_dependencies()" calls