### PR TITLE
Handle ActiveRecord::RecordNotUnique when creating projects too

### DIFF
--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -100,8 +100,8 @@ module PackageManager
 
       begin
         db_project.save!
-      rescue ActiveRecord::RecordInvalid => e
-        raise e unless e.message =~ /Name has already been taken/
+      rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
+        raise e if e == ActiveRecord::RecordInvalid && e.message !~ /Name has already been taken/
 
         # Probably a race condition with multiple versions of a new project being updated.
         db_project = Project.find_by(platform: db_platform, name: mapped_project[:name])

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -101,7 +101,7 @@ module PackageManager
       begin
         db_project.save!
       rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
-        raise e if e == ActiveRecord::RecordInvalid && e.message !~ /Name has already been taken/
+        raise e if e.is_a?(ActiveRecord::RecordInvalid) && e.message !~ /Name has already been taken/
 
         # Probably a race condition with multiple versions of a new project being updated.
         db_project = Project.find_by(platform: db_platform, name: mapped_project[:name])

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -124,7 +124,6 @@ class Project < ApplicationRecord
   delegate :code_of_conduct_url, :contribution_guidelines_url, :funding_urls, :security_policy_url, to: :repository, allow_nil: true
 
   validates :name, :platform, presence: true
-  validates :name, uniqueness: { scope: :platform, case_sensitive: true }
   validates :status, inclusion: { in: STATUSES, allow_blank: true }
 
   belongs_to :repository

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -466,7 +466,10 @@ describe PackageManager::Pypi do
 
       context "that was created by another process in between validation and save (a race condition)" do
         it "overwrites the homepage" do
-          allow(Project).to receive(:find_or_initialize_by).and_return(Project.new(name: project_name, platform: "Pypi"))
+          expect(Project).to receive(:find_or_initialize_by).and_invoke(
+            ->(args) { Project.new(args) }, # first try: Project doesn't exist yet, so we get a new instance
+            ->(_args) { db_project }        # second try: Project was created by another process, so we get that instance
+          )
 
           described_class.update(project_name)
 

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -464,7 +464,7 @@ describe PackageManager::Pypi do
         expect(db_project.reload.homepage).to eq(nil)
       end
 
-      context "that was created by another process in between lookup and save (a race condition)" do
+      context "that was created by another process in between validation and save (a race condition)" do
         it "overwrites the homepage" do
           allow(Project).to receive(:find_or_initialize_by).and_return(Project.new(name: project_name, platform: "Pypi"))
 

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -463,6 +463,16 @@ describe PackageManager::Pypi do
 
         expect(db_project.reload.homepage).to eq(nil)
       end
+
+      context "that was created by another process in between lookup and save (a race condition)" do
+        it "overwrites the homepage" do
+          allow(Project).to receive(:find_or_initialize_by).and_return(Project.new(name: project_name, platform: "Pypi"))
+
+          described_class.update(project_name)
+
+          expect(db_project.reload.homepage).to eq("https://www.libraries.io/package_name/home")
+        end
+      end
     end
 
     it "adds the versions with correct statuses" do


### PR DESCRIPTION
this handles a pernicious race condition wherein a Project is created in another worker, right after the current Process has run the `Project.validates :name, uniqueness: true` validation but before it saves the Project.