### PR TITLE
don't update webhook sent info for all project hooks

### DIFF
--- a/app/models/web_hook.rb
+++ b/app/models/web_hook.rb
@@ -92,7 +92,10 @@ class WebHook < ApplicationRecord
 
   def send_payload(data, ignore_errors: false)
     response = request(data).run
-    update(last_sent_at: Time.now.utc, last_response: response.response_code)
+    # for user facing webhooks, we update last sent/last response
+    # but skip that for the all_project_updates to avoid hammering
+    # the db too much
+    update(last_sent_at: Time.now.utc, last_response: response.response_code) unless all_project_updates
     raise StandardError, "webhook failed webhook_id=#{id} timed_out=#{response.timed_out?} code=#{response.code}" unless response.success? || ignore_errors
   end
 end

--- a/spec/workers/project_updated_worker_spec.rb
+++ b/spec/workers/project_updated_worker_spec.rb
@@ -22,7 +22,6 @@ describe ProjectUpdatedWorker do
 
       described_class.drain
 
-      expect(web_hook.reload.last_sent_at).not_to be_nil
       assert_requested :post, url,
                        body: be_json_string_matching({
                          event: "project_updated",


### PR DESCRIPTION
For the webhooks that get an update on every change, we end up hammering the db a bit unnecessarily. Just don't update the last response / last sent info for those hooks
