### PR TITLE
Update cocoapods things to rely on "newer" cocoapods infrastructure

### DIFF
--- a/spec/models/package_manager/cocoa_pods_spec.rb
+++ b/spec/models/package_manager/cocoa_pods_spec.rb
@@ -11,11 +11,11 @@ describe PackageManager::CocoaPods do
 
   describe "#package_link" do
     it "returns a link to project website" do
-      expect(described_class.package_link(project)).to eq("http://cocoapods.org/pods/foo")
+      expect(described_class.package_link(project)).to eq("https://cocoapods.org/pods/foo")
     end
 
     it "ignores version" do
-      expect(described_class.package_link(project, "2.0.0")).to eq("http://cocoapods.org/pods/foo")
+      expect(described_class.package_link(project, "2.0.0")).to eq("https://cocoapods.org/pods/foo")
     end
   end
 
@@ -31,11 +31,11 @@ describe PackageManager::CocoaPods do
 
   describe "#documentation_url" do
     it "returns a link to project website" do
-      expect(described_class.documentation_url("foo")).to eq("http://cocoadocs.org/docsets/foo/")
+      expect(described_class.documentation_url("foo")).to eq("https://cocoadocs.org/docsets/foo/")
     end
 
     it "handles version" do
-      expect(described_class.documentation_url("foo", "2.0.0")).to eq("http://cocoadocs.org/docsets/foo/2.0.0")
+      expect(described_class.documentation_url("foo", "2.0.0")).to eq("https://cocoadocs.org/docsets/foo/2.0.0")
     end
   end
 


### PR DESCRIPTION
This switches to using the cocoapods CDN to get information about cocoapods per the details in
https://blog.cocoapods.org/CocoaPods-1.7.2/
