### PR TITLE
Support emoji in Cocoapods names.

### DIFF
--- a/app/models/package_manager/cocoa_pods.rb
+++ b/app/models/package_manager/cocoa_pods.rb
@@ -39,6 +39,7 @@ module PackageManager
 
       # we want to get all the versions for a given pod from the text file
       pod_info = get_raw(pod_versions_url(name))
+        .force_encoding("UTF-8")
         .split("\n")
         .find { |line| line.starts_with?("#{name}/") }
       return {} unless pod_info.present? # it's been removed
@@ -93,7 +94,7 @@ module PackageManager
     end
 
     def self.podspec_path(name, version)
-      "Specs/#{cdn_shard(name).join('/')}/#{name}/#{version}/#{name}.podspec.json"
+      "Specs/#{cdn_shard(name).join('/')}/#{CGI.escape(name)}/#{version}/#{CGI.escape(name)}.podspec.json"
     end
   end
 end


### PR DESCRIPTION
* fixes this error, from encounters with emoji names like ["🔒"](https://github.com/CocoaPods/Specs/blob/824d64bcc07cbc479d1d9cc83155314a2febfca5/Specs/%F0%9F%94%92/0.2.0/%F0%9F%94%92.podspec.json):

 

```
Encoding::CompatibilityError 
PackageManagerDownloadWorker@critical
incompatible character encodings: ASCII-8BIT and UTF-8
```

