### PR TITLE
CocoaPods: handle deprecated version entries

### DIFF
--- a/app/models/package_manager/cocoa_pods.rb
+++ b/app/models/package_manager/cocoa_pods.rb
@@ -73,8 +73,10 @@ module PackageManager
     end
 
     def self.versions(raw_project, _name)
-      raw_project.fetch("versions", {}).values.map do |v|
-        VersionBuilder.build_hash(number: v["version"].to_s,
+      raw_project.fetch("versions", {}).map do |(k, v)|
+        VersionBuilder.build_hash(number: k.to_s,
+                                  # TODO: we could capture deprecated_in_favor_of and use it
+                                  status: v["deprecated"] || v["deprecated_in_favor_of"].present? ? "Deprecated" : VersionBuilder::MISSING,
                                   published_at: v["published_at"] || VersionBuilder::MISSING,
                                   original_license: parse_license(v["license"]) || VersionBuilder::MISSING)
       end

--- a/spec/models/package_manager/cocoa_pods_spec.rb
+++ b/spec/models/package_manager/cocoa_pods_spec.rb
@@ -59,13 +59,24 @@ describe PackageManager::CocoaPods do
                                                 "version" => "1.0.0",
                                                 "published_at" => Time.parse("2023-09-06 19:24:46.72 +0000"),
                                               },
+                                              "1.0.1" => { # Deprecated versions won't have "name"/"version" keys, e.g. AFNetworking
+                                                "deprecated_in_favor_of" => "another-package-name",
+                                                "published_at" => Time.parse("2023-09-07 19:24:46.72 +0000"),
+                                              },
                                             },
                                           }, "some-package")
 
-      expect(versions).to eq([{
-                               number: "1.0.0",
-                               published_at: Time.parse("2023-09-06 19:24:46.72 +0000"),
-                             }])
+      expect(versions).to eq([
+        {
+          number: "1.0.0",
+          published_at: Time.parse("2023-09-06 19:24:46.72 +0000"),
+        },
+        {
+          number: "1.0.1",
+          status: "Deprecated",
+          published_at: Time.parse("2023-09-07 19:24:46.72 +0000"),
+        },
+                           ])
     end
   end
 end


### PR DESCRIPTION
fixes this error, for packages like `AFNetworking`:

```
ActiveRecord::RecordInvalid 
PackageManagerDownloadWorker@critical
Validation failed: Number can't be blank
```