### PR TITLE
Project: specs related to repository_url

### DIFF
--- a/spec/serializers/project_serializer_spec.rb
+++ b/spec/serializers/project_serializer_spec.rb
@@ -53,4 +53,14 @@ describe ProjectSerializer do
       expect(subject.attributes.keys).to eq(default_attribute_names + %i[updated_at])
     end
   end
+
+  context "with a project that has a repository that does not match repository_url" do
+    let(:repository) { create(:repository) }
+    let(:project) { create(:project, repository_url: "https://github.com/something/unused", repository: repository) }
+    subject { described_class.new(project) }
+    it "should return repository_url not repository.url" do
+      expect(project.repository_url).not_to eq(project.repository.url)
+      expect(subject.attributes[:repository_url]).to eq(project.repository_url)
+    end
+  end
 end


### PR DESCRIPTION
 * clarify that we serialize repository_url that doesn't
   have to match repository.url because we fall back to
   home page for example when setting project.repository
 * add a little test coverage for project.update_repository
