### PR TITLE
Add Shallow Repository -> Project Names Endpoint

### DIFF
--- a/app/controllers/api/repositories_controller.rb
+++ b/app/controllers/api/repositories_controller.rb
@@ -15,6 +15,11 @@ class Api::RepositoriesController < Api::ApplicationController
     paginate json: @repository.projects.visible.order(custom_order).includes(:versions, :repository)
   end
 
+  def project_names
+    columns = %i[platform name]
+    render json: Project.visible.select(columns).where(repository: @repository).order(custom_order).as_json(only: columns)
+  end
+
   def dependencies
     cache_key = "repository_dependencies:#{@repository.id}"
     json_hash = Rails.cache.fetch(cache_key, expires_in: 1.day) do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,8 @@ Rails.application.routes.draw do
       get "/:host_type/:login", to: "repository_users#show"
     end
 
+    get "/repository/projects", to: "repositories#project_names"
+
     put "/maintenance/stats/enqueue/:platform/:name", as: :maintenance_stat_enqueue, to: "maintenance_stats#enqueue", constraints: { platform: PLATFORM_CONSTRAINT, name: PROJECT_CONSTRAINT }
     post "/maintenance/stats/begin/bulk", to: "maintenance_stats#begin_watching_bulk"
     post "/maintenance/stats/begin/repositories", to: "maintenance_stats#begin_watching_repositories"

--- a/spec/requests/api/repositories_spec.rb
+++ b/spec/requests/api/repositories_spec.rb
@@ -49,6 +49,22 @@ describe "Api::RepositoriesController" do
     end
   end
 
+  describe "GET /api/repository/projects", type: :request do
+    let!(:project) { create(:project, repository: repository) }
+    let!(:hidden_project) { create(:project, status: "Hidden", repository: repository) }
+
+    it "renders visible project names" do
+      get "/api/repository/projects", params: { host_type: repository.host_type, owner: repository.owner_name, name: repository.project_name }
+
+      expect(response).to have_http_status(:success)
+      expect(response.content_type).to start_with("application/json")
+
+      expect(json).to contain_exactly(
+        { "name" => project.name, "platform" => project.platform }
+      )
+    end
+  end
+
   describe "GET /api/github/:owner/:name/shields_dependencies", type: :request do
     let!(:project) { create(:project, repository: repository) }
     let!(:version) { create(:version, project: project) }


### PR DESCRIPTION
This adds an `/api/repository/projects` endpoint that returns only the platform and name of Projects tied to a Repository. The current `/host_type/owner/name/projects` endpoint returns full `Project` objects with full `Version` objects and 500s pretty regularly due to the size of the response and the amount of data being returned. This new endpoint also moves all the parameters into query parameters to avoid any issues with the dynamic path segments potentially triggering the incorrect controller methods if the parameters happen to clash between routes.