### PR TITLE
ProjectUpdatedSerializer: include the project status

### DIFF
--- a/app/serializers/project_updated_serializer.rb
+++ b/app/serializers/project_updated_serializer.rb
@@ -15,6 +15,7 @@ class ProjectUpdatedSerializer < ActiveModel::Serializer
     name
     platform
     repository_url
+    status
     updated_at
     versions_count
   ]

--- a/spec/models/web_hook_spec.rb
+++ b/spec/models/web_hook_spec.rb
@@ -107,6 +107,7 @@ describe WebHook, type: :model do
           name: project.name,
           platform: project.platform,
           repository_url: project.repository_url,
+          status: project.status,
           updated_at: ActiveModel::Type::DateTime.new(precision: 0).serialize(project.updated_at),
           versions_count: project.versions_count,
         }.stringify_keys

--- a/spec/workers/project_updated_worker_spec.rb
+++ b/spec/workers/project_updated_worker_spec.rb
@@ -33,6 +33,7 @@ describe ProjectUpdatedWorker do
         name: project.name,
         platform: project.platform,
         repository_url: project.repository_url,
+        status: project.status,
         updated_at: ActiveModel::Type::DateTime.new(precision: 0).serialize(first_updated_at),
         versions_count: project.versions_count,
       }.stringify_keys


### PR DESCRIPTION
This is needed in particular to ignore status=Hidden
