### PR TITLE
Project: do not send webhook when nothing actually happened

### DIFF
--- a/app/models/concerns/releases.rb
+++ b/app/models/concerns/releases.rb
@@ -66,7 +66,7 @@ module Releases
   end
 
   def set_latest_release_published_at
-    self.latest_release_published_at = (latest_release.try(:published_at).presence || updated_at)
+    self.latest_release_published_at = (latest_release.try(:published_at).presence || read_attribute(:latest_release_published_at) || updated_at)
   end
 
   def set_latest_release_number

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -212,7 +212,7 @@ class Project < ApplicationRecord
 
   after_commit :update_repository_async, on: :create
   after_commit :update_source_rank_async, on: %i[create update]
-  after_commit :send_project_updated, on: %i[create update]
+  after_commit :send_project_updated, on: %i[create update], if: :saved_change_to_updated_at?
   before_save  :update_details
   before_destroy :destroy_versions
   before_destroy :create_deleted_project


### PR DESCRIPTION
We seem to be sending a fair number of webhooks when there
was no bump to updated_at, because after_commit runs when
you update, even if the save had nothing to save.
Stop doing that.
