### PR TITLE
ProjectUpdatedWorker: don't ignore errors on all_project_updates

### DIFF
--- a/app/workers/project_updated_worker.rb
+++ b/app/workers/project_updated_worker.rb
@@ -2,18 +2,22 @@
 
 class ProjectUpdatedWorker
   include Sidekiq::Worker
-  # retries of 10 is about 7 hours, should often be enough to fix an outage, and
-  # if it goes longer than that we just miss some events. We don't want to let
-  # the backlog get too outrageous.
+  # retries of 10 is about 7 hours, should often be enough to fix an outage, and if it goes longer
+  # than that we just miss some events. We don't want to let the backlog get too outrageous.
+  #
+  # Keep in mind that this retry only happens if we raise an exception, so only when we set
+  # ignore_errors:false below.
   sidekiq_options queue: :small, retries: 10, lock: :until_executed
 
   def perform(project_id, web_hook_id)
     project = Project.find(project_id)
     web_hook = WebHook.find(web_hook_id)
-    web_hook.send_project_updated(project, ignore_errors: true)
+    # for all_project_updates we want to be sure the webhook reries so we don't ignore errors. For
+    # regular webhooks we are just best effort.
+    web_hook.send_project_updated(project, ignore_errors: !web_hook.all_project_updates)
   end
 
   sidekiq_retries_exhausted do |job, _ex|
-    Rails.logger.warn "Failed #{job['class']} with #{job['args']}: #{job['error_message']}"
+    Rails.logger.warn "PROJECT_UPDATED_WORKER_PERMANENT_FAILURE: Failed #{job['class']} with #{job['args']}: #{job['error_message']}"
   end
 end

--- a/spec/workers/project_updated_worker_spec.rb
+++ b/spec/workers/project_updated_worker_spec.rb
@@ -64,5 +64,15 @@ describe ProjectUpdatedWorker do
                          project: second_expected_payload,
                        }.stringify_keys)
     end
+
+    it "should raise an error on non-200" do
+      WebMock.stub_request(:post, url)
+        .to_return(status: 500)
+
+      project # create the project here
+      expect do
+        described_class.new.perform(project.id, web_hook.id)
+      end.to raise_error(/webhook failed.*code=500/)
+    end
   end
 end


### PR DESCRIPTION
We [had set ignore_errors:true to reduce logging noise](https://github.com/librariesio/libraries.io/pull/3396), but unfortunately
it means this job never retries and enver exhausts retries. To retry or
to exhaust retries we need to raise an exception.

While there have been no errors from the all_projet_updates hooks that
I see in the past 24 hours, we do want to be sure we retry if there
ever are such errors.
