### PR TITLE
Api::Status#check: Include list of project ids when tracing rendering

### DIFF
--- a/app/controllers/api/status_controller.rb
+++ b/app/controllers/api/status_controller.rb
@@ -6,10 +6,12 @@ class Api::StatusController < Api::BulkProjectController
   def check
     serializer = OptimizedProjectSerializer.new(projects, project_names, internal_key: internal_api_key?)
     serialized = serializer.serialize
-    dumped = Datadog::Tracing.trace("status_check_oj_dump") do |_span, _trace|
+    dumped = Datadog::Tracing.trace("status_check_oj_dump") do |_span, trace|
+      trace&.set_tag("project_ids", projects.map(&:id))
       Oj.dump(serialized, mode: :rails)
     end
-    Datadog::Tracing.trace("status_check_render_dumped") do |_span, _trace|
+    Datadog::Tracing.trace("status_check_render_dumped") do |_span, trace|
+      trace&.set_tag("project_ids", projects.map(&:id))
       render json: dumped
     end
   end


### PR DESCRIPTION
mostly interested in reproducing slow rendering times like these:

<img width="1058" alt="Screenshot 2024-12-16 at 6 52 59 PM" src="https://github.com/user-attachments/assets/f929c780-178d-4ba0-b7c5-fa50f7f4eb46" />
