### PR TITLE
OptimizedProjectSerializer: fall back to created_at for published_at

### DIFF
--- a/app/serializers/optimized_project_serializer.rb
+++ b/app/serializers/optimized_project_serializer.rb
@@ -88,12 +88,17 @@ class OptimizedProjectSerializer
   def versions_by_project_id
     @versions_by_project_id ||= Version
       .where(project_id: @projects.map(&:id))
-      .pluck(:project_id, *VERSION_ATTRIBUTES)
+      .pluck(:project_id, :created_at, *VERSION_ATTRIBUTES)
       .group_by(&:first)
       .transform_values do |versions_values|
         versions_values.map do |version_values|
           # turn Arrays into attribute Hashes, sans "id"
-          VERSION_ATTRIBUTES.zip(version_values[1..]).to_h
+          attrs = VERSION_ATTRIBUTES.zip(version_values[2..]).to_h
+
+          # Version model falls back published_at to created_at
+          attrs[:published_at] ||= version_values[1]
+
+          attrs
         end
       end
   end

--- a/spec/serializers/optimized_project_serializer_spec.rb
+++ b/spec/serializers/optimized_project_serializer_spec.rb
@@ -31,7 +31,7 @@ describe OptimizedProjectSerializer do
       pending "when internal_key is true"
 
       context "with versions" do
-        let!(:project_1_versions) { create_list(:version, 5, project: projects[0]) }
+        let!(:project_1_versions) { create_list(:version, 5, project: projects[0], published_at: 1.year.ago) }
 
         before { projects[0].versions = project_1_versions }
 
@@ -51,6 +51,16 @@ describe OptimizedProjectSerializer do
               }
             end
           )
+        end
+
+        it "should include versions that fall back to created_at for published_at" do
+          version = project_1_versions.first
+          version.update_column(:published_at, nil)
+
+          result = subject.serialize
+
+          actual_version = result[0][:versions].find { |v| v[:number] == version.number }
+          expect(actual_version[:published_at]).to eq(version.created_at)
         end
       end
     end


### PR DESCRIPTION
as @havocp points out, we need to fallback `Version#published_at` to `#created_at` when nil: https://github.com/librariesio/libraries.io/blob/627292f67f02d3d2a0a5e19c7a9be00acaec9dc4/app/models/version.rb#L141-L143