### PR TITLE
Maven: Fix property priority

### DIFF
--- a/app/models/package_manager/maven.rb
+++ b/app/models/package_manager/maven.rb
@@ -139,7 +139,9 @@ module PackageManager
       properties = {}
 
       pom_documents.each do |pom_document|
-        properties.merge!(extract_pom_properties(pom_document))
+        # prefer child values on overlap
+        new_properties = extract_pom_properties(pom_document)
+        properties = new_properties.merge(properties)
       end
 
       result = {

--- a/spec/fixtures/proto-google-common-protos-0.1.9.pom
+++ b/spec/fixtures/proto-google-common-protos-0.1.9.pom
@@ -36,7 +36,6 @@
   </developers>
   <scm>
     <connection>scm:git:https://github.com/googleapis/googleapis</connection>
-    <url>${scm.url}</url>
   </scm>
   <dependencies>
     <dependency>


### PR DESCRIPTION
#3537 introduced a regression on properties where the parent would win in a conflict. This PR corrects that regression and adds a spec to confirm the proper behavior.