### PR TITLE
Api::Projects#sync: parameterize force_sync_dependencies to make optional

### DIFF
--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -123,7 +123,10 @@ class Api::ProjectsController < Api::ApplicationController
       )
       render json: { error: "Project has already been synced recently" }
     else
-      @project.manual_sync
+      # TODO: was there a reason to default force_sync_dependencies to true
+      # in this endpoint? If not, we can default to false here instead.
+      force_sync_dependencies = ActiveModel::Type::Boolean.new.cast(params[:force_sync_dependencies].presence || true)
+      @project.manual_sync(force_sync_dependencies: force_sync_dependencies)
       render json: { message: "Project queued for re-sync" }
     end
   end

--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -123,9 +123,7 @@ class Api::ProjectsController < Api::ApplicationController
       )
       render json: { error: "Project has already been synced recently" }
     else
-      # TODO: was there a reason to default force_sync_dependencies to true
-      # in this endpoint? If not, we can default to false here instead.
-      force_sync_dependencies = ActiveModel::Type::Boolean.new.cast(params[:force_sync_dependencies].presence || true)
+      force_sync_dependencies = ActiveModel::Type::Boolean.new.cast(params[:force_sync_dependencies].presence || false)
       @project.manual_sync(force_sync_dependencies: force_sync_dependencies)
       render json: { message: "Project queued for re-sync" }
     end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -243,14 +243,14 @@ class Project < ApplicationRecord
     name
   end
 
-  def manual_sync
+  def manual_sync(force_sync_dependencies: true)
     StructuredLog.capture("PROJECT_MANUAL_SYNC",
                           {
                             platform: platform,
                             name: name,
                             last_synced_at: last_synced_at,
                           })
-    async_sync(force_sync_dependencies: true)
+    async_sync(force_sync_dependencies: force_sync_dependencies)
     update_repository_async
   end
 

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -466,8 +466,8 @@ describe "Api::ProjectsController" do
 
     context "success" do
       it "notifies the sync is queued" do
-        expect_any_instance_of(Project).to receive(:manual_sync).with(force_sync_dependencies: true)
-        
+        expect_any_instance_of(Project).to receive(:manual_sync).with(force_sync_dependencies: false)
+
         get "/api/#{project.platform}/#{project.name}/sync", params: { api_key: internal_user.api_key }
 
         expect(response).to have_http_status(:success)
@@ -476,9 +476,9 @@ describe "Api::ProjectsController" do
       end
 
       it "notifies the sync is queued with force_sync_dependencies=true" do
-        expect_any_instance_of(Project).to receive(:manual_sync).with(force_sync_dependencies: false)
+        expect_any_instance_of(Project).to receive(:manual_sync).with(force_sync_dependencies: true)
 
-        get "/api/#{project.platform}/#{project.name}/sync", params: { api_key: internal_user.api_key, force_sync_dependencies: false }
+        get "/api/#{project.platform}/#{project.name}/sync", params: { api_key: internal_user.api_key, force_sync_dependencies: true }
 
         expect(response).to have_http_status(:success)
         expect(response.content_type).to start_with("application/json")

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -466,7 +466,19 @@ describe "Api::ProjectsController" do
 
     context "success" do
       it "notifies the sync is queued" do
+        expect_any_instance_of(Project).to receive(:manual_sync).with(force_sync_dependencies: true)
+        
         get "/api/#{project.platform}/#{project.name}/sync", params: { api_key: internal_user.api_key }
+
+        expect(response).to have_http_status(:success)
+        expect(response.content_type).to start_with("application/json")
+        expect(response.body).to include("Project queued for re-sync")
+      end
+
+      it "notifies the sync is queued with force_sync_dependencies=true" do
+        expect_any_instance_of(Project).to receive(:manual_sync).with(force_sync_dependencies: false)
+
+        get "/api/#{project.platform}/#{project.name}/sync", params: { api_key: internal_user.api_key, force_sync_dependencies: false }
 
         expect(response).to have_http_status(:success)
         expect(response.content_type).to start_with("application/json")


### PR DESCRIPTION
sometimes clients hitting this endpoint don't need to "destroy and re-create all dependencies for all versions" when syncing the package, so this makes it optional and `false` by default, e.g.:

`/api/npm/some-package/sync?force_sync_dependencies=true`

**NOTE**:  I'm not disabling `force_sync_dependencies` altogether when calling this endpoint because I'm not sure yet what the original motivation for was in https://github.com/librariesio/libraries.io/pull/3059
