### PR TITLE
fix: [sc-47166] Libraries project webhook not 100% reliable

### DIFF
--- a/app/workers/project_updated_worker.rb
+++ b/app/workers/project_updated_worker.rb
@@ -7,7 +7,7 @@ class ProjectUpdatedWorker
   #
   # Keep in mind that this retry only happens if we raise an exception, so only when we set
   # ignore_errors:false below.
-  sidekiq_options queue: :small, retries: 10, lock: :until_executed
+  sidekiq_options queue: :small, retries: 10
 
   def perform(project_id, web_hook_id)
     project = Project.find(project_id)


### PR DESCRIPTION
Story details: https://app.shortcut.com/tidelift/story/47166

Remove sidekiq_unique_jobs from the ProjectUpdatedWorker. I'm not sure if unique is causing the problem or not. But this will possibly fix, or possibly rule it out. It doesn't look like sidekiq-unique is proc'ing that often according to logs, so I don't expect removing it from this worker will have detrimental impacts.