### PR TITLE
Hackage: use "Category" words from HTML instead of ToC content for keywords

### DIFF
--- a/app/models/package_manager/hackage.rb
+++ b/app/models/package_manager/hackage.rb
@@ -41,8 +41,8 @@ module PackageManager
         name: raw_project[:name],
         keywords_array: Array(
           raw_project[:page].css("#content table.properties tr")
-            .find { |tr| tr.css("th")&.text.strip == "Category" }
-            &.css("a").map(&:text).reject(&:blank?).map(&:strip)
+            .find { |tr| tr.css("th")&.text&.strip == "Category" }
+            &.css("a")&.map(&:text)&.reject(&:blank?)&.map(&:strip)
         ),
         description: description(raw_project[:page]),
         licenses: find_attribute(raw_project[:page], "License"),

--- a/app/models/package_manager/hackage.rb
+++ b/app/models/package_manager/hackage.rb
@@ -39,7 +39,11 @@ module PackageManager
     def self.mapping(raw_project)
       MappingBuilder.build_hash(
         name: raw_project[:name],
-        keywords_array: Array(raw_project[:page].css("#content div:first a")[1..].map(&:text)),
+        keywords_array: Array(
+          raw_project[:page].css("#content table.properties tr")
+            .find { |tr| tr.css("th")&.text.strip == "Category" }
+            &.css("a").map(&:text).reject(&:blank?).map(&:strip)
+        ),
         description: description(raw_project[:page]),
         licenses: find_attribute(raw_project[:page], "License"),
         homepage: find_attribute(raw_project[:page], "Home page"),


### PR DESCRIPTION
for Hackage packages, Libraries currently scrapes the links in the Table of Contents to store in the "Project#keywords" attribute, but that sometimes raises an error in our Sidekiq worker when the words exceed the Postgres index size. 

this also results in huge keyword arrays for Hackage packages:

<img width="795" alt="Screenshot 2025-01-06 at 2 43 28 PM" src="https://github.com/user-attachments/assets/3c1b25a5-f42c-4520-a48c-3c05d7a76b23" />

it's not clear from the [original PR](https://github.com/librariesio/libraries.io/commit/0ed14e37f2342c6d588b64eee4a153b4a7f49aa8) why the ToC was used, but there's a  more reasonable "Category" list of words/tags on the sidebar that we can use instead:

<img width="319" alt="Screenshot 2025-01-06 at 2 44 48 PM" src="https://github.com/user-attachments/assets/97ab2743-5ad4-43fa-b36d-2c1c42fdd8ac" />

