### PR TITLE
If a project 404s on Maven, return nil early from latest_version_scraped

### DIFF
--- a/app/models/package_manager/maven/maven_central.rb
+++ b/app/models/package_manager/maven/maven_central.rb
@@ -25,6 +25,8 @@ class PackageManager::Maven::MavenCentral < PackageManager::Maven::Common
       .map { |folder| folder.chomp("/") }                  # remove folder trailing slash
       .grep(/^\d+.\d/)                                     # only folders that look like versions
 
+    return nil if versions.empty?
+
     # Maven versions range from 1 to many "." and may not be valid SemVer. Use the more forgiving Gem::Version to sort
     # but we also want to prefer things that _don't_ look like a date as that's an ancient maven practice
     dated_versions, nodate_versions = versions.partition { |v| v =~ /\d{8}.\d+/ }

--- a/spec/models/package_manager/maven/maven_central_spec.rb
+++ b/spec/models/package_manager/maven/maven_central_spec.rb
@@ -87,6 +87,21 @@ describe PackageManager::Maven::MavenCentral do
         expect(Bugsnag).to have_received(:notify)
       end
     end
+
+    context "with empty response" do
+      # Example blank HTML from when we get a 404 back, e.g. https://repo1.maven.org/maven2/cljsjs/hammer
+      let(:html) { "" }
+
+      before do
+        allow(PackageManager::ApiService).to receive(:request_raw_data).and_return(html)
+        allow(Bugsnag).to receive(:notify)
+      end
+
+      it "scrapes the maven HTML and notifies us that there was no version found" do
+        expect(described_class.latest_version_scraped("foo:bar")).to eq(nil)
+        expect(Bugsnag).to_not have_received(:notify)
+      end
+    end
   end
 
   describe ".update" do

--- a/spec/models/package_manager/maven/maven_central_spec.rb
+++ b/spec/models/package_manager/maven/maven_central_spec.rb
@@ -97,7 +97,7 @@ describe PackageManager::Maven::MavenCentral do
         allow(Bugsnag).to receive(:notify)
       end
 
-      it "scrapes the maven HTML and notifies us that there was no version found" do
+      it "translates a 404 response into a blank string and ultimately a nil response" do
         expect(described_class.latest_version_scraped("foo:bar")).to eq(nil)
         expect(Bugsnag).to_not have_received(:notify)
       end


### PR DESCRIPTION
e.g. Libraries got an update request for `maven/cljsjs:hammer`, but that is a Clojars package and doesn't exist on Maven Central.