### PR TITLE
Cache Popular Languages and Platforms for Explore Page

### DIFF
--- a/app/controllers/explore_controller.rb
+++ b/app/controllers/explore_controller.rb
@@ -2,11 +2,14 @@
 
 class ExploreController < ApplicationController
   def index
-    @platforms = Project.maintained.group(:platform).order("count_id DESC").limit(28).count("id").keys
-    @languages = Project.maintained.where.not(language: nil).group(:language).order("count_id DESC").limit(21).count("id").keys
+    @platforms = Rails.cache.fetch("explore:platforms", expires_in: 1.day, race_condition_ttl: 2.minutes) do
+      Project.maintained.group(:platform).order("count_id DESC").limit(28).count("id").keys
+    end
+    @languages = Rails.cache.fetch("explore:languages", expires_in: 1.day, race_condition_ttl: 2.minutes) do
+      Project.maintained.where.not(language: nil).group(:language).order("count_id DESC").limit(21).count("id").keys
+    end
 
-    project_scope = Project.includes(:repository).maintained.with_description
-
+    project_scope = Project.maintained.with_description
     @new_projects = project_scope.order("projects.created_at desc").limit(10)
   end
 end


### PR DESCRIPTION
These are some fairly expensive queries to populate the lists of languages and platforms on the `/explore` page. These lists should not be changing very often so this PR introduces a caching layer for those lists to help reduce db usage.