### PR TITLE
Add id_new uuid column to the dependencies table

### DIFF
--- a/app/models/dependency.rb
+++ b/app/models/dependency.rb
@@ -5,6 +5,7 @@
 # Table name: dependencies
 #
 #  id           :integer          not null, primary key
+#  id_new       :uuid
 #  kind         :string
 #  optional     :boolean          default(FALSE)
 #  platform     :string

--- a/db/migrate/20250403234300_enable_uuid_extension.rb
+++ b/db/migrate/20250403234300_enable_uuid_extension.rb
@@ -1,0 +1,6 @@
+class EnableUuidExtension < ActiveRecord::Migration[7.1]
+  def change
+    enable_extension 'uuid-ossp'
+    enable_extension 'pgcrypto'
+  end
+end

--- a/db/migrate/20250403234300_enable_uuid_extension.rb
+++ b/db/migrate/20250403234300_enable_uuid_extension.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 class EnableUuidExtension < ActiveRecord::Migration[7.1]
   def change
-    enable_extension 'uuid-ossp'
-    enable_extension 'pgcrypto'
+    enable_extension "uuid-ossp"
+    enable_extension "pgcrypto"
   end
 end

--- a/db/migrate/20250403234330_add_new_id_to_dependencies.rb
+++ b/db/migrate/20250403234330_add_new_id_to_dependencies.rb
@@ -1,0 +1,9 @@
+class AddNewIdToDependencies < ActiveRecord::Migration[7.1]
+  def change
+    # Step 1: Add the new uuid column without a default value
+    add_column :dependencies, :id_new, :uuid
+
+    # Step 2: Add a default value for new rows
+    change_column_default :dependencies, :id_new, from: nil, to: 'gen_random_uuid()'
+  end
+end

--- a/db/migrate/20250403234330_add_new_id_to_dependencies.rb
+++ b/db/migrate/20250403234330_add_new_id_to_dependencies.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 class AddNewIdToDependencies < ActiveRecord::Migration[7.1]
   def change
     # Step 1: Add the new uuid column without a default value
     add_column :dependencies, :id_new, :uuid
 
     # Step 2: Add a default value for new rows
-    change_column_default :dependencies, :id_new, from: nil, to: 'gen_random_uuid()'
+    change_column_default :dependencies, :id_new, from: nil, to: "gen_random_uuid()"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_11_30_150002) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_03_234330) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
@@ -88,6 +88,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_30_150002) do
     t.string "requirements"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.uuid "id_new", default: -> { "gen_random_uuid()" }
     t.index "project_id, ((created_at)::date)", name: "index_dependencies_on_project_created_at_date"
     t.index ["project_id", "version_id"], name: "index_dependencies_on_project_id_and_version_id"
     t.index ["version_id"], name: "index_dependencies_on_version_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,7 +14,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_03_234330) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
+  enable_extension "uuid-ossp"
 
   create_table "api_keys", id: :serial, force: :cascade do |t|
     t.string "access_token"


### PR DESCRIPTION
This is step one in migrating to a uuid id.

next steps are roughly:
 * manually add index on id_new and backfill id_new
 * push a migration that adds the index and does the backfill (no-op)
 * push a migration that swaps id to id_old and id_new to id
 * push a migration that drops id_old