### PR TITLE
Project: use PEP530 name normalization for PyPi lookups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "active_model_serializers"
 gem "api-pagination"
 gem "asciidoctor"
 gem "audited"
-gem "bibliothecary", "~> 11.0.0"
+gem "bibliothecary", "~> 12.3.1"
 gem "bitbucket_rest_api", git: "https://github.com/librariesio/bitbucket"
 gem "bootsnap", require: false
 gem "bootstrap-sass"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,9 +121,10 @@ GEM
       execjs
     base64 (0.1.1)
     benchmark (0.4.0)
-    bibliothecary (11.0.1)
+    bibliothecary (12.3.1)
       commander
       deb_control
+      json (~> 2.8)
       librariesio-gem-parser
       ox (>= 2.8.1)
       packageurl-ruby
@@ -234,7 +235,7 @@ GEM
     faraday_middleware (0.14.0)
       faraday (>= 0.7.4, < 1.0)
     fast_blank (1.0.1)
-    ffi (1.17.0)
+    ffi (1.17.2)
     font-awesome-rails (4.7.0.8)
       railties (>= 3.2, < 8.0)
     foreman (0.88.1)
@@ -278,7 +279,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.6.3)
+    json (2.12.2)
     json_spec (1.1.5)
       multi_json (~> 1.0)
       rspec (>= 2.0, < 4.0)
@@ -374,8 +375,9 @@ GEM
       omniauth (~> 2.0)
     org-ruby (0.9.12)
       rubypants (~> 0.2)
-    ox (2.14.18)
-    packageurl-ruby (0.1.0)
+    ox (2.14.23)
+      bigdecimal (>= 3.0)
+    packageurl-ruby (0.2.0)
     parallel (1.23.0)
     parser (3.2.2.3)
       ast (~> 2.4.1)
@@ -622,7 +624,7 @@ DEPENDENCIES
   api-pagination
   asciidoctor
   audited
-  bibliothecary (~> 11.0.0)
+  bibliothecary (~> 12.3.1)
   bitbucket_rest_api!
   bootsnap
   bootstrap-sass
@@ -755,7 +757,7 @@ CHECKSUMS
   autoprefixer-rails (9.5.1.1) sha256=68f6076794fe4d37f42a53bb3c324808e341359c38d9e8c585dbc8557945a038
   base64 (0.1.1) sha256=0c75d351a429b5176a476cd8a3740cff3277d2bac26a50b5c7456c266e9acd33
   benchmark (0.4.0) sha256=0f12f8c495545e3710c3e4f0480f63f06b4c842cc94cec7f33a956f5180e874a
-  bibliothecary (11.0.1) sha256=8367e601b710260b12f9f9f6e5ed055da2d76f329c018d540eeeaae364e60ce1
+  bibliothecary (12.3.1) sha256=2d629b0b1f9033f50be67028c1037b6a252eb3cd2e1a766de010ead6f74c72ee
   bigdecimal (3.1.8) sha256=a89467ed5a44f8ae01824af49cbc575871fa078332e8f77ea425725c1ffe27be
   bitbucket_rest_api (0.1.7)
   bootsnap (1.12.0) sha256=6c6d7e57e6da89817953dbfb410d04c44ddfa6c3eb4be303d21e6c41dc20ea7b
@@ -811,7 +813,7 @@ CHECKSUMS
   faraday-http-cache (2.5.0) sha256=64b7366d66e508e1c3dd855ebb20ce9da429330e412a23d9ebbc0a7a7b227463
   faraday_middleware (0.14.0) sha256=4cb37ddd656b2c4de0bd684b72b08c34486f70560c31cb303cd506faef7ef2f4
   fast_blank (1.0.1) sha256=269fc30414fed4e6403bc4a49081e1ea539f8b9226e59276ed1efaefabaa17ea
-  ffi (1.17.0) sha256=51630e43425078311c056ca75f961bb3bda1641ab36e44ad4c455e0b0e4a231c
+  ffi (1.17.2) sha256=297235842e5947cc3036ebe64077584bff583cd7a4e94e9a02fdec399ef46da6
   font-awesome-rails (4.7.0.8) sha256=c26183d5f902858289692d3a173c3d8d0f769c3b0930259ae4181ddfd74d496c
   foreman (0.88.1) sha256=59c022125b6a328a2ce63da8d70b731f5dd13519e8d9a4184c696538088ea00a
   fuzzy_match (2.1.0) sha256=e97e25d0eaee48a5f77ed970d007c7b6ff3c6a6858303fead2d1986859204dfc
@@ -835,7 +837,7 @@ CHECKSUMS
   irb (1.14.0) sha256=53d805013bbd194874b8c13a56aca6aebcd11dd79166d88724f8a434fedde615
   jb (0.8.0) sha256=a100e19e5663d1401ab14c97b83ee2a792263e22a0ca53685404e6fb9398d32a
   jquery-rails (4.6.0) sha256=3c4e6bf47274340b44d836b8aa1b5472c6d451e2739af5ec094421f39025a7e2
-  json (2.6.3) sha256=86aaea16adf346a2b22743d88f8dcceeb1038843989ab93cda44b5176c845459
+  json (2.12.2) sha256=ba94a48ad265605c8fa9a50a5892f3ba6a02661aa010f638211f3cb36f44abf4
   json_spec (1.1.5) sha256=7a77b97a92c787e2aa3fbc4a1239afc3342c781151dc98cfb81461b3b7cad10f
   jsonapi-renderer (0.2.2) sha256=b5c44b033d61b4abdb6500fa4ab84807ca0b36ea0e59e47a2c3ca7095a6e447b
   jwt (2.8.1) sha256=4baaf38208a172398a802da9410d73235ecfd6af1bd9cb736c69dd44d4dfa30a
@@ -881,8 +883,8 @@ CHECKSUMS
   omniauth-oauth2 (1.8.0) sha256=b2f8e9559cc7e2d4efba57607691d6d2b634b879fc5b5b6ccfefa3da85089e78
   omniauth-rails_csrf_protection (1.0.1) sha256=fc546aeb7d43b7b9d7737051c380156e61c8f080b898cd4934d523eaa7e59acf
   org-ruby (0.9.12) sha256=93cbec3a4470cb9dca6a4a98dc276a6434ea9d9e7bc2d42ea33c3aedd5d1c974
-  ox (2.14.18) sha256=993e0290491bab6bbd4946d2fa98711b052634bbb25d7812b931b29de5562f71
-  packageurl-ruby (0.1.0) sha256=3edfa1ce355200fde2a1d2cf625dafdf28d0cc9472eb99493325bf3d88e9daa3
+  ox (2.14.23) sha256=4a9aedb4d6c78c5ebac1d7287dc7cc6808e14a8831d7adb727438f6a1b461b66
+  packageurl-ruby (0.2.0) sha256=9bef22c96622b7d3a0087a7fbca8903f9187b66fbfd6a78299ef115768f5012b
   parallel (1.23.0) sha256=27154713ad6ef32fa3dcb7788a721d6c07bca77e72443b4c6080a14145288c49
   parser (3.2.2.3) sha256=10685f358ab36ffea2252dc4952e5b8fad3a297a8152a85f59adc982747b91eb
   pg (1.5.4) sha256=04f7b247151c639a0b955d8e5a9a41541343f4640aa3c2bdf749a872c339d25d

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -388,11 +388,6 @@ module PackageManager
       RepositoryService.repo_fallback(repo, homepage)
     end
 
-    # A list of names to use when finding the project (override if necessary)
-    def self.possible_lookup_names(project_name)
-      [project_name]
-    end
-
     def self.deprecation_info(_db_project)
       { is_deprecated: false, message: nil }
     end

--- a/app/models/package_manager/base.rb
+++ b/app/models/package_manager/base.rb
@@ -388,7 +388,8 @@ module PackageManager
       RepositoryService.repo_fallback(repo, homepage)
     end
 
-    def self.project_find_names(project_name)
+    # A list of names to use when finding the project (override if necessary)
+    def self.possible_lookup_names(project_name)
       [project_name]
     end
 

--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -136,7 +136,7 @@ module PackageManager
       end
     end
 
-    def self.project_find_names(project_name)
+    def self.possible_lookup_names(project_name)
       [
         project_name,
         Bibliothecary::Parsers::Pypi.normalize_name(project_name),

--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -136,13 +136,6 @@ module PackageManager
       end
     end
 
-    def self.possible_lookup_names(project_name)
-      [
-        project_name,
-        Bibliothecary::Parsers::Pypi.normalize_name(project_name),
-      ]
-    end
-
     # checks to see if the package exists on PyPI and the name matches the canonical name
     def self.canonical_pypi_name?(name)
       json_api_project = project(name)

--- a/app/models/package_manager/pypi.rb
+++ b/app/models/package_manager/pypi.rb
@@ -139,8 +139,7 @@ module PackageManager
     def self.project_find_names(project_name)
       [
         project_name,
-        project_name.gsub("-", "_"),
-        project_name.gsub("_", "-"),
+        Bibliothecary::Parsers::Pypi.normalize_name(project_name),
       ]
     end
 

--- a/app/queries/project_status_query.rb
+++ b/app/queries/project_status_query.rb
@@ -27,17 +27,17 @@ class ProjectStatusQuery
     @missing_projects ||= Project
       .visible
       .lower_platform(@platform)
-      .where("lower(name) in (?)", missing_project_find_names.keys)
+      .where("lower(name) in (?)", missing_possible_lookup_names.keys)
       .includes(:repository)
       .find_each
-      .index_by { |project| missing_project_find_names[project.name.downcase] }
+      .index_by { |project| missing_possible_lookup_names[project.name.downcase] }
   end
 
-  def missing_project_find_names
-    @missing_project_find_names ||= (@requested_project_names - exact_projects.keys)
+  def missing_possible_lookup_names
+    @missing_possible_lookup_names ||= (@requested_project_names - exact_projects.keys)
       .each_with_object({}) do |requested_name, hash|
         platform_class
-          .project_find_names(requested_name)
+          .possible_lookup_names(requested_name)
           .each { |find_name| hash[find_name.downcase] = requested_name }
       end
   end

--- a/app/queries/project_status_query.rb
+++ b/app/queries/project_status_query.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Returns found projects by their requested names.
 class ProjectStatusQuery
   def initialize(platform, requested_project_names)
     @platform = platform

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -29,14 +29,14 @@ describe PackageManager::Pypi do
     end
   end
 
-  describe "project_find_names" do
+  describe "possible_lookup_names" do
     it "suggests underscore version of name" do
-      suggested_find_names = described_class.project_find_names("test-hyphen")
+      suggested_find_names = described_class.possible_lookup_names("test-hyphen")
       expect(suggested_find_names).to include("test_hyphen", "test-hyphen")
     end
 
     it "suggests hyphen version of name" do
-      suggested_find_names = described_class.project_find_names("test_underscore")
+      suggested_find_names = described_class.possible_lookup_names("test_underscore")
       expect(suggested_find_names).to include("test-underscore", "test_underscore")
     end
   end

--- a/spec/models/package_manager/pypi_spec.rb
+++ b/spec/models/package_manager/pypi_spec.rb
@@ -29,18 +29,6 @@ describe PackageManager::Pypi do
     end
   end
 
-  describe "possible_lookup_names" do
-    it "suggests underscore version of name" do
-      suggested_find_names = described_class.possible_lookup_names("test-hyphen")
-      expect(suggested_find_names).to include("test_hyphen", "test-hyphen")
-    end
-
-    it "suggests hyphen version of name" do
-      suggested_find_names = described_class.possible_lookup_names("test_underscore")
-      expect(suggested_find_names).to include("test-underscore", "test_underscore")
-    end
-  end
-
   describe "#deprecation_info" do
     let(:json_api_project) do
       instance_double(

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -287,6 +287,92 @@ describe Project, type: :model do
     end
   end
 
+  describe ".find_all_with_package_manager!" do
+    context "querying an NPM package" do
+      let!(:package1) { create(:project, name: "some-npm-pkg", platform: "NPM") }
+      let!(:package2) { create(:project, name: "another-npm-pkg", platform: "NPM") }
+
+      it "finds a single package" do
+        results = Project.find_all_with_package_manager!("npm", ["some-npm-pkg"])
+
+        expect(results).to eq({
+                                "some-npm-pkg" => package1,
+                              })
+      end
+
+      it "finds multiple packages" do
+        results = Project.find_all_with_package_manager!("npm", %w[some-npm-pkg another-npm-pkg])
+
+        expect(results).to eq({
+                                "some-npm-pkg" => package1,
+                                "another-npm-pkg" => package2,
+                              })
+      end
+
+      it "finds and doesn't find multiple packages" do
+        results = Project.find_all_with_package_manager!("npm", %w[some-npm-pkg not-found-pkg])
+
+        expect(results).to eq({
+                                "some-npm-pkg" => package1,
+                                "not-found-pkg" => nil,
+                              })
+      end
+    end
+
+    context "querying a Pypi package based on PEP503 name normalization" do
+      let!(:package1) { create(:project, name: "test____underscores", platform: "Pypi") }
+      let!(:package2) { create(:project, name: "test.....dots", platform: "Pypi") }
+      let!(:package3) { create(:project, name: "test-----hyphens", platform: "Pypi") }
+      let!(:package4) { create(:project, name: "test---__a..mix--of-EVERYthing", platform: "Pypi") }
+
+      it "finds a single package" do
+        results = Project.find_all_with_package_manager!("pypi", ["test-underscores"])
+
+        expect(results).to eq({
+                                "test-underscores" => package1,
+                              })
+      end
+
+      it "finds multiple packages" do
+        results = Project.find_all_with_package_manager!("pypi", %w[test-underscores test-dots test-hyphens test-a-mix-of-everything])
+
+        expect(results).to eq({
+                                "test-underscores" => package1,
+                                "test-dots" => package2,
+                                "test-hyphens" => package3,
+                                "test-a-mix-of-everything" => package4,
+                              })
+      end
+
+      it "finds and doesn't find multiple packages" do
+        results = Project.find_all_with_package_manager!("pypi", %w[test-underscores test-not-found test-dots])
+
+        expect(results).to eq({
+                                "test-underscores" => package1,
+                                "test-not-found" => nil,
+                                "test-dots" => package2,
+                              })
+      end
+
+      it "finds multiple package with different un-normalized names" do
+        results = Project.find_all_with_package_manager!(
+          "pypi",
+          ["test__...--__underscores",
+           "test....---__dots",
+           "test....__---hyphens",
+           "test____a....mix-of_-.everything"]
+        )
+
+        expect(results).to eq({
+                                "test__...--__underscores" => package1,
+                                "test....---__dots" => package2,
+                                "test....__---hyphens" => package3,
+                                "test____a....mix-of_-.everything" => package4,
+                              })
+      end
+    end
+  end
+
   describe "#async_sync" do
     let!(:project) { create(:project, platform: "NPM", name: "jade") }
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -218,6 +218,56 @@ describe Project, type: :model do
           .to raise_error(ActiveRecord::RecordNotFound)
       end
     end
+
+    context "querying a Pypi package based on PEP503 name normalization" do
+      context "with underscores" do
+        let!(:package) { create(:project, name: "test____underscores", platform: "Pypi") }
+
+        it "finds the package by its normalized name" do
+          expect(Project.find_best!("pypi", "test-underscores")).to eq(package)
+        end
+
+        it "finds the package by an equivalent un-normalized name" do
+          expect(Project.find_best!("pypi", "test_-__underscores")).to eq(package)
+        end
+      end
+
+      context "with dots" do
+        let!(:package) { create(:project, name: "test.....dots", platform: "Pypi") }
+
+        it "finds the package by its normalized name" do
+          expect(Project.find_best!("pypi", "test-dots")).to eq(package)
+        end
+
+        it "finds the package by an equivalent un-normalized name" do
+          expect(Project.find_best!("pypi", "test_-__..dots")).to eq(package)
+        end
+      end
+
+      context "with hyphens" do
+        let!(:package) { create(:project, name: "test-----hyphens", platform: "Pypi") }
+
+        it "finds the package by its normalized name" do
+          expect(Project.find_best!("pypi", "test-hyphens")).to eq(package)
+        end
+
+        it "finds the package by an equivalent un-normalized name" do
+          expect(Project.find_best!("pypi", "test_-__..hyphens")).to eq(package)
+        end
+      end
+
+      context "with a mix of hyphens, dots, underscores and uppercase" do
+        let!(:package) { create(:project, name: "test---__a..mix--of-EVERYthing", platform: "Pypi") }
+
+        it "finds the package by its normalized name" do
+          expect(Project.find_best!("pypi", "test-a-mix-of-everything")).to eq(package)
+        end
+
+        it "finds the package by an equivalent un-normalized name" do
+          expect(Project.find_best!("pypi", "test-__a..mix--of-everyTHING")).to eq(package)
+        end
+      end
+    end
   end
 
   describe ".find_best" do

--- a/spec/queries/project_status_query_spec.rb
+++ b/spec/queries/project_status_query_spec.rb
@@ -12,6 +12,14 @@ describe ProjectStatusQuery do
       expect(instance.projects_by_name).to eq({ "foo" => project })
     end
 
+    it "omits projects that aren't found" do
+      project = create(:project, platform: "Pypi", name: "foo")
+
+      instance = described_class.new("Pypi", %w[foo bar])
+
+      expect(instance.projects_by_name).to eq({ "foo" => project })
+    end
+
     it "handles pypi lookups using unnormalized names against packages that would have the same normalized name" do
       project = create(:project, platform: "Pypi", name: "A-Python-Package")
 

--- a/spec/queries/project_status_query_spec.rb
+++ b/spec/queries/project_status_query_spec.rb
@@ -5,28 +5,19 @@ require "rails_helper"
 describe ProjectStatusQuery do
   describe "#projects_by_name" do
     it "returns a list of projects by their requested names" do
-      project = create(:project, platform: "Go", name: "known/project")
+      project = create(:project, platform: "Pypi", name: "foo")
 
-      instance = described_class.new("go", ["known/project"])
+      instance = described_class.new("Pypi", ["foo"])
 
-      expect(instance.projects_by_name).to eq({ "known/project" => project })
+      expect(instance.projects_by_name).to eq({ "foo" => project })
     end
 
-    it "handles go project redirects" do
-      project = create(:project, platform: "Go", name: "known/project")
+    it "handles pypi normalized names" do
+      project = create(:project, platform: "Pypi", name: "a-python-package")
 
-      allow(PackageManager::Go)
-        .to receive(:project_find_names)
-        .with("unknown/project")
-        .and_return(["known/project"])
-      allow(PackageManager::Go)
-        .to receive(:project_find_names)
-        .with("second/unknown/project")
-        .and_return(["other/unknown/project"])
+      instance = described_class.new("Pypi", ["A___Python___Package"])
 
-      instance = described_class.new("Go", ["unknown/project", "second/unknown/project"])
-
-      expect(instance.projects_by_name).to eq({ "unknown/project" => project })
+      expect(instance.projects_by_name).to eq({ "A___Python___Package" => project })
     end
   end
 end

--- a/spec/queries/project_status_query_spec.rb
+++ b/spec/queries/project_status_query_spec.rb
@@ -12,12 +12,12 @@ describe ProjectStatusQuery do
       expect(instance.projects_by_name).to eq({ "foo" => project })
     end
 
-    it "handles pypi normalized names" do
-      project = create(:project, platform: "Pypi", name: "a-python-package")
+    it "handles pypi lookups using unnormalized names against packages that would have the same normalized name" do
+      project = create(:project, platform: "Pypi", name: "A-Python-Package")
 
-      instance = described_class.new("Pypi", ["A___Python___Package"])
+      instance = described_class.new("Pypi", ["A___python___package"])
 
-      expect(instance.projects_by_name).to eq({ "A___Python___Package" => project })
+      expect(instance.projects_by_name).to eq({ "A___python___package" => project })
     end
   end
 end

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -377,7 +377,7 @@ describe "Api::ProjectsController" do
       context "that redirects to a known project" do
         it "redirects" do
           allow(PackageManager::Go)
-            .to receive(:project_find_names)
+            .to receive(:possible_lookup_names)
             .with("unknown/project")
             .and_return([project.name])
 
@@ -389,7 +389,7 @@ describe "Api::ProjectsController" do
       context "that redirects to an unknown project" do
         it "returns not found" do
           allow(PackageManager::Go)
-            .to receive(:project_find_names)
+            .to receive(:possible_lookup_names)
             .with("unknown/project")
             .and_return(["other/unknown/project"])
 
@@ -401,7 +401,7 @@ describe "Api::ProjectsController" do
       context "that does not redirect" do
         it "returns not found" do
           allow(PackageManager::Go)
-            .to receive(:project_find_names)
+            .to receive(:possible_lookup_names)
             .with("unknown/project")
             .and_return(["unknown/project"])
 

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -371,41 +371,19 @@ describe "Api::ProjectsController" do
       expect(response.body).to be_json_eql([].to_json)
     end
 
-    context "for a Go project that is not in the DB" do
-      let!(:project) { create(:project, platform: "Go", name: "known/project") }
+    context "for a Pypi project that has an un-normalized name" do
+      let!(:project) { create(:project, platform: "Pypi", name: "this_IS__NOT__a-normalized-NAME") }
 
-      context "that redirects to a known project" do
+      context "that redirects to the name of the project" do
         it "redirects" do
-          allow(PackageManager::Go)
-            .to receive(:possible_lookup_names)
-            .with("unknown/project")
-            .and_return([project.name])
-
-          get "/api/go/unknown%2Fproject/contributors"
-          expect(response).to redirect_to("/api/go/known%2Fproject/contributors")
+          get "/api/pypi/this-is-NOT...a-normalized-name/contributors"
+          expect(response).to redirect_to("/api/pypi/this_IS__NOT__a-normalized-NAME/contributors")
         end
       end
 
-      context "that redirects to an unknown project" do
+      context "that is not found" do
         it "returns not found" do
-          allow(PackageManager::Go)
-            .to receive(:possible_lookup_names)
-            .with("unknown/project")
-            .and_return(["other/unknown/project"])
-
-          expect { get "/api/go/unknown%2Fproject/contributors" }
-            .to raise_exception(ActiveRecord::RecordNotFound)
-        end
-      end
-
-      context "that does not redirect" do
-        it "returns not found" do
-          allow(PackageManager::Go)
-            .to receive(:possible_lookup_names)
-            .with("unknown/project")
-            .and_return(["unknown/project"])
-
-          expect { get "/api/go/unknown%2Fproject/contributors" }
+          expect { get "/api/pypi/unknown%2Fproject/contributors" }
             .to raise_exception(ActiveRecord::RecordNotFound)
         end
       end

--- a/spec/requests/api/status_spec.rb
+++ b/spec/requests/api/status_spec.rb
@@ -140,13 +140,9 @@ describe "API::StatusController" do
       expect(JSON.parse(response.body).dig(0, "name")).to eq(requested_name)
     end
 
-    it "correctly handles go redirects" do
-      project = create(:project, platform: "Go", name: "known/project")
-      requested_name = "unknown/project"
-      allow(PackageManager::Go)
-        .to receive(:project_find_names)
-        .with(requested_name)
-        .and_return([project.name])
+    it "correctly handles pypi lookup" do
+      project = create(:project, platform: "Pypi", name: "A-Python-Package")
+      requested_name = "a_python_package"
 
       post(
         url,


### PR DESCRIPTION
Currently Libraries looks up Pypi projects using 3 lookup names: "FOO-BAR_BAZ" (the requested name), "foo-bar-baz", and "foo_bar_baz".

This PR goes further by using [PEP 503's name normalization rules](https://packaging.python.org/en/latest/specifications/name-normalization/): replace any run of "_-." with a single "-" and lower case it.

I've checked every PyPi Project on Libraries right now, and fetching the normalized name from PyPI's API returns the exact same project for the name in our database, which implies that any PyPi project can be queried by its normalized name (at the very least, this can be guaranteed for the "pypi.org/simple/" API, because of PEP 503).

### Changes

* `Project`:
  * adds a `find_all_with_package_manager!` method that does platform-specific alternate name bulk lookup
    * for PyPi, use the PEP503 name normalization regexp on both lookup and database name to match them
      * (we could also avoid the latter by adding a `normalized_name` column but performance on the database lookup seems fine)
    * for everything else do a lowercase'ed name lookup (as we currently do)
  * adds a `find_with_package_manager!` method that just takes the first result from `find_all_with_package_manager!`, or raises RecordNotFound
  * replace the alternate name lookup usage of `project_find_names` with `find_with_package_manager!`
* `PackageStatusQuery`:  (used for bulk project lookup in controllers)
  * replace usage of `project_find_names` with `find_all_with_package_manager!`
* `PackageManager`:
  * `Base`: remove `project_find_names()`, as it's no longer used

### Example

Passing these platform/name pairs to the `/api/check` bulk API searching for [winui3-Microsoft.UI.Xaml.Interop/](https://pypi.org/project/winui3-Microsoft.UI.Xaml.Interop/):
* "pypi"/"winui3-microsoft-ui-xaml-interop"
* "pypi"/"not-found-package"

#### Before

Returns name/canonical_names:

```
* nothing
```

#### After

Returns list of name/canonical_names:

```
[["winui3-microsoft-ui-xaml-interop", "winui3-Microsoft.UI.Xaml.Interop"]]
```

### Existing Limitation

We have a limitation where `Api::BulkProjectController#project_names` combines all the lookup names from `ProjectStatusQuery`, so a search for the project "foo"  with `["FOO", "foo", "foO"]` would return something like `[["FOO", "foo"], ["FOO", "foo"], ["FOO", "foo"]]`