### PR TITLE
Use the Maven metadata url for Google Maven status checks.

### DIFF
--- a/app/models/package_manager/maven/google.rb
+++ b/app/models/package_manager/maven/google.rb
@@ -16,6 +16,10 @@ class PackageManager::Maven::Google < PackageManager::Maven::Common
     get("https://maven.libraries.io/googleMaven/recent")
   end
 
+  def self.check_status_url(db_project)
+    MavenUrl.from_name(db_project.name, repository_base, NAME_DELIMITER).maven_metadata
+  end
+
   # TODO: check and store if the value on the other end is a JAR or AAR file
   # This returns a link to the Google Maven docs where the JAR or AAR
   # file can be downloaded.

--- a/spec/models/package_manager/maven/google_spec.rb
+++ b/spec/models/package_manager/maven/google_spec.rb
@@ -56,4 +56,11 @@ describe PackageManager::Maven::Google do
       end
     end
   end
+
+  describe ".check_status_url" do
+    it "uses Google's maven-metadata.xml for lack of better options" do
+      project = Project.new(platform: "Maven", name: "fake:package")
+      expect(described_class.check_status_url(project)).to eq("https://dl.google.com/dl/android/maven2/fake/package/maven-metadata.xml")
+    end
+  end
 end


### PR DESCRIPTION
The url we use for `Project#check_status` for `PackageManager::Maven::Google` projects is broken, e.g.: `https://dl.google.com/dl/android/maven2/android/arch/core/core-testing`

I haven't determined if it ever worked, but it's forcing us to mark some Google-hosted projects as "Removed". 

This starts using the "maven-metadata.xml" URL for these status checks instead: `https://dl.google.com/dl/android/maven2/android/arch/core/core-testing/maven-metadata.xml`

They take about 500ms-ish for me, but I can't find a better option and there are [relatively few](https://maven.google.com/web/index.html) projects to check anyway.