### PR TITLE
Require users to be logged in to see dependency trees

### DIFF
--- a/app/controllers/tree_controller.rb
+++ b/app/controllers/tree_controller.rb
@@ -3,6 +3,7 @@
 class TreeController < ApplicationController
   before_action :find_project
   before_action :load_tree_resolver
+  before_action :ensure_logged_in
 
   def show
     # if cache is disabled (such as in dev), just do this synchronously

--- a/spec/requests/tree_spec.rb
+++ b/spec/requests/tree_spec.rb
@@ -5,16 +5,21 @@ require "rails_helper"
 describe "TreeController" do
   let(:project) { create(:project) }
   let!(:version) { create(:version, project: project) }
+  let(:user) { create :user }
+
+  before do
+    login(user)
+  end
 
   describe "GET /:platform/:project/tree", type: :request do
-    it "renders successfully when logged out" do
+    it "renders successfully" do
       visit tree_path(project.to_param)
       expect(page).to have_content "Dependency Tree"
     end
   end
 
   describe "GET /:platform/:project/:number/tree", type: :request do
-    it "renders successfully when logged out" do
+    it "renders successfully" do
       visit version_tree_path(version.to_param)
       expect(page).to have_content "Dependency Tree"
     end


### PR DESCRIPTION
Avoids some crawlers that are going wild and not listening to robots.txt
