### PR TITLE
Routes: handle versions that contain plus/minus signs

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@
 
 PLATFORM_CONSTRAINT = /[\w-]+/
 PROJECT_CONSTRAINT = /[^\/]+/
-VERSION_CONSTRAINT = /[\w.-]+/
+VERSION_CONSTRAINT = /[\w.+\-%]+/
 
 class IsAdminConstraint
   def matches?(request)

--- a/spec/requests/api/projects_spec.rb
+++ b/spec/requests/api/projects_spec.rb
@@ -165,7 +165,7 @@ describe "Api::ProjectsController" do
     end
   end
 
-  describe "GET /api/:platform/:name/dependencies", type: :request do
+  describe "GET /api/:platform/:name/:number/dependencies", type: :request do
     it "renders successfully" do
       get "/api/#{project.platform}/#{project.name}/#{version.number}/dependencies"
       expect(response).to have_http_status(:success)
@@ -222,6 +222,68 @@ describe "Api::ProjectsController" do
           versions: project.versions.as_json(only: %i[number original_license published_at spdx_expression researched_at repository_sources]),
         }.to_json
       )
+    end
+
+    context "with a long version" do
+      let!(:version) { create(:version, number: "1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay", project: project, repository_sources: ["Rubygems"]) }
+
+      it "renders successfully" do
+        get "/api/#{project.platform}/#{project.name}/#{version.number}/dependencies"
+        expect(response).to have_http_status(:success)
+        expect(response.content_type).to start_with("application/json")
+        expect(response.body).to be_json_eql(
+          {
+            code_of_conduct_url: project.code_of_conduct_url,
+            contributions_count: 0,
+            contribution_guidelines_url: project.contribution_guidelines_url,
+            dependencies_for_version: version.number,
+            dependent_repos_count: project.dependent_repos_count,
+            dependents_count: project.dependents_count,
+            deprecation_reason: project.deprecation_reason,
+            dependencies: version.dependencies.map do |dependency|
+              {
+                project_name: dependency.name,
+                name: dependency.name,
+                platform: dependency.platform,
+                requirements: dependency.requirements,
+                latest_stable: dependency.latest_stable,
+                latest: dependency.latest,
+                deprecated: dependency.deprecated,
+                outdated: dependency.outdated,
+                filepath: dependency.filepath,
+                kind: dependency.kind,
+                optional: dependency.optional,
+                normalized_licenses: dependency.project.normalized_licenses,
+              }
+            end,
+            description: project.description,
+            forks: project.forks,
+            funding_urls: project.funding_urls,
+            homepage: project.homepage,
+            keywords: project.keywords,
+            language: project.language,
+            latest_download_url: project.latest_download_url,
+            latest_release_number: project.latest_release_number,
+            latest_release_published_at: project.latest_release_published_at,
+            latest_stable_release_number: project.latest_stable_release_number,
+            latest_stable_release_published_at: project.latest_stable_release_published_at,
+            license_normalized: project.license_normalized,
+            licenses: project.licenses,
+            name: project.name,
+            normalized_licenses: project.normalized_licenses,
+            package_manager_url: project.package_manager_url,
+            platform: project.platform,
+            rank: project.rank,
+            repository_license: project.repository_license,
+            repository_status: project.repository_status,
+            repository_url: project.repository_url,
+            security_policy_url: project.security_policy_url,
+            stars: project.stars,
+            status: project.status,
+            versions: project.versions.as_json(only: %i[number original_license published_at spdx_expression researched_at repository_sources]),
+          }.to_json
+        )
+      end
     end
   end
 

--- a/spec/requests/api/tree_spec.rb
+++ b/spec/requests/api/tree_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe "Api::TreesController" do
   let!(:old_version) { create(:version, number: "1.0.0", published_at: 1.month.ago) }
+  let!(:long_version) { create(:version, number: "1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay", project: old_version.project, published_at: 1.week.ago) }
   let!(:new_version) { create(:version, number: "2.0.0", project: old_version.project, published_at: 1.day.ago) }
   let(:user) { create(:user) }
 
@@ -22,6 +23,13 @@ describe "Api::TreesController" do
       expect(response).to have_http_status(:success)
       expect(response.content_type).to start_with("application/json")
       expect(response.body).to be_json_eql TreeResolver.new(old_version, "runtime", Date.today).tree.to_json
+    end
+
+    it "renders successfully with all semver versions" do
+      get "/api/#{old_version.project.platform}/#{old_version.project.name}/#{long_version.number}/tree?api_key=#{user.api_key}"
+      expect(response).to have_http_status(:success)
+      expect(response.content_type).to start_with("application/json")
+      expect(response.body).to be_json_eql TreeResolver.new(long_version, "runtime", Date.today).tree.to_json
     end
   end
 end


### PR DESCRIPTION
Plus and minus signs are legit [Semver characters](https://regex101.com/r/Ly7O1x/3/) so we should support them in urls:

### Before

```
curl "http://localhost:3000/api/nuget/Topshelf/4.3.0+build.251.sha.509556a/tree?api_key=..."
<html lang="en">
<head>
  <meta charset="utf-8" />
  <meta name="viewport" content="width=device-width, initial-scale=1">
  <meta name="turbo-visit-control" content="reload">
  <title>Action Controller: Exception caught</title>
  ...
```

### After

```
curl "http://localhost:3000/api/nuget/Topshelf/4.3.0+build.251.sha.509556a/tree?api_key=..."
{"version":{"number":"4.3.0+build.251.sha.509556a"},"requirements":null,"dependency":{"platform":"NuGet","project_name":"Topshelf","kind":null},"normalized_licenses":["Apache-2.0"],"dependencies":[]}%                        
```